### PR TITLE
Bump version to v1.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.4.2
+FULL_VERSION=1.4.3
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
This release includes various fixes for macOS (concurrency issues on
Apple Silicon and tracking unlinked files) and a performance
optimization backported from virtiofsd. Just bump release to
v1.4.3.

Signed-off-by: Sergio Lopez <slp@redhat.com>