### PR TITLE
macos: fix symlink ownership and mode attrs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.3.0
+FULL_VERSION=1.4.1
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -37,7 +37,7 @@ struct BootParamsWrapper(boot_params);
 unsafe impl ByteValued for BootParamsWrapper {}
 
 /// Errors thrown while configuring x86_64 system.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     /// Invalid e820 setup params.
     E820Configuration,

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -47,7 +47,7 @@ unsafe impl ByteValued for MpfIntelWrapper {}
 // MPTABLE, describing VCPUS.
 const MPTABLE_START: u64 = 0x9fc00;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     /// There was too little guest memory to store the entire MP table.
     NotEnoughMemory,

--- a/src/cpuid/src/brand_string.rs
+++ b/src/cpuid/src/brand_string.rs
@@ -5,7 +5,7 @@ use crate::common::{VENDOR_ID_AMD, VENDOR_ID_INTEL};
 use std::arch::x86_64::__cpuid as host_cpuid;
 use std::slice;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Error {
     NotSupported,
     Overflow(String),

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -31,7 +31,7 @@ use crate::virtio::VIRTIO_MMIO_INT_CONFIG;
 use crate::Error as DeviceError;
 
 /// Configuration options for disk caching.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CacheType {
     /// Flushing mechanic will be advertised to the guest driver, but
     /// the operation will be a noop.

--- a/src/devices/src/virtio/block/request.rs
+++ b/src/devices/src/virtio/block/request.rs
@@ -41,7 +41,7 @@ impl ExecuteError {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RequestType {
     In,
     Out,

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -186,7 +186,7 @@ impl<'a> DescriptorChain<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 /// A virtio queue's parameters.
 pub struct Queue {
     /// The maximal size in elements offered by the device

--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -20,7 +20,7 @@ pub enum ProxyError {
     SettingReusePort(nix::errno::Errno),
 }
 
-#[derive(PartialEq, Clone, Copy, Debug)]
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
 pub enum ProxyStatus {
     Idle,
     Connecting,

--- a/src/kernel/src/cmdline/mod.rs
+++ b/src/kernel/src/cmdline/mod.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::result;
 
 /// The error type for command line building operations.
-#[derive(PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug)]
 pub enum Error {
     /// Failed to copy to guest memory.
     CommandLineCopy,

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -14,7 +14,7 @@ use std::fmt;
 use super::cmdline::Error as CmdlineError;
 use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Error {
     BigEndianElfOnLittle,
     InvalidElfMagicNumber,

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.4.0"
+version = "1.4.1"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -667,7 +667,7 @@ pub struct VmState {
 }
 
 /// Encapsulates configuration parameters for the guest vCPUS.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct VcpuConfig {
     /// Number of guest VCPUs.
     pub vcpu_count: u8,
@@ -1359,7 +1359,7 @@ pub enum VcpuEvent {
     // Serialize and Deserialize to follow after we get the support from kvm-ioctls.
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 /// List of responses that the Vcpu reports.
 pub enum VcpuResponse {
     /// Vcpu is paused.

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -154,7 +154,7 @@ impl Vm {
 }
 
 /// Encapsulates configuration parameters for the guest vCPUS.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct VcpuConfig {
     /// Number of guest VCPUs.
     pub vcpu_count: u8,
@@ -537,7 +537,7 @@ pub enum VcpuEvent {
     // Serialize and Deserialize to follow after we get the support from kvm-ioctls.
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 /// List of responses that the Vcpu reports.
 pub enum VcpuResponse {
     /// Vcpu is paused.

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -21,7 +21,7 @@ impl fmt::Display for BlockConfigError {
 
 type Result<T> = std::result::Result<T, BlockConfigError>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BlockDeviceConfig {
     pub block_id: String,
     pub cache_type: CacheType,

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -33,7 +33,7 @@ pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodu
 
 /// Strongly typed data structure used to configure the boot source of the
 /// microvm.
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, Eq, PartialEq)]
 pub struct BootSourceConfig {
     /// The boot arguments to pass to the kernel. If this field is uninitialized, the default
     /// kernel command line is used: `reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0`.

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -22,7 +22,7 @@ impl fmt::Display for FsConfigError {
 
 type Result<T> = std::result::Result<T, FsConfigError>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FsDeviceConfig {
     pub fs_id: String,
     pub shared_dir: String,

--- a/src/vmm/src/vmm_config/machine_config.rs
+++ b/src/vmm/src/vmm_config/machine_config.rs
@@ -8,7 +8,7 @@ use std::fmt;
 pub const MAX_SUPPORTED_VCPUS: u8 = 32;
 
 /// Errors associated with configuring the microVM.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum VmConfigError {
     /// The vcpu count is invalid. When hyperthreading is enabled, the `cpu_count` must be either
     /// 1 or an even number.
@@ -33,7 +33,7 @@ impl fmt::Display for VmConfigError {
 
 /// Strongly typed structure that represents the configuration of the
 /// microvm.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VmConfig {
     /// The number of vCPUs.
     pub vcpu_count: Option<u8>,
@@ -72,7 +72,7 @@ impl fmt::Display for VmConfig {
 
 /// Template types available for configuring the CPU features that map
 /// to EC2 instances.
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CpuFeaturesTemplate {
     /// C3 Template.
     C3,

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -29,7 +29,7 @@ type Result<T> = std::result::Result<T, VsockConfigError>;
 
 /// This struct represents the strongly typed equivalent of the json body
 /// from vsock related requests.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VsockDeviceConfig {
     /// ID of the vsock device.
     pub vsock_id: String,


### PR DESCRIPTION
Use XATTR_NOFOLLOW with setxattr when updating the ownership and mode bits for symlinks, and return a fixed Entry on Passthrough::symlink()