### PR TITLE
SEV: Implement support for SEV-ES

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -567,14 +567,15 @@ pub fn build_microvm(
         load_cmdline(&vmm)?;
     }
 
+    vmm.configure_system(vcpus.as_slice(), &None)
+        .map_err(StartMicrovmError::Internal)?;
+
     #[cfg(feature = "amd-sev")]
     let _measurement = vmm
         .kvm_vm()
         .secure_virt_attest(vmm.guest_memory(), measured_regions)
         .map_err(StartMicrovmError::SecureVirtAttest)?;
 
-    vmm.configure_system(vcpus.as_slice(), &None)
-        .map_err(StartMicrovmError::Internal)?;
     vmm.start_vcpus(vcpus)
         .map_err(StartMicrovmError::Internal)?;
 

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -881,11 +881,11 @@ impl Vcpu {
             .map_err(Error::VcpuSetCpuid)?;
 
         arch::x86_64::msr::setup_msrs(&self.fd).map_err(Error::MSRSConfiguration)?;
-        arch::x86_64::regs::setup_regs(&self.fd, kernel_start_addr.raw_value() as u64)
+        arch::x86_64::regs::setup_regs(&self.fd, kernel_start_addr.raw_value() as u64, self.id)
             .map_err(Error::REGSConfiguration)?;
         arch::x86_64::regs::setup_fpu(&self.fd).map_err(Error::FPUConfiguration)?;
-        #[cfg(not(feature = "amd-sev"))]
-        arch::x86_64::regs::setup_sregs(guest_mem, &self.fd).map_err(Error::SREGSConfiguration)?;
+        arch::x86_64::regs::setup_sregs(guest_mem, &self.fd, self.id)
+            .map_err(Error::SREGSConfiguration)?;
         arch::x86_64::interrupts::set_lint(&self.fd).map_err(Error::LocalIntConfiguration)?;
         Ok(())
     }


### PR DESCRIPTION
Add support for running the VM with SEV-ES. This feature is only
enabled if the attestation server requests it (that is,
PolicyFlags::ENCRYPTED_STATE is present in the Policy flags).

Signed-off-by: Sergio Lopez <slp@redhat.com>