### PR TITLE
devices/fs: Drop mutability from FileReadWriteAtVolatile

### DIFF
--- a/src/devices/src/virtio/fs/descriptor_utils.rs
+++ b/src/devices/src/virtio/fs/descriptor_utils.rs
@@ -257,7 +257,7 @@ impl<'a> Reader<'a> {
     /// enough data in the descriptor chain buffer.
     pub fn read_to_at<F: FileReadWriteAtVolatile>(
         &mut self,
-        mut dst: F,
+        dst: F,
         count: usize,
         off: u64,
     ) -> io::Result<usize> {
@@ -404,7 +404,7 @@ impl<'a> Writer<'a> {
     /// there isn't enough data in the descriptor chain buffer.
     pub fn write_from_at<F: FileReadWriteAtVolatile>(
         &mut self,
-        mut src: F,
+        src: F,
         count: usize,
         off: u64,
     ) -> io::Result<usize> {

--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -127,7 +127,7 @@ pub trait ZeroCopyReader {
     /// If any error is returned then the implementation must guarantee that no bytes were copied
     /// from `self`. If the underlying write to `f` returns `0` then the implementation must return
     /// an error of the kind `io::ErrorKind::WriteZero`.
-    fn read_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize>;
+    fn read_to(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize>;
 
     /// Copies exactly `count` bytes of data from `self` into `f` at offset `off`. `off + count`
     /// must be less than `u64::MAX`.
@@ -190,7 +190,7 @@ pub trait ZeroCopyReader {
 }
 
 impl<'a, R: ZeroCopyReader> ZeroCopyReader for &'a mut R {
-    fn read_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+    fn read_to(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
         (**self).read_to(f, count, off)
     }
     fn read_exact_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<()> {
@@ -217,7 +217,7 @@ pub trait ZeroCopyWriter {
     /// If any error is returned then the implementation must guarantee that no bytes were copied
     /// from `f`. If the underlying read from `f` returns `0` then the implementation must return an
     /// error of the kind `io::ErrorKind::UnexpectedEof`.
-    fn write_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize>;
+    fn write_from(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize>;
 
     /// Copies exactly `count` bytes of data from `f` at offset `off` into `self`. `off + count`
     /// must be less than `u64::MAX`.
@@ -283,7 +283,7 @@ pub trait ZeroCopyWriter {
 }
 
 impl<'a, W: ZeroCopyWriter> ZeroCopyWriter for &'a mut W {
-    fn write_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+    fn write_from(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
         (**self).write_from(f, count, off)
     }
     fn write_all_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<()> {

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -1003,8 +1003,8 @@ impl FileSystem for PassthroughFs {
 
         // This is safe because write_from uses preadv64, so the underlying file descriptor
         // offset is not affected by this operation.
-        let mut f = data.file.read().unwrap().try_clone().unwrap();
-        w.write_from(&mut f, size as usize, offset)
+        let f = data.file.read().unwrap();
+        w.write_from(&f, size as usize, offset)
     }
 
     fn write<R: io::Read + ZeroCopyReader>(
@@ -1037,8 +1037,8 @@ impl FileSystem for PassthroughFs {
 
         // This is safe because read_to uses pwritev64, so the underlying file descriptor
         // offset is not affected by this operation.
-        let mut f = data.file.read().unwrap().try_clone().unwrap();
-        r.read_to(&mut f, size as usize, offset)
+        let f = data.file.read().unwrap();
+        r.read_to(&f, size as usize, offset)
     }
 
     fn getattr(

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -1401,8 +1401,8 @@ impl FileSystem for PassthroughFs {
 
         // This is safe because write_from uses preadv64, so the underlying file descriptor
         // offset is not affected by this operation.
-        let mut f = data.file.read().unwrap().try_clone().unwrap();
-        w.write_from(&mut f, size as usize, offset)
+        let mut f = data.file.read().unwrap();
+        w.write_from(&f, size as usize, offset)
     }
 
     fn write<R: io::Read + ZeroCopyReader>(
@@ -1429,8 +1429,8 @@ impl FileSystem for PassthroughFs {
 
         // This is safe because read_to uses pwritev64, so the underlying file descriptor
         // offset is not affected by this operation.
-        let mut f = data.file.read().unwrap().try_clone().unwrap();
-        r.read_to(&mut f, size as usize, offset)
+        let mut f = data.file.read().unwrap();
+        r.read_to(&f, size as usize, offset)
     }
 
     fn getattr(

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -27,7 +27,7 @@ const DIRENT_PADDING: [u8; 8] = [0; 8];
 struct ZCReader<'a>(Reader<'a>);
 
 impl<'a> ZeroCopyReader for ZCReader<'a> {
-    fn read_to(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+    fn read_to(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
         self.0.read_to_at(f, count, off)
     }
 }
@@ -41,7 +41,7 @@ impl<'a> io::Read for ZCReader<'a> {
 struct ZCWriter<'a>(Writer<'a>);
 
 impl<'a> ZeroCopyWriter for ZCWriter<'a> {
-    fn write_from(&mut self, f: &mut File, count: usize, off: u64) -> io::Result<usize> {
+    fn write_from(&mut self, f: &File, count: usize, off: u64) -> io::Result<usize> {
         self.0.write_from_at(f, count, off)
     }
 }


### PR DESCRIPTION
Internally, the FileReadWriteAtVolatile methods are going to use
pread/pwrite family of syscalls, which implies the file descriptor
offset is not altered. With this in mind, drop the mutability
requirement on the File argument.

This change allows us to drop the "try_clone()" on
PassthroughFs::[read()|write()], saving a "dup()" syscall on both of
those critical paths.

This is a backport of virtiofsd:595126fe.

Signed-off-by: Sergio Lopez <slp@redhat.com>