### PR TITLE
src: Switch to rust-vmm/vm-memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ version = "0.1.0"
 [[package]]
 name = "vm-memory"
 version = "0.2.0"
-source = "git+https://github.com/containers/vm-memory#2a6da794f19f05ae6697ef9d5b50fb03d72cde40"
+source = "git+https://github.com/rust-vmm/vm-memory#788019f7ac36ac5bc0b06c1ac6b4c2fe5cf803e6"
 dependencies = [
  "libc",
  "winapi",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -10,7 +10,7 @@ libc = ">=0.2.39"
 utils = { path = "../utils" }
 
 arch_gen = { path = "../arch_gen" }
-vm-memory = { git = "https://github.com/containers/vm-memory", features = ["backend-mmap"] }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", features = ["backend-mmap"] }
 
 [dev-dependencies]
 utils = { path = "../utils" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 bitflags = "1.2.0"
 libc = ">=0.2.39"
 logger = { path = "../logger" }
-vm-memory = { git = "https://github.com/containers/vm-memory", features = ["backend-mmap"] }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", features = ["backend-mmap"] }
 utils = { path = "../utils" }
 polly = { path = "../polly" }
 virtio_gen = { path = "../virtio_gen" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -3,5 +3,5 @@ name = "kernel"
 version = "0.1.0"
 
 [dependencies]
-vm-memory = { git = "https://github.com/containers/vm-memory", features = ["backend-mmap"] }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", features = ["backend-mmap"] }
 utils = { path = "../utils" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -12,7 +12,7 @@ arch = { path = "../arch" }
 devices = { path = "../devices" }
 kernel = { path = "../kernel" }
 logger = { path = "../logger" }
-vm-memory = { git = "https://github.com/containers/vm-memory", features = ["backend-mmap"] }
+vm-memory = { git = "https://github.com/rust-vmm/vm-memory", features = ["backend-mmap"] }
 utils = { path = "../utils"}
 polly = { path = "../polly" }
 


### PR DESCRIPTION
Now that build_raw support has been merged into rust-vmm/vm-memory,
switch to it. Once released we'll be able to switch from git to
crate+version reference.

Signed-off-by: Sergio Lopez <slp@redhat.com>