### PR TITLE
Fix unitialized access of err and erroneous error message.

### DIFF
--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -45,8 +45,7 @@ int main(int argc, char *const argv[])
     int i;
 
     if (argc < 3) {
-        printf("Invalid arguments\n");
-        printf("Usage: %s NEWROOT COMMAND [ARG...]\n", argv[0]);
+        fprintf(stderr, "usage: %s NEWROOT COMMAND [ARG...]\n", argv[0]);
         return -1;
     }
 

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -89,8 +89,8 @@ int main(int argc, char *const argv[])
     volume_len = strlen(current_path) + strlen(volume_tail) + 1;
     volume = malloc(volume_len);
     if (volume == NULL) {
-        errno = -err;
         perror("Error allocating memory for volume string");
+        return -1;
     }
 
     snprintf(volume, volume_len, "%s%s", current_path, volume_tail);

--- a/examples/sev-attest.c
+++ b/examples/sev-attest.c
@@ -83,8 +83,8 @@ int main(int argc, char *const argv[])
     volume_len = strlen(current_path) + strlen(volume_tail) + 1;
     volume = malloc(volume_len);
     if (volume == NULL) {
-        errno = -err;
         perror("Error allocating memory for volume string");
+        return -1;
     }
 
     // Map port 18000 in the host to 8000 in the guest.

--- a/examples/sev-attest.c
+++ b/examples/sev-attest.c
@@ -39,8 +39,7 @@ int main(int argc, char *const argv[])
     int i;
 
     if (argc != 3) {
-        printf("Invalid arguments\n");
-        printf("Usage: %s DISK_IMAGE ATTESTATION_URL\n", argv[0]);
+        fprintf(stderr, "usage: %s DISK_IMAGE ATTESTATION_URL\n", argv[0]);
         return -1;
     }
 

--- a/examples/sev-noattest.c
+++ b/examples/sev-noattest.c
@@ -89,8 +89,8 @@ int main(int argc, char *const argv[])
     volume_len = strlen(current_path) + strlen(volume_tail) + 1;
     volume = malloc(volume_len);
     if (volume == NULL) {
-        errno = -err;
         perror("Error allocating memory for volume string");
+        return -1;
     }
 
     // Map port 18000 in the host to 8000 in the guest.

--- a/examples/sev-noattest.c
+++ b/examples/sev-noattest.c
@@ -45,8 +45,7 @@ int main(int argc, char *const argv[])
     int i;
 
     if (argc < 4) {
-        printf("Invalid arguments\n");
-        printf("Usage: %s DISK_IMAGE PASSPHRASE COMMAND [ARG...]\n", argv[0]);
+        fprintf(stderr, "usage: %s DISK_IMAGE PASSPHRASE COMMAND [ARG...]\n", argv[0]);
         return -1;
     }
 

--- a/init/init.c
+++ b/init/init.c
@@ -69,38 +69,38 @@ int main(int argc, char **argv)
     if (passp) {
         printf("Unlocking LUKS root filesystem\n");
 
-	    if (mount("proc", "/proc", "proc",
-		      MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
-		    perror("mount(/proc)");
-		    exit(-1);
-	    }
+        if (mount("proc", "/proc", "proc",
+            MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
+            perror("mount(/proc)");
+            exit(-1);
+        }
 
-	    pipe(pipefd);
+        pipe(pipefd);
 
-	    pid = fork();
-	    if (pid == 0) {
+        pid = fork();
+        if (pid == 0) {
             close(pipefd[1]);
-		    dup2(pipefd[0], 0);
-		    close(pipefd[0]);
+            dup2(pipefd[0], 0);
+            close(pipefd[0]);
 
-		    if (execl("/sbin/cryptsetup", "cryptsetup", "open", "/dev/vda", "luksroot", "-", NULL) < 0) {
+            if (execl("/sbin/cryptsetup", "cryptsetup", "open", "/dev/vda", "luksroot", "-", NULL) < 0) {
                 perror("execl");
                 exit(-1);
             }
-	    } else {
-		    write(pipefd[1], passp, strnlen(passp, 128));
-		    close(pipefd[1]);
-		    waitpid(pid, &wstatus, 0);
-	    }
+        } else {
+            write(pipefd[1], passp, strnlen(passp, 128));
+            close(pipefd[1]);
+            waitpid(pid, &wstatus, 0);
+        }
 
         printf("Mounting LUKS root filesystem\n");
 
-	    if (mount("/dev/mapper/luksroot", "/luksroot", "ext4", 0, NULL) < 0) {
-		    perror("mount(/luksroot)");
-		    exit(-1);
-	    }
+        if (mount("/dev/mapper/luksroot", "/luksroot", "ext4", 0, NULL) < 0) {
+            perror("mount(/luksroot)");
+            exit(-1);
+        }
 
-	    chdir("/luksroot");
+        chdir("/luksroot");
 
         if (mount(".", "/", NULL, MS_MOVE, NULL)) {
             perror("remount root");
@@ -110,19 +110,19 @@ int main(int argc, char **argv)
     }
 
     if (mount("proc", "/proc", "proc",
-              MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
+        MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
         perror("mount(/proc)");
         exit(-1);
     }
 
     if (mount("sysfs", "/sys", "sysfs",
-              MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
+        MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
         perror("mount(/sys)");
         exit(-1);
     }
 
     if (mount("cgroup2", "/sys/fs/cgroup", "cgroup2",
-              MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
+        MS_NODEV | MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
         perror("mount(/sys/fs/cgroup)");
         exit(-1);
     }
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
     }
 
     if (mount("devpts", "/dev/pts", "devpts",
-              MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
+        MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
         perror("mount(/dev/pts)");
         exit(-1);
     }
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
     }
 
     if (mount("tmpfs", "/dev/shm", "tmpfs",
-              MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
+        MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
         perror("mount(/dev/shm)");
         exit(-1);
     }


### PR DESCRIPTION
malloc(3) already sets errno and we should return on NULL.
--
Hi, sorry if this is too silly I was just going over the code and noticed it, also you could use err(3) or errx(3) and cut some lines.
I have more silly fixes like this I can push if you want.