### PR TITLE
Bump version to v1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.1.0
+FULL_VERSION=1.2.0
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
This release includes changes in behavior:

- Disable virtio-fs DAX
- Defer TSI proxy removal

Bump minor number to v1.2.0.

Signed-off-by: Sergio Lopez <slp@redhat.com>