### PR TITLE
vmm: Refactor kernel bundle config and parameters

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,32 @@
+name: Unit Tests
+on: [pull_request, create]
+
+jobs:
+  build:
+    if: github.event_name == 'pull_request'
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+        target:
+          - x86_64-unknown-linux-gnu
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: ${{ matrix.rust }}
+            target: ${{ matrix.target }}
+            override: true
+
+      - name: Create a fake init
+        run: touch init/init
+
+      - name: Grab a libkrunfw release
+        run: curl -L -o /usr/lib/libkrunfw.so https://github.com/containers/libkrunfw/releases/download/v0.1/libkrunfw.so
+
+      - name: Run Unit Tests (all features)
+        run: cargo test --all-targets --all-features

--- a/src/vmm/src/vmm_config/kernel_bundle.rs
+++ b/src/vmm/src/vmm_config/kernel_bundle.rs
@@ -1,0 +1,34 @@
+// Copyright 2020, Red Hat Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::{Display, Formatter, Result};
+
+/// Data structure holding the attributes read from the `libkrunfw` kernel config.
+#[derive(Debug, Default)]
+pub struct KernelBundle {
+    pub host_addr: u64,
+    pub guest_addr: u64,
+    pub size: usize,
+}
+
+/// Structure used to specify the parameters for the `libkrunfw` kernel bundle.
+#[derive(Debug)]
+pub enum KernelBundleError {
+    /// Guest address is not page-aligned.
+    InvalidGuestAddress,
+    /// Host address is zero or not page-aligned.
+    InvalidHostAddress,
+    /// Kernel size is zero or not a multiple of the page size.
+    InvalidSize,
+}
+
+impl Display for KernelBundleError {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        use self::KernelBundleError::*;
+        match *self {
+            InvalidGuestAddress => write!(f, "Guest address is not page-aligned"),
+            InvalidHostAddress => write!(f, "Host address is zero or not page-aligned"),
+            InvalidSize => write!(f, "Kernel size is zero or not a multiple of the page size"),
+        }
+    }
+}

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -14,6 +14,8 @@ pub mod boot_source;
 pub mod fs;
 /// Wrapper over the microVM general information attached to the microVM.
 pub mod instance_info;
+/// Wrapper for configuring the kernel bundle to be loaded in the microVM.
+pub mod kernel_bundle;
 /// Wrapper for configuring the logger.
 pub mod logger;
 /// Wrapper for configuring the memory and CPU of the microVM.


### PR DESCRIPTION
Move the responsibility of dealing with libkrunfw away from vmm to
libkrun, wrapping the parameters into vmm_config::KernelBundle. Also,
adapt the code to libkrunfw-0.1, which implements API versioning.

Signed-off-by: Sergio Lopez <slp@redhat.com>