### PR TITLE
vmm: Add "no-kvmapf" to the kernel command line

### DIFF
--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -17,7 +17,7 @@ use std::fmt::{Display, Formatter, Result};
 //                                          i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd";
 
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 pci=off nomodules \
-                                          console=hvc0 rootfstype=virtiofs rw quiet";
+                                          console=hvc0 rootfstype=virtiofs rw quiet no-kvmapf";
 
 //pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules earlyprintk=ttyS0 \
 //                                          console=ttyS0";


### PR DESCRIPTION
With recent Guest kernels, there appears to be an unexpected
interaction between KVM asynchronous page fault and some other VM
mechanism that causes the vCPU to return immediately to the Guest on
"hlt", leading to the thread managing vcpu 0 to spin up with ~99% of
CPU usage.

Turn KVM asynchronous page fault for the moment. We'll revisit this
issue in the future.

Signed-off-by: Sergio Lopez <slp@redhat.com>