### PR TITLE
Disable virtio-fs DAX

### DIFF
--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -18,8 +18,7 @@ use std::fmt::{Display, Formatter, Result};
 
 #[cfg(all(target_os = "linux", not(feature = "amd-sev")))]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
-                                          rootflags=dax rootfstype=virtiofs rw quiet no-kvmapf \
-                                          tsi_hijack";
+                                          rootfstype=virtiofs rw quiet no-kvmapf tsi_hijack";
 
 #[cfg(feature = "amd-sev")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \


### PR DESCRIPTION
On 5.15 kernels, a zero byte read on a DAX-enabled virtio-fs
filesystem causes the kernel to hang with a call trace like this:

[    5.363419] Call Trace:
[    5.363420]  <TASK>
[    5.363421]  dax_iomap_rw+0xa3/0xf0
[    5.363425]  fuse_dax_read_iter+0x41/0x70
[    5.363427]  fuse_file_read_iter+0x123/0x140
[    5.363430]  ? _copy_to_user+0x20/0x30
[    5.363433]  ? cp_new_stat+0x14d/0x180
[    5.363436]  new_sync_read+0x103/0x190
[    5.363438]  vfs_read+0xfa/0x190
[    5.363441]  ksys_read+0x66/0xe0
[    5.363443]  __x64_sys_read+0x14/0x20
[    5.363445]  do_syscall_64+0x37/0x80
[    5.363447]  entry_SYSCALL_64_after_hwframe+0x44/0xae

This adds up to other DAX-related issues such as the fact it breaks
PTRACE.

Let's disable virtio-fs DAX until we jump to a kernel were those
issues are fixed.

Signed-off-by: Sergio Lopez <slp@redhat.com>