### PR TITLE
amdsev: Replace implementation ioctls with sev library equivalents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitfield"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
@@ -652,6 +652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,17 +693,18 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07fba5645febfaab8958c9a5812d737911a29f353462288937df138a241f9d4"
+version = "0.3.0"
+source = "git+https://github.com/tylerfanelli/sev.git?branch=vmsa_update#b43459a6bd29c24c3504e85c35254bb7882b56ba"
 dependencies = [
  "bitfield",
  "bitflags",
  "codicon",
  "dirs",
  "iocuddle",
+ "kvm-ioctls",
  "openssl",
  "serde",
+ "serde-big-array",
  "serde_bytes",
 ]
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -36,4 +36,4 @@ rootfs:
 	podman rm libkrun_chroot_vm
 
 clean:
-	rm -rf chroot_vm $(ROOTFS_DIR)
+	rm -rf chroot_vm $(ROOTFS_DIR) launch-tee

--- a/src/kbs-types/Cargo.toml
+++ b/src/kbs-types/Cargo.toml
@@ -13,4 +13,4 @@ tee-sev = [ "sev" ]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sev = { version = "0.2.0", features = ["openssl"], optional = true }
+sev = { git = "https://github.com/tylerfanelli/sev.git", branch = "vmsa_update", features = ["openssl"], optional = true }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -26,7 +26,7 @@ kbs-types = { path = "../kbs-types", features = ["tee-sev"], optional = true }
 procfs = { version = "0.12", optional = true }
 serde = { version = "1.0.125", optional = true }
 serde_json = { version = "1.0.64", optional = true }
-sev = { version = "0.2", features = ["openssl"], optional = true }
+sev = { git = "https://github.com/tylerfanelli/sev.git", branch = "vmsa_update", features = ["openssl"], optional = true }
 curl = { version = "0.4", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -355,7 +355,7 @@ pub fn build_microvm(
     let mut vm = setup_vm(&guest_memory, vm_resources.tee_config())?;
 
     #[cfg(feature = "amd-sev")]
-    let (_launcher, measured_regions) = {
+    let (launcher, measured_regions) = {
         let launcher = vm
             .secure_virt_prepare(&guest_memory)
             .map_err(StartMicrovmError::SecureVirtPrepare)?;
@@ -581,7 +581,7 @@ pub fn build_microvm(
     #[cfg(feature = "amd-sev")]
     {
         vmm.kvm_vm()
-            .secure_virt_attest(vmm.guest_memory(), measured_regions)
+            .secure_virt_attest(vmm.guest_memory(), measured_regions, launcher)
             .map_err(StartMicrovmError::SecureVirtAttest)?;
 
         println!("Starting TEE/microVM.");

--- a/src/vmm/src/linux/amdsev.rs
+++ b/src/vmm/src/linux/amdsev.rs
@@ -355,17 +355,6 @@ impl AmdSev {
         vm_fd.encrypt_op_sev(&mut cmd)
     }
 
-    fn sev_launch_finish(&self, vm_fd: &VmFd) -> Result<(), kvm_ioctls::Error> {
-        let mut cmd = kvm_sev_cmd {
-            id: 7, // SEV_LAUNCH_FINISH
-            data: 0,
-            error: 0,
-            sev_fd: self.fw.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)
-    }
-
     pub fn vm_prepare(
         &self,
         vm_fd: &VmFd,
@@ -457,8 +446,7 @@ impl AmdSev {
                 .unwrap();
         }
 
-        self.sev_launch_finish(vm_fd)
-            .map_err(Error::SevLaunchFinish)?;
+        let _handle = launcher.finish();
 
         Ok(())
     }

--- a/src/vmm/src/linux/amdsev.rs
+++ b/src/vmm/src/linux/amdsev.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::Read;
 use std::mem::{size_of_val, MaybeUninit};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -18,7 +18,7 @@ use procfs::CpuInfo;
 use serde::{Deserialize, Serialize};
 use sev::certs;
 use sev::firmware::Firmware;
-use sev::launch::sev::{Measurement, Policy, PolicyFlags, Secret, Start};
+use sev::launch::sev::*;
 use sev::session::Session;
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 
@@ -329,50 +329,6 @@ impl AmdSev {
         })
     }
 
-    fn sev_init(&self, vm_fd: &VmFd) -> Result<(), kvm_ioctls::Error> {
-        let id = if self.sev_es { 1 } else { 0 };
-
-        let mut cmd = kvm_sev_cmd {
-            id,
-            data: 0,
-            error: 0,
-            sev_fd: self.fw.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)?;
-        Ok(())
-    }
-
-    fn sev_launch_start(&self, vm_fd: &VmFd) -> Result<(), kvm_ioctls::Error> {
-        #[repr(C)]
-        struct Data {
-            handle: u32,
-            policy: Policy,
-            dh_addr: u64,
-            dh_size: u32,
-            session_addr: u64,
-            session_size: u32,
-        }
-
-        let mut data = Data {
-            handle: 0,
-            policy: self.start.policy,
-            dh_addr: &self.start.cert as *const _ as u64,
-            dh_size: size_of_val(&self.start.cert) as u32,
-            session_addr: &self.start.session as *const _ as u64,
-            session_size: size_of_val(&self.start.session) as u32,
-        };
-
-        let mut cmd = kvm_sev_cmd {
-            id: 2, // SEV_LAUNCH_START
-            data: &mut data as *mut _ as u64,
-            error: 0,
-            sev_fd: self.fw.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)
-    }
-
     fn sev_launch_update_data(
         &self,
         vm_fd: &VmFd,
@@ -482,8 +438,19 @@ impl AmdSev {
         vm_fd.encrypt_op_sev(&mut cmd)
     }
 
-    pub fn vm_prepare(&self, vm_fd: &VmFd, guest_mem: &GuestMemoryMmap) -> Result<(), Error> {
-        self.sev_init(vm_fd).map_err(Error::SevInit)?;
+    pub fn vm_prepare(
+        &self,
+        vm_fd: &VmFd,
+        guest_mem: &GuestMemoryMmap,
+    ) -> Result<Launcher<Started, RawFd, RawFd>, Error> {
+        let vm_rfd = vm_fd.as_raw_fd();
+        let fw_rfd = self.fw.as_raw_fd();
+
+        let launcher = if self.sev_es {
+            Launcher::new_es(vm_rfd, fw_rfd).unwrap()
+        } else {
+            Launcher::new(vm_rfd, fw_rfd).unwrap()
+        };
 
         for region in guest_mem.iter() {
             // It's safe to unwrap because the guest address is valid.
@@ -497,10 +464,9 @@ impl AmdSev {
                 .map_err(|_| Error::MemoryEncryptRegion)?;
         }
 
-        self.sev_launch_start(vm_fd)
-            .map_err(Error::SevLaunchStart)?;
+        let launcher = launcher.start(self.start).unwrap();
 
-        Ok(())
+        Ok(launcher)
     }
 
     pub fn vm_attest(

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -561,9 +561,10 @@ impl Vm {
         &self,
         guest_mem: &GuestMemoryMmap,
         measured_regions: Vec<MeasuredRegion>,
+        launcher: Launcher<Started, RawFd, RawFd>,
     ) -> Result<()> {
         self.sev
-            .vm_attest(&self.fd, guest_mem, measured_regions)
+            .vm_attest(&self.fd, guest_mem, measured_regions, launcher)
             .map_err(Error::SecVirtAttest)
     }
 


### PR DESCRIPTION
This relies on changes from the sev library and an update to 1.0. There will also be an upcoming SNP implementation.