### PR TITLE
vsock: restore lost port mapping feature

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -93,11 +93,22 @@ int32_t krun_set_mapped_volumes(uint32_t ctx_id, char *const mapped_volumes[]);
  * Configures a map of host to guest TCP ports for the microVM.
  *
  * Arguments:
- *  "ctx_id"         - the configuration context ID.
- *  "mapped_volumes" - an array of string pointers with format "host_port:guest_port"
+ *  "ctx_id"   - the configuration context ID.
+ *  "port_map" - an array of string pointers with format "host_port:guest_port"
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
+ *
+ * Notes:
+ *  Passing NULL (or not calling this function) as "port_map" has a different meaning than
+ *  passing an empty array. The first one will instruct libkrun to attempt to expose all
+ *  listening ports in the guest to the host, while the second means that no port from
+ *  the guest will be exposed to host.
+ *
+ *  Exposed ports will only become accessible by their "host_port" in the guest too. This
+ *  means that for a map such as "8080:80", applications running inside the guest will also
+ *  need to access the service through the "8080" port.
+ *
  */
 int32_t krun_set_port_map(uint32_t ctx_id, char *const port_map[]);
 

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -90,6 +90,7 @@ pub fn push_packet(
 
 pub struct VsockMuxer {
     cid: u64,
+    host_port_map: Option<HashMap<u16, u16>>,
     queue_stream: Option<Arc<Mutex<VirtQueue>>>,
     queue_dgram: Option<Arc<Mutex<VirtQueue>>>,
     mem: Option<GuestMemoryMmap>,
@@ -106,11 +107,13 @@ pub struct VsockMuxer {
 impl VsockMuxer {
     pub(crate) fn new(
         cid: u64,
+        host_port_map: Option<HashMap<u16, u16>>,
         interrupt_evt: EventFd,
         interrupt_status: Arc<AtomicUsize>,
     ) -> Self {
         VsockMuxer {
             cid,
+            host_port_map,
             queue_stream: None,
             queue_dgram: None,
             mem: None,
@@ -369,7 +372,7 @@ impl VsockMuxer {
                 .read()
                 .unwrap()
                 .get(&id)
-                .map(|proxy| proxy.lock().unwrap().listen(pkt, req));
+                .map(|proxy| proxy.lock().unwrap().listen(pkt, req, &self.host_port_map));
 
             if let Some(update) = update {
                 self.process_proxy_update(id, update);

--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fmt;
 use std::os::unix::io::{AsRawFd, RawFd};
 
@@ -56,7 +57,12 @@ pub trait Proxy: Send + AsRawFd {
     fn sendmsg(&mut self, pkt: &VsockPacket) -> ProxyUpdate;
     fn sendto_addr(&mut self, req: TsiSendtoAddr) -> ProxyUpdate;
     fn sendto_data(&mut self, _pkt: &VsockPacket) {}
-    fn listen(&mut self, pkt: &VsockPacket, req: TsiListenReq) -> ProxyUpdate;
+    fn listen(
+        &mut self,
+        pkt: &VsockPacket,
+        req: TsiListenReq,
+        host_port_map: &Option<HashMap<u16, u16>>,
+    ) -> ProxyUpdate;
     fn accept(&mut self, req: TsiAcceptReq) -> ProxyUpdate;
     fn update_peer_credit(&mut self, pkt: &VsockPacket) -> ProxyUpdate;
     fn push_op_request(&self) {}

--- a/src/devices/src/virtio/vsock/udp.rs
+++ b/src/devices/src/virtio/vsock/udp.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddrV4};
 use std::num::Wrapping;
 use std::os::unix::io::{AsRawFd, RawFd};
@@ -358,7 +359,12 @@ impl Proxy for UdpProxy {
         }
     }
 
-    fn listen(&mut self, _pkt: &VsockPacket, _req: TsiListenReq) -> ProxyUpdate {
+    fn listen(
+        &mut self,
+        _pkt: &VsockPacket,
+        _req: TsiListenReq,
+        _host_port_map: &Option<HashMap<u16, u16>>,
+    ) -> ProxyUpdate {
         ProxyUpdate::default()
     }
 

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -71,7 +71,8 @@ impl VsockBuilder {
 
     /// Creates a Vsock device from a VsockDeviceConfig.
     pub fn create_vsock(cfg: VsockDeviceConfig) -> Result<Vsock> {
-        Vsock::new(u64::from(cfg.guest_cid)).map_err(VsockConfigError::CreateVsockDevice)
+        Vsock::new(u64::from(cfg.guest_cid), cfg.host_port_map)
+            .map_err(VsockConfigError::CreateVsockDevice)
     }
 }
 


### PR DESCRIPTION
On the transition from TSIv1 to TSIv2, the ability to restrict exposed
ports and configure port mappings from guest to the host was
accidentally lost. Restore it now.

Signed-off-by: Sergio Lopez <slp@redhat.com>