### PR TITLE
vsock: defer TSI proxy removal

### DIFF
--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -13,6 +13,7 @@ mod muxer_thread;
 #[allow(dead_code)]
 mod packet;
 mod proxy;
+mod reaper;
 mod tcp;
 mod udp;
 

--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -32,10 +32,22 @@ pub enum ProxyStatus {
     WaitingOnAccept,
 }
 
+pub enum ProxyRemoval {
+    Keep,
+    Immediate,
+    Deferred,
+}
+
+impl Default for ProxyRemoval {
+    fn default() -> ProxyRemoval {
+        ProxyRemoval::Keep
+    }
+}
+
 #[derive(Default)]
 pub struct ProxyUpdate {
     pub signal_queue: bool,
-    pub remove_proxy: bool,
+    pub remove_proxy: ProxyRemoval,
     pub polling: Option<(u64, RawFd, EventSet)>,
     pub new_proxy: Option<(u32, RawFd)>,
     pub push_accept: Option<(u64, u64)>,

--- a/src/devices/src/virtio/vsock/reaper.rs
+++ b/src/devices/src/virtio/vsock/reaper.rs
@@ -1,0 +1,67 @@
+use std::collections::HashMap;
+use std::sync::mpsc::Receiver;
+use std::sync::{Arc, Mutex, RwLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use super::proxy::Proxy;
+
+pub type ProxyMap = Arc<RwLock<HashMap<u64, Mutex<Box<dyn Proxy>>>>>;
+const TIMEOUT: Duration = Duration::new(5, 0);
+
+pub struct ReaperThread {
+    receiver: Receiver<u64>,
+    proxy_map: ProxyMap,
+    released_map: HashMap<u64, Instant>,
+}
+
+impl ReaperThread {
+    pub fn new(receiver: Receiver<u64>, proxy_map: ProxyMap) -> Self {
+        Self {
+            receiver,
+            proxy_map,
+            released_map: HashMap::new(),
+        }
+    }
+
+    fn check_expiration(&mut self) -> Duration {
+        let mut lowest_elapsed = Duration::MAX;
+        let mut expired: Vec<u64> = Vec::new();
+        let now = Instant::now();
+
+        for (id, exptime) in self.released_map.iter() {
+            let elapsed = now.duration_since(*exptime);
+            if elapsed > TIMEOUT {
+                expired.push(*id);
+            } else if elapsed < lowest_elapsed {
+                lowest_elapsed = elapsed;
+            }
+        }
+
+        if !expired.is_empty() {
+            let mut pmap = self.proxy_map.write().unwrap();
+            for id in expired {
+                debug!("removing proxy: {}", id);
+                pmap.remove(&id);
+                self.released_map.remove(&id);
+            }
+            debug!("remainig proxies: {}", pmap.len());
+        }
+
+        lowest_elapsed
+    }
+
+    fn work(&mut self) {
+        loop {
+            let timeout = self.check_expiration();
+            if let Ok(id) = self.receiver.recv_timeout(timeout) {
+                println!("reaper alive");
+                self.released_map.insert(id, Instant::now());
+            }
+        }
+    }
+
+    pub fn run(mut self) {
+        thread::spawn(move || self.work());
+    }
+}


### PR DESCRIPTION
In guests with multiple vCPUs, the request to release a sock may be
processed before all data has left the guest. This means we can't
immediately release the TSI proxy upon receiving a TsiReleaseReq
message, but we need to keep it around for a while.

Implement a reaper thread, and upon receiving a TsiReleaseReq schedule
the proxy to be freed after a timeout (5 seconds).

Signed-off-by: Sergio Lopez <slp@redhat.com>