### PR TITLE
devices/fs: Implement support for DAX

### DIFF
--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -16,6 +16,13 @@ extern crate vm_memory;
 use std::fmt;
 use std::result;
 
+#[derive(Default)]
+pub struct ArchMemoryInfo {
+    pub ram_last_addr: u64,
+    pub shm_start_addr: u64,
+    pub shm_size: u64,
+}
+
 /// Module for aarch64 related functionality.
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
@@ -24,6 +31,7 @@ pub mod aarch64;
 pub use aarch64::{
     arch_memory_regions, configure_system, get_kernel_start, initrd_load_addr,
     layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error, MMIO_MEM_START,
+    MMIO_SHM_SIZE,
 };
 
 /// Module for x86_64 related functionality.
@@ -34,6 +42,7 @@ pub mod x86_64;
 pub use x86_64::{
     arch_memory_regions, configure_system, get_kernel_start, initrd_load_addr,
     layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error, MMIO_MEM_START,
+    MMIO_SHM_SIZE,
 };
 
 /// Type for returning public functions outcome.

--- a/src/devices/src/virtio/device.rs
+++ b/src/devices/src/virtio/device.rs
@@ -19,6 +19,13 @@ pub enum DeviceState {
     Activated(GuestMemoryMmap),
 }
 
+#[derive(Clone)]
+pub struct VirtioShmRegion {
+    pub host_addr: u64,
+    pub guest_addr: u64,
+    pub size: usize,
+}
+
 /// Trait for virtio devices to be driven by a virtio transport.
 ///
 /// The lifecycle of a virtio device is to be moved to a virtio transport, which will then query the
@@ -109,6 +116,11 @@ pub trait VirtioDevice: AsAny + Send {
     /// Optionally deactivates this device and returns ownership of the guest memory map, interrupt
     /// event, and queue events.
     fn reset(&mut self) -> Option<(EventFd, Vec<EventFd>)> {
+        None
+    }
+
+    /// Get base and size of the SHM region
+    fn shm_region(&self) -> Option<&VirtioShmRegion> {
         None
     }
 }

--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -1086,6 +1086,33 @@ pub trait FileSystem {
         Err(io::Error::from_raw_os_error(bindings::LINUX_ENOSYS))
     }
 
+    /// Setup a mapping so that guest can access files in DAX style.
+    #[allow(clippy::too_many_arguments)]
+    fn setupmapping(
+        &self,
+        _ctx: Context,
+        inode: Self::Inode,
+        handle: Self::Handle,
+        foffset: u64,
+        len: u64,
+        flags: u64,
+        moffset: u64,
+        host_shm_base: u64,
+        shm_size: u64,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
+    fn removemapping(
+        &self,
+        _ctx: Context,
+        requests: Vec<RemovemappingOne>,
+        host_shm_base: u64,
+        shm_size: u64,
+    ) -> io::Result<()> {
+        Err(io::Error::from_raw_os_error(libc::ENOSYS))
+    }
+
     /// TODO: support this
     fn getlk(&self) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(bindings::LINUX_ENOSYS))

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -1732,4 +1732,122 @@ impl FileSystem for PassthroughFs {
             Ok(res as usize)
         }
     }
