### PR TITLE
Fix compiler warnings of init.c

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ all: $(LIBRARY_RELEASE_$(OS))
 debug: $(LIBRARY_DEBUG_$(OS))
 
 $(INIT_BINARY): init/init.c
-	gcc -O2 -static -o $@ init/init.c
+	gcc -O2 -static -Wall -o $@ init/init.c
 
 $(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY)
 	cargo build --release

--- a/init/init.c
+++ b/init/init.c
@@ -37,7 +37,7 @@ void set_rlimits(const char *rlimits)
         rlim.rlim_cur = lim_cur;
         rlim.rlim_max = lim_max;
         if (setrlimit(lim_id, &rlim) != 0) {
-            printf("Error setting rlimit for ID=%d\n", lim_id);
+            printf("Error setting rlimit for ID=%lld\n", lim_id);
         }
 
         if (*item != '\0') {


### PR DESCRIPTION
This enables the `-Wall` GCC flag and then fix the only warning emitted by the compiler.