### PR TITLE
Bump vm-memory dependency from 0.7.0 to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,9 +1864,9 @@ version = "0.1.0"
 
 [[package]]
 name = "vm-memory"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339d4349c126fdcd87e034631d7274370cf19eb0e87b33166bcd956589fc72c5"
+checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
 dependencies = [
  "libc",
  "winapi 0.3.9",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -9,7 +9,7 @@ amd-sev = []
 
 [dependencies]
 libc = ">=0.2.39"
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap"] }
 
 arch_gen = { path = "../arch_gen" }
 utils = { path = "../utils" }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -15,7 +15,7 @@ log = "0.4.0"
 lru = "0.6.3"
 nix = "0.24.1"
 rand = "0.8.5"
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap"] }
 
 arch = { path = "../arch" }
 utils = { path = "../utils" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap"] }
 
 utils = { path = "../utils" }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -11,7 +11,7 @@ amd-sev = [ "codicon", "procfs", "reqwest", "serde", "serde_json", "sev", "ureq"
 env_logger = "0.9.0"
 libc = ">=0.2.39"
 log = "0.4.0"
-vm-memory = { version = "0.7.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.8.0", features = ["backend-mmap"] }
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }


### PR DESCRIPTION
Bump vm-memory dependency from 0.7.0 to 0.8.0, the latest available
version.

Signed-off-by: Sergio Lopez <slp@redhat.com>