+
+    fn setupmapping(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        _handle: Handle,
+        foffset: u64,
+        len: u64,
+        flags: u64,
+        moffset: u64,
+        host_shm_base: u64,
+        shm_size: u64,
+    ) -> io::Result<()> {
+        let open_flags = if (flags & fuse::SetupmappingFlags::WRITE.bits()) != 0 {
+            libc::O_RDWR
+        } else {
+            libc::O_RDONLY
+        };
+
+        let prot_flags = if (flags & fuse::SetupmappingFlags::WRITE.bits()) != 0 {
+            libc::PROT_READ | libc::PROT_WRITE
+        } else {
+            libc::PROT_READ
+        };
+
+        if (moffset + len) > shm_size {
+            return Err(io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let addr = host_shm_base + moffset;
+
+        debug!("setupmapping: ino {:?} addr={:x} len={}", inode, addr, len);
+
+        if inode == self.init_inode {
+            let ret = unsafe {
+                libc::mmap(
+                    addr as *mut libc::c_void,
+                    len as usize,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED,
+                    -1,
+                    0,
+                )
+            };
+            if ret == libc::MAP_FAILED {
+                return Err(io::Error::last_os_error());
+            }
+
+            let to_copy = if len as usize > INIT_BINARY.len() {
+                INIT_BINARY.len()
+            } else {
+                len as usize
+            };
+            unsafe {
+                libc::memcpy(
+                    addr as *mut libc::c_void,
+                    INIT_BINARY.as_ptr() as *const _,
+                    to_copy,
+                )
+            };
+            return Ok(());
+        }
+
+        let file = self.open_inode(inode, open_flags as i32)?;
+        let fd = file.as_raw_fd();
+
+        let ret = unsafe {
+            libc::mmap(
+                addr as *mut libc::c_void,
+                len as usize,
+                prot_flags,
+                libc::MAP_SHARED | libc::MAP_FIXED,
+                fd,
+                foffset as libc::off_t,
+            )
+        };
+        if ret == libc::MAP_FAILED {
+            return Err(io::Error::last_os_error());
+        }
+
+        let ret = unsafe { libc::close(fd) };
+        if ret == -1 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(())
+    }
+
+    fn removemapping(
+        &self,
+        _ctx: Context,
+        requests: Vec<fuse::RemovemappingOne>,
+        host_shm_base: u64,
+        shm_size: u64,
+    ) -> io::Result<()> {
+        for req in requests {
+            let addr = host_shm_base + req.moffset;
+            if (req.moffset + req.len) > shm_size {
+                return Err(io::Error::from_raw_os_error(libc::EINVAL));
+            }
+            debug!("removemapping: addr={:x} len={:?}", addr, req.len);
+            let ret = unsafe {
+                libc::mmap(
+                    addr as *mut libc::c_void,
+                    req.len as usize,
+                    libc::PROT_NONE,
+                    libc::MAP_ANONYMOUS | libc::MAP_PRIVATE | libc::MAP_FIXED,
+                    -1,
+                    0 as libc::off_t,
+                )
+            };
+            if ret == libc::MAP_FAILED {
+                return Err(io::Error::last_os_error());
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -57,6 +57,7 @@ use std::sync::Mutex;
 #[cfg(target_os = "linux")]
 use std::time::Duration;
 
+use arch::ArchMemoryInfo;
 use arch::DeviceType;
 use arch::InitrdConfig;
 #[cfg(target_arch = "x86_64")]
@@ -203,6 +204,7 @@ pub struct Vmm {
 
     // Guest VM core resources.
     guest_memory: GuestMemoryMmap,
+    arch_memory_info: ArchMemoryInfo,
 
     kernel_cmdline: KernelCmdline,
 
@@ -281,6 +283,7 @@ impl Vmm {
         #[cfg(target_arch = "x86_64")]
         arch::x86_64::configure_system(
             &self.guest_memory,
+            &self.arch_memory_info,
             vm_memory::GuestAddress(arch::x86_64::layout::CMDLINE_START),
             self.kernel_cmdline.len() + 1,
             initrd,
@@ -293,6 +296,7 @@ impl Vmm {
             let vcpu_mpidr = vcpus.into_iter().map(|cpu| cpu.get_mpidr()).collect();
             arch::aarch64::configure_system(
                 &self.guest_memory,
+                &self.arch_memory_info,
                 &self
                     .kernel_cmdline
                     .as_cstring()
@@ -310,6 +314,7 @@ impl Vmm {
             let vcpu_mpidr = vcpus.into_iter().map(|cpu| cpu.get_mpidr()).collect();
             arch::aarch64::configure_system(
                 &self.guest_memory,
+                &self.arch_memory_info,
                 &self
                     .kernel_cmdline
                     .as_cstring()

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -442,7 +442,6 @@ impl Vm {
                 // It's safe to unwrap because the guest address is valid.
                 let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap();
                 info!("Guest memory starts at {:x?}", host_addr);
-
                 let memory_region = kvm_userspace_memory_region {
                     slot: index as u32,
                     guest_phys_addr: region.start_addr().raw_value() as u64,

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -17,7 +17,8 @@ use std::fmt::{Display, Formatter, Result};
 //                                          i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd";
 
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 pci=off nomodules \
-                                          console=hvc0 rootfstype=virtiofs rw quiet no-kvmapf";
+                                          console=hvc0 rootflags=dax rootfstype=virtiofs rw \
+                                          quiet no-kvmapf";
 
 //pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules earlyprintk=ttyS0 \
 //                                          console=ttyS0";


### PR DESCRIPTION
Implement support for DAX in virtio-fs. We use a static 512MB window
at the end of the RAM. This enables the guest to bypass its own cache
for some VFS operations, reducing the amount of memory used in the
guest for its own FS cache, and increasing the number of pages we can
return to the host to free them.

This feature is supported in Linux/KVM, and has been tested on x86_64
and Aarch64. We can't use DAX on macOS, because Hypervisor.framework
doesn't allow adding MAP_SHARED maps to the VM (or, at least, I
couldn't find a way).

Signed-off-by: Sergio Lopez <slp@redhat.com>