### PR TITLE
vsock: set TCP_NODELAY on external sockets

### DIFF
--- a/src/devices/src/virtio/vsock/unix/muxer.rs
+++ b/src/devices/src/virtio/vsock/unix/muxer.rs
@@ -460,6 +460,12 @@ impl VsockMuxer {
                             .map_err(Error::WrapUnixAccept)
                     })
                     .and_then(|stream| {
+                        stream
+                            .set_nodelay(true)
+                            .map(|_| stream)
+                            .map_err(Error::WrapUnixAccept)
+                    })
+                    .and_then(|stream| {
                         let local_port = self.allocate_local_port();
                         self.add_connection(
                             ConnMapKey {


### PR DESCRIPTION
Set TCP_NODELAY on external sockets so each packet is immediately sent.

Signed-off-by: Sergio Lopez <slp@redhat.com>