### PR TITLE
Bump version to v1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,7 +738,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.2.0
+FULL_VERSION=1.2.1
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.2.0"
+version = "1.2.1"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
This is just a minor release updating vm-memory dependency from 0.7.0
to 0.8.0. Only bump patch number to v1.2.1.

Signed-off-by: Sergio Lopez <slp@redhat.com>