### PR TITLE
libkrun: Make "args" an array of string pointers

### DIFF
--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -12,13 +12,13 @@
 
 #define MAX_ARGS_LEN 4096
 
-int main(int argc, void **argv)
+int main(int argc, char *const argv[])
 {
-    // Use an empty NULL-terminated string as env_line, so libkrun won't inject the variables
-    // currently present in the environment into the microVM.
-    char env_line[] = "\0";
-    char args[MAX_ARGS_LEN] = "\0";
-    int args_len = 0;
+    char *const envp[] =
+    {
+        "TEST=works",
+        0
+    };
     int ctx_id;
     int err;
     int i;
@@ -59,25 +59,9 @@ int main(int argc, void **argv)
         return -1;
     }
 
-    // If we have additional arguments, collect them into "args".
-    for (i = 3; i < argc; i++) {
-        // We need to add an space as a separator.
-        int len = strlen(argv[i]) + 1;
-
-        if ((len + args_len) >= (MAX_ARGS_LEN - 1)) {
-            printf("Too many arguments\n");
-            return -1;
-        }
-
-        strncpy(&args[args_len], argv[i], MAX_ARGS_LEN - args_len - 1);
-        args_len += len;
-        args[args_len - 1] = ' ';
-    }
-    args[args_len] = '\0';
-
     // Use the second argument as the path of the binary to be executed in the isolated
     // context, relative to the root path.
-    if (err = krun_set_exec(ctx_id, argv[2], &args[0], &env_line[0])) {
+    if (err = krun_set_exec(ctx_id, argv[2], &argv[3], &envp[0])) {
         errno = -err;
         perror("Error configuring the parameters for the executable to be run");
         return -1;

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -68,19 +68,18 @@ int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
  * Arguments:
  *  "ctx_id"    - the configuration context ID.
  *  "exec_path" - the path to the executable, relative to the root configured with "krun_set_root".
- *  "args"      - a null-terminated string representing the arguments to be passed to the
- *                executable.
- *  "env_line"  - a null-terminated string with the variables to be injected into the context of
- *                the executable, with "KEY=VALUE" format. If NULL, it will auto-generate a line
- *                collecting the variables currently present in the environment.
+ *  "argv"      - an array of string pointers to be passed as arguments.
+ *  "envp"      - an array of string pointers to be injected as environment variables into the
+ *                context of the executable. If NULL, it will auto-generate an array collecting the
+ *                the variables currently present in the environment.
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
  */
 int32_t krun_set_exec(uint32_t ctx_id,
                       const char *exec_path,
-                      const char *args,
-                      const char *env_line);
+                      char *const argv[],
+                      char *const envp[]);
 
 /*
  * Starts and enters the microVM with the configured parameters. The VMM will attempt to take over


### PR DESCRIPTION
krun_set_exec needed the arguments to be passed as a collapsed string,
which is not what people will probably expect. Replace both the
arguments and the environment lines and use an array of string
pointers instead, just as 'execve(2)' does.

Signed-off-by: Sergio Lopez <slp@redhat.com>