### PR TITLE
Add support for mapped volumes

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -62,6 +62,20 @@ int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib)
 int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
 
 /*
+ * Configures the mapped volumes for the microVM. Only supported on macOS, on Linux use
+ * user_namespaces and bind-mounts instead.
+ *
+ * Arguments:
+ *  "ctx_id"         - the configuration context ID.
+ *  "mapped_volumes" - an array of string pointers with format "host_path:guest_map" representing
+ *                     the volumes to be mapped inside the microVM
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_mapped_volumes(uint32_t ctx_id, const char *mapped_volumes[]);
+
+/*
  * Sets the working directory for the executable to be run inside the microVM.
  *
  * Arguments:

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -1,5 +1,6 @@
 use std::cmp;
 use std::io::Write;
+use std::path::PathBuf;
 use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -62,6 +63,7 @@ impl Fs {
     pub(crate) fn with_queues(
         fs_id: String,
         shared_dir: String,
+        mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
         queues: Vec<VirtQueue>,
     ) -> super::Result<Fs> {
         let mut queue_events = Vec::new();
@@ -77,6 +79,7 @@ impl Fs {
 
         let fs_cfg = passthrough::Config {
             root_dir: shared_dir,
+            mapped_volumes,
             ..Default::default()
         };
 
@@ -96,12 +99,16 @@ impl Fs {
         })
     }
 
-    pub fn new(fs_id: String, shared_dir: String) -> super::Result<Fs> {
+    pub fn new(
+        fs_id: String,
+        shared_dir: String,
+        mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
+    ) -> super::Result<Fs> {
         let queues: Vec<VirtQueue> = defs::QUEUE_SIZES
             .iter()
             .map(|&max_size| VirtQueue::new(max_size))
             .collect();
-        Self::with_queues(fs_id, shared_dir, queues)
+        Self::with_queues(fs_id, shared_dir, mapped_volumes, queues)
     }
 
     pub fn id(&self) -> &str {

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 use std::io;
 use std::mem::{self, size_of, MaybeUninit};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -247,6 +248,12 @@ pub struct Config {
     ///
     /// The default is `None`.
     pub proc_sfd_rawfd: Option<RawFd>,
+
+    /// Optional list of tuples of (host_path, guest_path) elements, representing paths from the host
+    /// to be exposed in the guest.
+    ///
+    /// The default in `None`.
+    pub mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
 }
 
 impl Default for Config {
@@ -259,6 +266,7 @@ impl Default for Config {
             root_dir: String::from("/"),
             xattr: true,
             proc_sfd_rawfd: None,
+            mapped_volumes: None,
         }
     }
 }

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -1,5 +1,6 @@
 use std::collections::VecDeque;
 use std::fmt;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use devices::virtio::{Fs, FsError};
@@ -25,6 +26,7 @@ type Result<T> = std::result::Result<T, FsConfigError>;
 pub struct FsDeviceConfig {
     pub fs_id: String,
     pub shared_dir: String,
+    pub mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
 }
 
 #[derive(Default)]
@@ -46,7 +48,9 @@ impl FsBuilder {
     }
 
     pub fn create_fs(config: FsDeviceConfig) -> Result<Fs> {
-        Ok(devices::virtio::Fs::new(config.fs_id, config.shared_dir)
-            .map_err(FsConfigError::CreateFsDevice)?)
+        Ok(
+            devices::virtio::Fs::new(config.fs_id, config.shared_dir, config.mapped_volumes)
+                .map_err(FsConfigError::CreateFsDevice)?,
+        )
     }
 }


### PR DESCRIPTION
Add support for mapped volumes, so platforms that doesn't support user
namespaces (namely, macOS) can have an alternative to bind-mount for
accessing host volumes.

Signed-off-by: Sergio Lopez <slp@redhat.com>