### PR TITLE
libkrun: Put env vars values between quotes

### DIFF
--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -476,7 +476,7 @@ pub unsafe extern "C" fn krun_set_exec(
         }
     } else {
         env::vars()
-            .map(|(key, value)| format!(" {}={}", key, value))
+            .map(|(key, value)| format!(" {}=\"{}\"", key, value))
             .collect()
     };
 


### PR DESCRIPTION
When the env vars are being collected from the current context (as
opposed of them being specified by the caller), put the values between
quotes to cope with the presence of spaces in them.

Signed-off-by: Sergio Lopez <slp@redhat.com>