### PR TITLE
SEV "sev" library usage and introduced SEV-SNP support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bitfield"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
 name = "bitflags"
@@ -652,6 +652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3323f09a748af288c3dc2474ea6803ee81f118321775bffa3ac8f7e65c5e90e7"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -684,18 +693,20 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07fba5645febfaab8958c9a5812d737911a29f353462288937df138a241f9d4"
+version = "0.3.0"
+source = "git+https://github.com/virtee/sev.git?branch=main#0896f64e880fe9d043fda5862c29edfacbf5a8e0"
 dependencies = [
  "bitfield",
  "bitflags",
  "codicon",
  "dirs",
  "iocuddle",
+ "kvm-ioctls",
  "openssl",
  "serde",
+ "serde-big-array",
  "serde_bytes",
+ "static_assert_macro",
 ]
 
 [[package]]
@@ -707,6 +718,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "static_assert_macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aa19fe1f820914e252c747ee699215bba50c0f7b38af8828e4a85f79142fedb"
 
 [[package]]
 name = "syn"

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,6 @@ $(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY)
 ifeq ($(SEV),1)
 	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
 endif
-ifeq ($(SNP), 1)
-	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
-endif
 ifeq ($(OS),Linux)
 	patchelf --set-soname $(KRUN_SONAME_$(OS)) --output $(LIBRARY_RELEASE_$(OS)) target/release/$(KRUN_BASE_$(OS))
 else
@@ -62,9 +59,6 @@ endif
 $(LIBRARY_DEBUG_$(OS)): $(INIT_BINARY)
 	cargo build $(FEATURE_FLAGS)
 ifeq ($(SEV),1)
-	mv target/debug/libkrun.so target/debug/$(KRUN_BASE_$(OS))
-endif
-ifeq ($(SNP), 1)
 	mv target/debug/libkrun.so target/debug/$(KRUN_BASE_$(OS))
 endif
 ifeq ($(OS),Linux)

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,9 @@ $(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY)
 ifeq ($(SEV),1)
 	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
 endif
+ifeq ($(SNP), 1)
+	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
+endif
 ifeq ($(OS),Linux)
 	patchelf --set-soname $(KRUN_SONAME_$(OS)) --output $(LIBRARY_RELEASE_$(OS)) target/release/$(KRUN_BASE_$(OS))
 else
@@ -59,6 +62,9 @@ endif
 $(LIBRARY_DEBUG_$(OS)): $(INIT_BINARY)
 	cargo build $(FEATURE_FLAGS)
 ifeq ($(SEV),1)
+	mv target/debug/libkrun.so target/debug/$(KRUN_BASE_$(OS))
+endif
+ifeq ($(SNP), 1)
 	mv target/debug/libkrun.so target/debug/$(KRUN_BASE_$(OS))
 endif
 ifeq ($(OS),Linux)

--- a/examples/snp-config-noattest.json
+++ b/examples/snp-config-noattest.json
@@ -1,0 +1,8 @@
+{
+    "workload_id": "snptest",
+    "cpus": 2,
+    "ram_mib": 2048,
+    "tee": "snp",
+    "tee_data": "{\"vendor_chain\": \"\", \"attestation_server_pubkey\": \"\"}",
+    "attestation_url": ""
+}

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["The Chromium OS Authors"]
 edition = "2021"
 
 [features]
-amd-sev = []
+tee = []
+amd-sev = [ "tee" ]
+amd-snp = [ "tee" ]
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [features]
 tee = []
 amd-sev = [ "tee" ]
-amd-snp = [ "tee" ]
 
 [dependencies]
 libc = ">=0.2.39"

--- a/src/arch/src/x86_64/regs.rs
+++ b/src/arch/src/x86_64/regs.rs
@@ -63,7 +63,7 @@ pub fn setup_fpu(vcpu: &VcpuFd) -> Result<()> {
 /// * `vcpu` - Structure for the VCPU that holds the VCPU's fd.
 /// * `boot_ip` - Starting instruction pointer.
 pub fn setup_regs(vcpu: &VcpuFd, boot_ip: u64, id: u8) -> Result<()> {
-    let regs: kvm_regs = if id == 0 || cfg!(not(feature = "amd-sev")) {
+    let regs: kvm_regs = if id == 0 || cfg!(not(feature = "tee")) {
         kvm_regs {
             rflags: 0x0000_0000_0000_0002u64,
             rip: boot_ip,
@@ -97,7 +97,7 @@ pub fn setup_regs(vcpu: &VcpuFd, boot_ip: u64, id: u8) -> Result<()> {
 pub fn setup_sregs(mem: &GuestMemoryMmap, vcpu: &VcpuFd, id: u8) -> Result<()> {
     let mut sregs: kvm_sregs = vcpu.get_sregs().map_err(Error::GetStatusRegisters)?;
 
-    if cfg!(not(feature = "amd-sev")) {
+    if cfg!(not(feature = "tee")) {
         configure_segments_and_sregs(mem, &mut sregs)?;
         setup_page_tables(mem, &mut sregs)?; // TODO(dgreid) - Can this be done once per system instead
     } else if id != 0 {

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [features]
 tee = []
 amd-sev = [ "tee" ]
-amd-snp = [ "tee" ]
 
 [dependencies]
 bitflags = "1.2.0"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["The Chromium OS Authors"]
 edition = "2021"
 
 [features]
-amd-sev = []
+tee = []
+amd-sev = [ "tee" ]
+amd-snp = [ "tee" ]
 
 [dependencies]
 bitflags = "1.2.0"

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -10,33 +10,33 @@ use std;
 use std::any::Any;
 use std::io::Error as IOError;
 
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub mod balloon;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 pub mod block;
 pub mod console;
 pub mod device;
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub mod fs;
 #[cfg(target_os = "macos")]
 pub mod linux_errno;
 mod mmio;
 mod queue;
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub mod rng;
 pub mod vsock;
 
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub use self::balloon::*;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 pub use self::block::*;
 pub use self::console::*;
 pub use self::device::*;
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub use self::fs::*;
 pub use self::mmio::*;
 pub use self::queue::*;
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub use self::rng::*;
 pub use self::vsock::*;
 

--- a/src/kbs-types/Cargo.toml
+++ b/src/kbs-types/Cargo.toml
@@ -8,7 +8,9 @@ homepage = "https://github.com/virtee/kbs-types"
 license = "Apache-2.0"
 
 [features]
-tee-sev = [ "sev" ]
+tee = []
+tee-sev = [ "sev", "tee" ]
+tee-snp = [ "sev", "tee" ]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/kbs-types/Cargo.toml
+++ b/src/kbs-types/Cargo.toml
@@ -13,4 +13,4 @@ tee-sev = [ "sev" ]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sev = { version = "0.2.0", features = ["openssl"], optional = true }
+sev = { git = "https://github.com/virtee/sev.git", branch = "main", features = ["openssl"], optional = true }

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -6,7 +6,9 @@ edition = "2021"
 build = "build.rs"
 
 [features]
-amd-sev = []
+tee = []
+amd-sev = [ "tee" ]
+amd-snp = [ "tee" ]
 
 [dependencies]
 env_logger = "0.9.0"

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -8,7 +8,6 @@ build = "build.rs"
 [features]
 tee = []
 amd-sev = [ "tee" ]
-amd-snp = [ "tee" ]
 
 [dependencies]
 env_logger = "0.9.0"

--- a/src/libkrun/build.rs
+++ b/src/libkrun/build.rs
@@ -3,9 +3,9 @@ fn main() {
     println!("cargo:rustc-link-lib=framework=Hypervisor");
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-search=/opt/homebrew/lib");
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     println!("cargo:rustc-link-lib=krunfw");
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     println!("cargo:rustc-link-lib=krunfw-sev");
     #[cfg(target_arch = "aarch64")]
     println!("cargo:rustc-link-lib=fdt");

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -8,28 +8,28 @@ use std::env;
 use std::ffi::CStr;
 #[cfg(target_os = "linux")]
 use std::ffi::CString;
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 use std::path::Path;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use std::path::PathBuf;
 use std::slice;
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Mutex;
 
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use devices::virtio::CacheType;
 use env_logger::Env;
 use libc::{c_char, size_t};
 use once_cell::sync::Lazy;
 use polly::event_manager::EventManager;
 use vmm::resources::VmResources;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use vmm::vmm_config::block::BlockDeviceConfig;
 use vmm::vmm_config::boot_source::{BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 use vmm::vmm_config::fs::FsDeviceConfig;
 use vmm::vmm_config::kernel_bundle::KernelBundle;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use vmm::vmm_config::kernel_bundle::{InitrdBundle, QbootBundle};
 use vmm::vmm_config::machine_config::VmConfig;
 use vmm::vmm_config::vsock::VsockDeviceConfig;
@@ -52,12 +52,12 @@ struct ContextConfig {
     env: Option<String>,
     args: Option<String>,
     rlimits: Option<String>,
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     fs_cfg: Option<FsDeviceConfig>,
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     block_cfg: Option<BlockDeviceConfig>,
     port_map: Option<HashMap<u16, u16>>,
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     tee_config_file: Option<PathBuf>,
 }
 
@@ -117,22 +117,22 @@ impl ContextConfig {
         }
     }
 
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     fn set_fs_cfg(&mut self, fs_cfg: FsDeviceConfig) {
         self.fs_cfg = Some(fs_cfg);
     }
 
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     fn get_fs_cfg(&self) -> Option<FsDeviceConfig> {
         self.fs_cfg.clone()
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     fn set_block_cfg(&mut self, block_cfg: BlockDeviceConfig) {
         self.block_cfg = Some(block_cfg);
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     fn get_block_cfg(&self) -> Option<BlockDeviceConfig> {
         self.block_cfg.clone()
     }
@@ -145,12 +145,12 @@ impl ContextConfig {
         self.port_map.clone()
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     fn set_tee_config_file(&mut self, filepath: PathBuf) {
         self.tee_config_file = Some(filepath);
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     fn get_tee_config_file(&self) -> Option<PathBuf> {
         self.tee_config_file.clone()
     }
@@ -159,14 +159,14 @@ impl ContextConfig {
 static CTX_MAP: Lazy<Mutex<HashMap<u32, ContextConfig>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 static CTX_IDS: AtomicI32 = AtomicI32::new(0);
 
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 #[link(name = "krunfw")]
 extern "C" {
     fn krunfw_get_kernel(load_addr: *mut u64, size: *mut size_t) -> *mut c_char;
     fn krunfw_get_version() -> u32;
 }
 
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 #[link(name = "krunfw-sev")]
 extern "C" {
     fn krunfw_get_qboot(size: *mut size_t) -> *mut c_char;
@@ -215,7 +215,7 @@ pub extern "C" fn krun_create_ctx() -> i32 {
     };
     ctx_cfg.vmr.set_kernel_bundle(kernel_bundle).unwrap();
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     {
         let mut qboot_size: usize = 0;
         let qboot_host_addr = unsafe { krunfw_get_qboot(&mut qboot_size as *mut usize) };
@@ -283,7 +283,7 @@ pub extern "C" fn krun_set_vm_config(ctx_id: u32, num_vcpus: u32, ram_mib: u32) 
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub unsafe extern "C" fn krun_set_root(ctx_id: u32, c_root_path: *const c_char) -> i32 {
     let root_path = match CStr::from_ptr(c_root_path).to_str() {
         Ok(root) => root,
@@ -318,7 +318,7 @@ pub unsafe extern "C" fn krun_set_root(ctx_id: u32, c_root_path: *const c_char) 
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub unsafe extern "C" fn krun_set_mapped_volumes(
     ctx_id: u32,
     c_mapped_volumes: *const *const c_char,
@@ -377,7 +377,7 @@ pub unsafe extern "C" fn krun_set_mapped_volumes(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 pub unsafe extern "C" fn krun_set_root_disk(ctx_id: u32, c_disk_path: *const c_char) -> i32 {
     let disk_path = match CStr::from_ptr(c_disk_path).to_str() {
         Ok(disk) => disk,
@@ -609,7 +609,7 @@ pub unsafe extern "C" fn krun_set_env(ctx_id: u32, c_envp: *const *const c_char)
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 pub unsafe extern "C" fn krun_set_tee_config_file(ctx_id: u32, c_filepath: *const c_char) -> i32 {
     let filepath = match CStr::from_ptr(c_filepath).to_str() {
         Ok(f) => f,
@@ -651,7 +651,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         None => return -libc::ENOENT,
     };
 
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     if let Some(fs_cfg) = ctx_cfg.get_fs_cfg() {
         if ctx_cfg.vmr.set_fs_device(fs_cfg).is_err() {
             error!("Error configuring virtio-fs");
@@ -659,7 +659,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         }
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     if let Some(block_cfg) = ctx_cfg.get_block_cfg() {
         if ctx_cfg.vmr.set_block_device(block_cfg).is_err() {
             error!("Error configuring virtio-blk");
@@ -667,7 +667,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         }
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     if let Some(filepath) = ctx_cfg.get_tee_config_file() {
         if ctx_cfg.vmr.set_tee_config(filepath).is_err() {
             error!("Error parsing TEE config file");

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -26,7 +26,7 @@ kbs-types = { path = "../kbs-types", features = ["tee-sev"], optional = true }
 procfs = { version = "0.12", optional = true }
 serde = { version = "1.0.125", optional = true }
 serde_json = { version = "1.0.64", optional = true }
-sev = { version = "0.2", features = ["openssl"], optional = true }
+sev = { git = "https://github.com/virtee/sev.git", branch = "main", features = ["openssl"], optional = true }
 curl = { version = "0.4", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [features]
 tee = []
 amd-sev = [ "tee", "codicon", "kbs-types", "procfs", "serde", "serde_json", "sev", "curl" ]
-amd-snp = [ "tee" ]
+amd-snp = [ "tee", "codicon", "kbs-types", "procfs", "serde", "serde_json", "sev", "curl" ]
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [features]
 tee = []
 amd-sev = [ "tee", "codicon", "kbs-types", "procfs", "serde", "serde_json", "sev", "curl" ]
-amd-snp = [ "tee", "codicon", "kbs-types", "procfs", "serde", "serde_json", "sev", "curl" ]
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -5,7 +5,9 @@ authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
 
 [features]
-amd-sev = [ "codicon", "kbs-types", "procfs", "serde", "serde_json", "sev", "curl" ]
+tee = []
+amd-sev = [ "tee", "codicon", "kbs-types", "procfs", "serde", "serde_json", "sev", "curl" ]
+amd-snp = [ "tee" ]
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -355,13 +355,14 @@ pub fn build_microvm(
     let mut vm = setup_vm(&guest_memory, vm_resources.tee_config())?;
 
     #[cfg(feature = "amd-sev")]
-    let measured_regions = {
-        vm.secure_virt_prepare(&guest_memory)
+    let (launcher, measured_regions) = {
+        let launcher = vm
+            .secure_virt_prepare(&guest_memory)
             .map_err(StartMicrovmError::SecureVirtPrepare)?;
 
         println!("Injecting and measuring memory regions. This may take a while.");
 
-        vec![
+        let m = vec![
             MeasuredRegion {
                 host_addr: guest_memory
                     .get_host_address(GuestAddress(arch::BIOS_START))
@@ -386,7 +387,9 @@ pub fn build_microvm(
                     .unwrap() as u64,
                 size: 4096,
             },
-        ]
+        ];
+
+        (launcher, m)
     };
 
     // On x86_64 always create a serial device,
@@ -578,7 +581,7 @@ pub fn build_microvm(
     #[cfg(feature = "amd-sev")]
     {
         vmm.kvm_vm()
-            .secure_virt_attest(vmm.guest_memory(), measured_regions)
+            .secure_virt_attest(vmm.guest_memory(), measured_regions, launcher)
             .map_err(StartMicrovmError::SecureVirtAttest)?;
 
         println!("Starting TEE/microVM.");

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -364,24 +364,28 @@ pub fn build_microvm(
 
         let m = vec![
             MeasuredRegion {
+                guest_addr: arch::BIOS_START,
                 host_addr: guest_memory
                     .get_host_address(GuestAddress(arch::BIOS_START))
                     .unwrap() as u64,
                 size: qboot_bundle.size,
             },
             MeasuredRegion {
+                guest_addr: kernel_bundle.guest_addr,
                 host_addr: guest_memory
                     .get_host_address(GuestAddress(kernel_bundle.guest_addr))
                     .unwrap() as u64,
                 size: kernel_bundle.size,
             },
             MeasuredRegion {
+                guest_addr: arch::x86_64::layout::INITRD_SEV_START,
                 host_addr: guest_memory
                     .get_host_address(GuestAddress(arch::x86_64::layout::INITRD_SEV_START))
                     .unwrap() as u64,
                 size: initrd_bundle.size,
             },
             MeasuredRegion {
+                guest_addr: arch::x86_64::layout::ZERO_PAGE_START,
                 host_addr: guest_memory
                     .get_host_address(GuestAddress(arch::x86_64::layout::ZERO_PAGE_START))
                     .unwrap() as u64,

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -719,7 +719,7 @@ pub(crate) fn setup_vm(
 #[cfg(all(target_os = "linux", feature = "tee"))]
 pub(crate) fn setup_vm(
     guest_memory: &GuestMemoryMmap,
-    tee_config: &Option<TeeConfig>,
+    tee_config: &TeeConfig,
 ) -> std::result::Result<Vm, StartMicrovmError> {
     let kvm = KvmContext::new()
         .map_err(Error::KvmContext)

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -261,7 +261,7 @@ impl Vmm {
     pub fn configure_system(&self, vcpus: &[Vcpu], initrd: &Option<InitrdConfig>) -> Result<()> {
         #[cfg(target_arch = "x86_64")]
         {
-            let cmdline_len = if cfg!(feature = "amd-sev") {
+            let cmdline_len = if cfg!(feature = "tee") {
                 arch::x86_64::layout::CMDLINE_SEV_SIZE
             } else {
                 self.kernel_cmdline.len() + 1

--- a/src/vmm/src/linux/amdsev.rs
+++ b/src/vmm/src/linux/amdsev.rs
@@ -1,8 +1,7 @@
 use std::fmt;
 use std::fs::File;
 use std::io::Read;
-use std::mem::{size_of_val, MaybeUninit};
-use std::os::unix::io::AsRawFd;
+use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -17,8 +16,8 @@ use kvm_ioctls::VmFd;
 use procfs::CpuInfo;
 use serde::{Deserialize, Serialize};
 use sev::certs;
-use sev::firmware::Firmware;
-use sev::launch::sev::{Measurement, Policy, PolicyFlags, Secret, Start};
+use sev::firmware::uapi::host::Firmware;
+use sev::launch::sev::*;
 use sev::session::Session;
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 
@@ -330,48 +329,6 @@ impl AmdSev {
         })
     }
 
-    fn sev_init(&self, vm_fd: &VmFd) -> Result<(), kvm_ioctls::Error> {
-        let mut cmd = kvm_sev_cmd {
-            id: u32::from(self.sev_es),
-            data: 0,
-            error: 0,
-            sev_fd: self.fw.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)?;
-        Ok(())
-    }
-
-    fn sev_launch_start(&self, vm_fd: &VmFd) -> Result<(), kvm_ioctls::Error> {
-        #[repr(C)]
-        struct Data {
-            handle: u32,
-            policy: Policy,
-            dh_addr: u64,
-            dh_size: u32,
-            session_addr: u64,
-            session_size: u32,
-        }
-
-        let mut data = Data {
-            handle: 0,
-            policy: self.start.policy,
-            dh_addr: &self.start.cert as *const _ as u64,
-            dh_size: size_of_val(&self.start.cert) as u32,
-            session_addr: &self.start.session as *const _ as u64,
-            session_size: size_of_val(&self.start.session) as u32,
-        };
-
-        let mut cmd = kvm_sev_cmd {
-            id: 2, // SEV_LAUNCH_START
-            data: &mut data as *mut _ as u64,
-            error: 0,
-            sev_fd: self.fw.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)
-    }
-
     fn sev_launch_update_data(
         &self,
         vm_fd: &VmFd,
@@ -399,90 +356,19 @@ impl AmdSev {
         vm_fd.encrypt_op_sev(&mut cmd)
     }
 
-    fn sev_launch_measure(&self, vm_fd: &VmFd) -> Result<Measurement, kvm_ioctls::Error> {
-        #[repr(C)]
-        struct Data {
-            addr: u64,
-            size: u32,
-        }
-
-        let mut measurement: MaybeUninit<Measurement> = MaybeUninit::uninit();
-        let mut data = Data {
-            addr: &mut measurement as *mut _ as u64,
-            size: size_of_val(&measurement) as u32,
-        };
-
-        let mut cmd = kvm_sev_cmd {
-            id: 6, // SEV_LAUNCH_MEASURE
-            data: &mut data as *mut _ as u64,
-            error: 0,
-            sev_fd: self.fw.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)?;
-
-        Ok(unsafe { measurement.assume_init() })
-    }
-
-    fn sev_launch_finish(&self, vm_fd: &VmFd) -> Result<(), kvm_ioctls::Error> {
-        let mut cmd = kvm_sev_cmd {
-            id: 7, // SEV_LAUNCH_FINISH
-            data: 0,
-            error: 0,
-            sev_fd: self.fw.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)
-    }
-
-    fn sev_inject_secret(
+    pub fn vm_prepare(
         &self,
         vm_fd: &VmFd,
-        mut secret: Secret,
-        secret_host_addr: u64,
-    ) -> Result<(), kvm_ioctls::Error> {
-        #[repr(C)]
-        struct Data {
-            headr_addr: u64,
-            headr_size: u32,
-            guest_addr: u64,
-            guest_size: u32,
-            trans_addr: u64,
-            trans_size: u32,
-        }
+        guest_mem: &GuestMemoryMmap,
+    ) -> Result<Launcher<Started, RawFd, RawFd>, Error> {
+        let vm_rfd = vm_fd.as_raw_fd();
+        let fw_rfd = self.fw.as_raw_fd();
 
-        let mut data = Data {
-            headr_addr: &mut secret.header as *mut _ as u64,
-            headr_size: size_of_val(&secret.header) as u32,
-            guest_addr: secret_host_addr,
-            guest_size: secret.ciphertext.len() as u32,
-            trans_addr: secret.ciphertext.as_mut_ptr() as u64,
-            trans_size: secret.ciphertext.len() as u32,
+        let launcher = if self.sev_es {
+            Launcher::new_es(vm_rfd, fw_rfd).unwrap()
+        } else {
+            Launcher::new(vm_rfd, fw_rfd).unwrap()
         };
-
-        let mut cmd = kvm_sev_cmd {
-            id: 5, // SEV_LAUNCH_SECRET
-            data: &mut data as *mut _ as u64,
-            error: 0,
-            sev_fd: vm_fd.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)
-    }
-
-    fn sev_launch_update_vmsa(&self, vm_fd: &VmFd) -> Result<(), kvm_ioctls::Error> {
-        let mut cmd = kvm_sev_cmd {
-            id: 4, // SEV_LAUNCH_UPDATE_VMSA
-            data: 0,
-            error: 0,
-            sev_fd: vm_fd.as_raw_fd() as u32,
-        };
-
-        vm_fd.encrypt_op_sev(&mut cmd)
-    }
-
-    pub fn vm_prepare(&self, vm_fd: &VmFd, guest_mem: &GuestMemoryMmap) -> Result<(), Error> {
-        self.sev_init(vm_fd).map_err(Error::SevInit)?;
 
         for region in guest_mem.iter() {
             // It's safe to unwrap because the guest address is valid.
@@ -496,10 +382,9 @@ impl AmdSev {
                 .map_err(|_| Error::MemoryEncryptRegion)?;
         }
 
-        self.sev_launch_start(vm_fd)
-            .map_err(Error::SevLaunchStart)?;
+        let launcher = launcher.start(self.start).unwrap();
 
-        Ok(())
+        Ok(launcher)
     }
 
     pub fn vm_attest(
@@ -507,6 +392,7 @@ impl AmdSev {
         vm_fd: &VmFd,
         guest_mem: &GuestMemoryMmap,
         measured_regions: Vec<MeasuredRegion>,
+        mut launcher: Launcher<Started, RawFd, RawFd>,
     ) -> Result<(), Error> {
         for region in measured_regions {
             self.sev_launch_update_data(vm_fd, region.host_addr, region.size)
@@ -514,13 +400,11 @@ impl AmdSev {
         }
 
         if self.sev_es {
-            self.sev_launch_update_vmsa(vm_fd)
-                .map_err(Error::SevLaunchUpdateVmsa)?;
+            launcher.update_vmsa().unwrap()
         }
 
-        let measurement = self
-            .sev_launch_measure(vm_fd)
-            .map_err(Error::SevLaunchMeasure)?;
+        let mut launcher = launcher.measure().unwrap();
+        let measurement = launcher.measurement();
 
         if !self.tee_config.attestation_url.is_empty() {
             let tee_pubkey = TeePubKey {
@@ -555,12 +439,13 @@ impl AmdSev {
             let secret_host_addr = guest_mem
                 .get_host_address(GuestAddress(arch::x86_64::layout::CMDLINE_START))
                 .unwrap() as u64;
-            self.sev_inject_secret(vm_fd, secret, secret_host_addr)
-                .map_err(Error::SevInjectSecret)?;
+
+            launcher
+                .inject(&secret, secret_host_addr.try_into().unwrap())
+                .unwrap();
         }
 
-        self.sev_launch_finish(vm_fd)
-            .map_err(Error::SevLaunchFinish)?;
+        let _handle = launcher.finish();
 
         Ok(())
     }

--- a/src/vmm/src/linux/mod.rs
+++ b/src/vmm/src/linux/mod.rs
@@ -1,3 +1,4 @@
-#[cfg(feature = "amd-sev")]
-mod amdsev;
+#[cfg(feature = "tee")]
+pub mod tee;
+
 pub mod vstate;

--- a/src/vmm/src/linux/tee/amdsev.rs
+++ b/src/vmm/src/linux/tee/amdsev.rs
@@ -5,8 +5,8 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use super::super::resources::TeeConfig;
-use super::vstate::MeasuredRegion;
+use super::super::super::resources::TeeConfig;
+use super::super::vstate::MeasuredRegion;
 
 use codicon::{Decoder, Encoder};
 use curl::easy::{Easy, List};

--- a/src/vmm/src/linux/tee/amdsnp.rs
+++ b/src/vmm/src/linux/tee/amdsnp.rs
@@ -1,9 +1,8 @@
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use crate::resources::TeeConfig;
 use crate::vstate::MeasuredRegion;
 
-use sev::firmware::Firmware;
+use sev::firmware::uapi::host::Firmware;
 use sev::launch::snp::*;
 
 use kvm_bindings::kvm_enc_region;
@@ -18,21 +17,18 @@ pub enum Error {
     LaunchStart(std::io::Error),
     LaunchUpdate(std::io::Error),
     LaunchFinish(std::io::Error),
+    CpuIdWrite,
 }
 
 pub struct AmdSnp {
-    tee_config: TeeConfig,
     fw: Firmware,
 }
 
 impl AmdSnp {
-    pub fn new(tee_config: &TeeConfig) -> Result<Self, Error> {
+    pub fn new() -> Result<Self, Error> {
         let fw = Firmware::open().map_err(Error::OpenFirmware)?;
 
-        Ok(AmdSnp {
-            tee_config: tee_config.clone(),
-            fw,
-        })
+        Ok(AmdSnp { fw })
     }
 
     pub fn vm_prepare(

--- a/src/vmm/src/linux/tee/amdsnp.rs
+++ b/src/vmm/src/linux/tee/amdsnp.rs
@@ -1,0 +1,143 @@
+use std::os::unix::io::{AsRawFd, RawFd};
+
+use crate::resources::TeeConfig;
+use crate::vstate::MeasuredRegion;
+
+use sev::firmware::Firmware;
+use sev::launch::snp::*;
+
+use kvm_bindings::kvm_enc_region;
+use kvm_ioctls::VmFd;
+use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap};
+
+#[derive(Debug)]
+pub enum Error {
+    OpenFirmware(std::io::Error),
+    CreateLauncher(std::io::Error),
+    MemoryEncryptRegion,
+    LaunchStart(std::io::Error),
+    LaunchUpdate(std::io::Error),
+    LaunchFinish(std::io::Error),
+}
+
+pub struct AmdSnp {
+    tee_config: TeeConfig,
+    fw: Firmware,
+}
+
+impl AmdSnp {
+    pub fn new(tee_config: &TeeConfig) -> Result<Self, Error> {
+        let fw = Firmware::open().map_err(Error::OpenFirmware)?;
+
+        Ok(AmdSnp {
+            tee_config: tee_config.clone(),
+            fw,
+        })
+    }
+
+    pub fn vm_prepare(
+        &self,
+        vm_fd: &VmFd,
+        guest_mem: &GuestMemoryMmap,
+    ) -> Result<Launcher<Started, RawFd, RawFd>, Error> {
+        let vm_rfd = vm_fd.as_raw_fd();
+        let fw_rfd = self.fw.as_raw_fd();
+
+        let launcher = Launcher::new(vm_rfd, fw_rfd).map_err(Error::CreateLauncher)?;
+
+        for region in guest_mem.iter() {
+            // It's safe to unwrap because the guest address is valid.
+            let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap();
+            let enc_region = kvm_enc_region {
+                addr: host_addr as u64,
+                size: region.len() as u64,
+            };
+
+            vm_fd
+                .register_enc_memory_region(&enc_region)
+                .map_err(|_| Error::MemoryEncryptRegion)?;
+        }
+
+        let start = Start::new(
+            None,
+            Policy {
+                flags: PolicyFlags::SMT,
+                ..Default::default()
+            },
+            false,
+            [0; 16],
+        );
+
+        let launcher = launcher.start(start).map_err(Error::LaunchStart)?;
+
+        Ok(launcher)
+    }
+
+    pub fn vm_measure(
+        &self,
+        guest_mem: &GuestMemoryMmap,
+        measured_regions: Vec<MeasuredRegion>,
+        mut launcher: Launcher<Started, RawFd, RawFd>,
+    ) -> Result<(), Error> {
+        let dp = VmplPerms::empty();
+        for region in measured_regions {
+            let page_type = if region.guest_addr == arch::x86_64::layout::ZERO_PAGE_START {
+                PageType::Zero
+            } else {
+                PageType::Normal
+            };
+
+            let ga = GuestAddress(region.guest_addr);
+
+            /*
+             * Use the guest's address to obtain its GuestRegionMmap, and then
+             * convert this region to a slice. Basically, we are taking an
+             * entire slice of a guest memory region.
+             */
+            let gr: &GuestRegionMmap = guest_mem.find_region(ga).unwrap();
+            let region_slice = unsafe { gr.as_slice().unwrap() };
+
+            /*
+             * The memory region we are currently looking to measure is
+             * represented simply as a guest address at the moment. Instead,
+             * we would like to obtain a slice of it. To do this, we must use
+             * the guest address as an OFFSET within the slice, and only take
+             * that subslice.
+             */
+            let offset: usize = guest_mem
+                .to_region_addr(ga)
+                .unwrap()
+                .1
+                 .0
+                .try_into()
+                .unwrap();
+
+            /*
+             * We know the size of the region to be measured from the
+             * MeasuredRegion.
+             */
+            let count: usize = region.size;
+
+            /*
+             * We now have the start and end indexes of the slice, so use these
+             * indexes to take a subslice of the guest region (corresponding to
+             * the slice of bytes that we're looking to measure).
+             */
+            let buf = &region_slice[offset..offset + count];
+
+            /*
+             * From that subslice, build an Update struct and call
+             * SNP_LAUNCH_UPDATE.
+             */
+            let update = Update::new(region.guest_addr >> 12, buf, false, page_type, (dp, dp, dp));
+
+            launcher.update_data(update).map_err(Error::LaunchUpdate)?;
+        }
+
+        let finish = Finish::new(None, None, [0; 32]);
+
+        let (_vmfd, _fwfd) = launcher.finish(finish).map_err(Error::LaunchFinish)?;
+
+        Ok(())
+    }
+}

--- a/src/vmm/src/linux/tee/mod.rs
+++ b/src/vmm/src/linux/tee/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "amd-sev")]
 pub mod amdsev;
 
-#[cfg(feature = "amd-snp")]
+#[cfg(feature = "amd-sev")]
 pub mod amdsnp;

--- a/src/vmm/src/linux/tee/mod.rs
+++ b/src/vmm/src/linux/tee/mod.rs
@@ -1,2 +1,5 @@
 #[cfg(feature = "amd-sev")]
 pub mod amdsev;
+
+#[cfg(feature = "amd-snp")]
+pub mod amdsnp;

--- a/src/vmm/src/linux/tee/mod.rs
+++ b/src/vmm/src/linux/tee/mod.rs
@@ -1,0 +1,2 @@
+#[cfg(feature = "amd-sev")]
+pub mod amdsev;

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -512,8 +512,6 @@ impl Vm {
             fd: vm_fd,
             supported_cpuid,
             supported_msrs,
-            #[cfg(target_arch = "aarch64")]
-            irqchip_handle: None,
             sev,
         })
     }

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -489,7 +489,7 @@ impl Vm {
     }
 
     #[cfg(feature = "amd-sev")]
-    pub fn new(kvm: &Kvm, tee_config: &Option<TeeConfig>) -> Result<Self> {
+    pub fn new(kvm: &Kvm, tee_config: &TeeConfig) -> Result<Self> {
         //create fd for interacting with kvm-vm specific functions
         let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
 
@@ -500,13 +500,7 @@ impl Vm {
         let supported_msrs =
             arch::x86_64::msr::supported_guest_msrs(kvm).map_err(Error::GuestMSRs)?;
 
-        let sev = {
-            if let Some(config) = tee_config {
-                AmdSev::new(config).map_err(Error::SecVirtInit)?
-            } else {
-                return Err(Error::MissingTeeConfig);
-            }
-        };
+        let sev = AmdSev::new(tee_config).map_err(Error::SecVirtInit)?;
 
         Ok(Vm {
             fd: vm_fd,
@@ -517,7 +511,7 @@ impl Vm {
     }
 
     #[cfg(feature = "amd-snp")]
-    pub fn new(kvm: &Kvm, tee_config: &Option<TeeConfig>) -> Result<Self> {
+    pub fn new(kvm: &Kvm, tee_config: &TeeConfig) -> Result<Self> {
         let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
 
         let supported_cpuid = kvm
@@ -526,11 +520,7 @@ impl Vm {
         let supported_msrs =
             arch::x86_64::msr::supported_guest_msrs(kvm).map_err(Error::GuestMSRs)?;
 
-        let snp = if let Some(config) = tee_config {
-            AmdSnp::new(config).map_err(Error::SecVirtInit)?
-        } else {
-            return Err(Error::MissingTeeConfig);
-        };
+        let snp = AmdSnp::new(tee_config).map_err(Error::SecVirtInit)?;
 
         Ok(Vm {
             fd: vm_fd,

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -26,8 +26,11 @@ use super::super::{FC_EXIT_CODE_GENERIC_ERROR, FC_EXIT_CODE_OK};
 #[cfg(feature = "amd-sev")]
 use super::tee::amdsev::{AmdSev, Error as SevError};
 
-#[cfg(feature = "amd-snp")]
+#[cfg(feature = "amd-sev")]
 use super::tee::amdsnp::{AmdSnp, Error as SnpError};
+
+#[cfg(feature = "tee")]
+use kbs_types::Tee;
 
 #[cfg(feature = "tee")]
 use crate::resources::TeeConfig;
@@ -54,10 +57,10 @@ use vm_memory::{
 };
 
 #[cfg(feature = "amd-sev")]
-use sev::launch::sev::*;
+use sev::launch::sev as sev_launch;
 
-#[cfg(feature = "amd-snp")]
-use sev::launch::snp::*;
+#[cfg(feature = "amd-sev")]
+use sev::launch::snp;
 
 #[cfg(target_arch = "x86_64")]
 const MAGIC_IOPORT_SIGNAL_GUEST_BOOT_COMPLETE: u64 = 0x03f0;
@@ -114,22 +117,25 @@ pub enum Error {
     SetUserMemoryRegion(kvm_ioctls::Error),
     #[cfg(feature = "amd-sev")]
     /// Error initializing the Secure Virtualization Backend (SEV).
-    SecVirtInit(SevError),
+    SevSecVirtInit(SevError),
     #[cfg(feature = "amd-sev")]
     /// Error preparing the VM for Secure Virtualization (SEV).
-    SecVirtPrepare(SevError),
+    SevSecVirtPrepare(SevError),
     #[cfg(feature = "amd-sev")]
     /// Error attesting the Secure VM (SEV).
-    SecVirtAttest(SevError),
-    #[cfg(feature = "amd-snp")]
+    SevSecVirtAttest(SevError),
+    #[cfg(feature = "amd-sev")]
     /// Error initializing the Secure Virtualization Backend (SNP).
-    SecVirtInit(SnpError),
-    #[cfg(feature = "amd-snp")]
+    SnpSecVirtInit(SnpError),
+    #[cfg(feature = "amd-sev")]
     /// Error preparing the VM for Secure Virtualization (SNP).
-    SecVirtPrepare(SnpError),
-    #[cfg(feature = "amd-snp")]
+    SnpSecVirtPrepare(SnpError),
+    #[cfg(feature = "amd-sev")]
     /// Error attesting the Secure VM (SNP).
-    SecVirtAttest(SnpError),
+    SnpSecVirtAttest(SnpError),
+    #[cfg(feature = "tee")]
+    /// The TEE specified is not supported.
+    InvalidTee,
     /// Failed to signal Vcpu.
     SignalVcpu(utils::errno::Error),
     #[cfg(target_arch = "x86_64")]
@@ -270,21 +276,39 @@ impl Display for Error {
             ),
             SetUserMemoryRegion(e) => write!(f, "Cannot set the memory regions: {}", e),
             #[cfg(feature = "tee")]
-            SecVirtInit(e) => {
+            SevSecVirtInit(e) => {
                 write!(
                     f,
-                    "Error initializing the Secure Virtualization Backend: {:?}",
+                    "Error initializing the Secure Virtualization Backend (SEV): {:?}",
                     e
                 )
             }
             #[cfg(feature = "tee")]
-            SecVirtPrepare(e) => write!(
+            SevSecVirtPrepare(e) => write!(
                 f,
-                "Error preparing the VM for Secure Virtualization: {:?}",
+                "Error preparing the VM for Secure Virtualization (SEV): {:?}",
                 e
             ),
             #[cfg(feature = "tee")]
-            SecVirtAttest(e) => write!(f, "Error attesting the Secure VM: {:?}", e),
+            SevSecVirtAttest(e) => write!(f, "Error attesting the Secure VM (SEV): {:?}", e),
+
+            #[cfg(feature = "tee")]
+            SnpSecVirtInit(e) => write!(
+                f,
+                "Error initializing the Secure Virtualization Backend (SEV): {:?}",
+                e
+            ),
+
+            #[cfg(feature = "tee")]
+            SnpSecVirtPrepare(e) => write!(
+                f,
+                "Error preparing the VM for Secure Virtualization (SNP): {:?}",
+                e
+            ),
+
+            #[cfg(feature = "tee")]
+            SnpSecVirtAttest(e) => write!(f, "Error attesting the Secure VM (SNP): {:?}", e),
+
             SignalVcpu(e) => write!(f, "Failed to signal Vcpu: {}", e),
             #[cfg(feature = "tee")]
             MissingTeeConfig => write!(f, "Missing TEE configuration"),
@@ -377,6 +401,9 @@ impl Display for Error {
             }
             #[cfg(target_arch = "aarch64")]
             VcpuArmInit(e) => write!(f, "Error doing Vcpu Init on Arm: {}", e),
+
+            #[cfg(feature = "tee")]
+            InvalidTee => write!(f, "TEE selected is not currently supported"),
         }
     }
 }
@@ -456,10 +483,13 @@ pub struct Vm {
     irqchip_handle: Option<Box<dyn GICDevice>>,
 
     #[cfg(feature = "amd-sev")]
-    sev: AmdSev,
+    sev: Option<AmdSev>,
 
-    #[cfg(feature = "amd-snp")]
-    snp: AmdSnp,
+    #[cfg(feature = "amd-sev")]
+    snp: Option<AmdSnp>,
+
+    #[cfg(feature = "amd-sev")]
+    pub tee: Tee,
 }
 
 impl Vm {
@@ -500,33 +530,22 @@ impl Vm {
         let supported_msrs =
             arch::x86_64::msr::supported_guest_msrs(kvm).map_err(Error::GuestMSRs)?;
 
-        let sev = AmdSev::new(tee_config).map_err(Error::SecVirtInit)?;
+        let (sev, snp) = match tee_config.tee {
+            Tee::Sev => (
+                Some(AmdSev::new(tee_config).map_err(Error::SevSecVirtInit)?),
+                None,
+            ),
+            Tee::Snp => (None, Some(AmdSnp::new().map_err(Error::SnpSecVirtInit)?)),
+            _ => return Err(Error::InvalidTee),
+        };
 
         Ok(Vm {
             fd: vm_fd,
             supported_cpuid,
             supported_msrs,
             sev,
-        })
-    }
-
-    #[cfg(feature = "amd-snp")]
-    pub fn new(kvm: &Kvm, tee_config: &TeeConfig) -> Result<Self> {
-        let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
-
-        let supported_cpuid = kvm
-            .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)
-            .map_err(Error::VmFd)?;
-        let supported_msrs =
-            arch::x86_64::msr::supported_guest_msrs(kvm).map_err(Error::GuestMSRs)?;
-
-        let snp = AmdSnp::new(tee_config).map_err(Error::SecVirtInit)?;
-
-        Ok(Vm {
-            fd: vm_fd,
-            supported_cpuid,
-            supported_msrs,
             snp,
+            tee: tee_config.tee.clone(),
         })
     }
 
@@ -580,47 +599,59 @@ impl Vm {
     }
 
     #[cfg(feature = "amd-sev")]
-    pub fn secure_virt_prepare(
+    pub fn sev_secure_virt_prepare(
         &mut self,
         guest_mem: &GuestMemoryMmap,
-    ) -> Result<Launcher<Started, RawFd, RawFd>> {
-        self.sev
-            .vm_prepare(&self.fd, guest_mem)
-            .map_err(Error::SecVirtPrepare)
+    ) -> Result<sev_launch::Launcher<sev_launch::Started, RawFd, RawFd>> {
+        match &self.sev {
+            Some(s) => s
+                .vm_prepare(&self.fd, guest_mem)
+                .map_err(Error::SevSecVirtPrepare),
+            None => Err(Error::InvalidTee),
+        }
     }
 
     #[cfg(feature = "amd-sev")]
-    pub fn secure_virt_attest(
+    pub fn sev_secure_virt_attest(
         &self,
         guest_mem: &GuestMemoryMmap,
         measured_regions: Vec<MeasuredRegion>,
-        launcher: Launcher<Started, RawFd, RawFd>,
+        launcher: sev_launch::Launcher<sev_launch::Started, RawFd, RawFd>,
     ) -> Result<()> {
-        self.sev
-            .vm_attest(&self.fd, guest_mem, measured_regions, launcher)
-            .map_err(Error::SecVirtAttest)
+        match &self.sev {
+            Some(s) => s
+                .vm_attest(&self.fd, guest_mem, measured_regions, launcher)
+                .map_err(Error::SevSecVirtAttest),
+            None => Err(Error::InvalidTee),
+        }
     }
 
-    #[cfg(feature = "amd-snp")]
-    pub fn secure_virt_prepare(
+    #[cfg(feature = "amd-sev")]
+    pub fn snp_secure_virt_prepare(
         &self,
         guest_mem: &GuestMemoryMmap,
-    ) -> Result<Launcher<Started, RawFd, RawFd>> {
-        self.snp
-            .vm_prepare(&self.fd, guest_mem)
-            .map_err(Error::SecVirtPrepare)
+    ) -> Result<snp::Launcher<snp::Started, RawFd, RawFd>> {
+        match &self.snp {
+            Some(s) => s
+                .vm_prepare(&self.fd, guest_mem)
+                .map_err(Error::SnpSecVirtPrepare),
+            None => Err(Error::InvalidTee),
+        }
     }
 
-    #[cfg(feature = "amd-snp")]
-    pub fn secure_virt_attest(
+    #[cfg(feature = "amd-sev")]
+    pub fn snp_secure_virt_attest(
         &self,
         guest_mem: &GuestMemoryMmap,
         measured_regions: Vec<MeasuredRegion>,
-        launcher: Launcher<Started, RawFd, RawFd>,
+        launcher: snp::Launcher<snp::Started, RawFd, RawFd>,
     ) -> Result<()> {
-        self.snp
-            .vm_measure(guest_mem, measured_regions, launcher)
-            .map_err(Error::SecVirtAttest)
+        match &self.snp {
+            Some(s) => s
+                .vm_measure(guest_mem, measured_regions, launcher)
+                .map_err(Error::SnpSecVirtAttest),
+            None => Err(Error::InvalidTee),
+        }
     }
 
     /// Creates the irq chip and an in-kernel device model for the PIT.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -3,22 +3,22 @@
 
 //#![deny(warnings)]
 
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use std::fs::File;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use std::io::BufReader;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use std::path::PathBuf;
 
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use crate::vmm_config::block::{BlockBuilder, BlockConfigError, BlockDeviceConfig};
 use crate::vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 use crate::vmm_config::fs::*;
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 use crate::vmm_config::kernel_bundle::{InitrdBundle, QbootBundle, QbootBundleError};
 use crate::vmm_config::kernel_bundle::{KernelBundle, KernelBundleError};
 use crate::vmm_config::machine_config::{VmConfig, VmConfigError};
@@ -35,13 +35,13 @@ pub enum Error {
     /// Boot source configuration error.
     BootSource(BootSourceConfigError),
     /// Error opening TEE config file.
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     OpenTeeConfig(std::io::Error),
     /// Fs device configuration error.
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     FsDevice(FsConfigError),
     /// Error parsing TEE config file.
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     ParseTeeConfig(serde_json::Error),
     /// microVM vCpus or memory configuration error.
     VmConfig(VmConfigError),
@@ -49,7 +49,7 @@ pub enum Error {
     VsockDevice(VsockConfigError),
 }
 
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TeeConfig {
     pub workload_id: String,
@@ -71,21 +71,21 @@ pub struct VmResources {
     /// The parameters for the kernel bundle to be loaded in this microVM.
     pub kernel_bundle: Option<KernelBundle>,
     /// The parameters for the qboot bundle to be loaded in this microVM.
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub qboot_bundle: Option<QbootBundle>,
     /// The parameters for the initrd bundle to be loaded in this microVM.
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub initrd_bundle: Option<InitrdBundle>,
     /// The fs device.
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     pub fs: FsBuilder,
     /// The vsock device.
     pub vsock: VsockBuilder,
     /// The virtio-blk device.
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub block: BlockBuilder,
     /// TEE configuration
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub tee_config: Option<TeeConfig>,
 }
 
@@ -179,12 +179,12 @@ impl VmResources {
         Ok(())
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub fn qboot_bundle(&self) -> Option<&QbootBundle> {
         self.qboot_bundle.as_ref()
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub fn set_qboot_bundle(&mut self, qboot_bundle: QbootBundle) -> Result<QbootBundleError> {
         if qboot_bundle.size != 0x10000 {
             return Err(QbootBundleError::InvalidSize);
@@ -194,23 +194,23 @@ impl VmResources {
         Ok(())
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub fn initrd_bundle(&self) -> Option<&InitrdBundle> {
         self.initrd_bundle.as_ref()
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub fn set_initrd_bundle(&mut self, initrd_bundle: InitrdBundle) -> Result<KernelBundleError> {
         self.initrd_bundle = Some(initrd_bundle);
         Ok(())
     }
 
-    #[cfg(not(feature = "amd-sev"))]
+    #[cfg(not(feature = "tee"))]
     pub fn set_fs_device(&mut self, config: FsDeviceConfig) -> Result<FsConfigError> {
         self.fs.insert(config)
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub fn set_block_device(&mut self, config: BlockDeviceConfig) -> Result<BlockConfigError> {
         self.block.insert(config)
     }
@@ -220,12 +220,12 @@ impl VmResources {
         self.vsock.insert(config)
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub fn tee_config(&self) -> &Option<TeeConfig> {
         &self.tee_config
     }
 
-    #[cfg(feature = "amd-sev")]
+    #[cfg(feature = "tee")]
     pub fn set_tee_config(&mut self, filepath: PathBuf) -> Result<Error> {
         let file = File::open(filepath.as_path()).map_err(Error::OpenTeeConfig)?;
         let reader = BufReader::new(file);

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -50,7 +50,7 @@ pub enum Error {
 }
 
 #[cfg(feature = "tee")]
-#[derive(Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TeeConfig {
     pub workload_id: String,
     pub cpus: u8,
@@ -58,6 +58,20 @@ pub struct TeeConfig {
     pub tee: kbs_types::Tee,
     pub tee_data: String,
     pub attestation_url: String,
+}
+
+#[cfg(feature = "tee")]
+impl Default for TeeConfig {
+    fn default() -> Self {
+        Self {
+            workload_id: "".to_string(),
+            cpus: 0,
+            ram_mib: 0,
+            tee: kbs_types::Tee::Sev,
+            tee_data: "".to_string(),
+            attestation_url: "".to_string(),
+        }
+    }
 }
 
 /// A data structure that encapsulates the device configurations
@@ -84,9 +98,10 @@ pub struct VmResources {
     /// The virtio-blk device.
     #[cfg(feature = "tee")]
     pub block: BlockBuilder,
+
     /// TEE configuration
     #[cfg(feature = "tee")]
-    pub tee_config: Option<TeeConfig>,
+    pub tee_config: TeeConfig,
 }
 
 impl VmResources {
@@ -221,7 +236,7 @@ impl VmResources {
     }
 
     #[cfg(feature = "tee")]
-    pub fn tee_config(&self) -> &Option<TeeConfig> {
+    pub fn tee_config(&self) -> &TeeConfig {
         &self.tee_config
     }
 
@@ -241,7 +256,7 @@ impl VmResources {
         })
         .map_err(Error::VmConfig)?;
 
-        self.tee_config = Some(tee_config);
+        self.tee_config = tee_config;
 
         Ok(())
     }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -14,6 +14,9 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "tee")]
+use kbs_types::Tee;
+
+#[cfg(feature = "tee")]
 use crate::vmm_config::block::{BlockBuilder, BlockConfigError, BlockDeviceConfig};
 use crate::vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
 #[cfg(not(feature = "tee"))]
@@ -55,7 +58,7 @@ pub struct TeeConfig {
     pub workload_id: String,
     pub cpus: u8,
     pub ram_mib: usize,
-    pub tee: kbs_types::Tee,
+    pub tee: Tee,
     pub tee_data: String,
     pub attestation_url: String,
 }
@@ -67,7 +70,7 @@ impl Default for TeeConfig {
             workload_id: "".to_string(),
             cpus: 0,
             ram_mib: 0,
-            tee: kbs_types::Tee::Sev,
+            tee: Tee::Sev,
             tee_data: "".to_string(),
             attestation_url: "".to_string(),
         }

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -16,14 +16,13 @@ use std::fmt::{Display, Formatter, Result};
 //pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0 \
 //                                          i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd";
 
-#[cfg(all(target_os = "linux", not(feature = "amd-sev")))]
-pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
-                                          rootfstype=virtiofs rw quiet no-kvmapf tsi_hijack";
+#[cfg(all(target_os = "linux", not(feature = "tee")))]
+pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console= \
+                                          rootfstype=virtiofs rw no-kvmapf tsi_hijack";
 
 #[cfg(feature = "amd-sev")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
                                           root=/dev/vda rw quiet no-kvmapf tsi_hijack";
-
 #[cfg(target_os = "macos")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
                                           rootfstype=virtiofs rw quiet no-kvmapf tsi_hijack";

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -2,18 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Wrapper for configuring the Block devices attached to the microVM.
-#[cfg(feature = "amd-sev")]
+#[cfg(feature = "tee")]
 pub mod block;
+
 /// Wrapper for configuring the microVM boot source.
 pub mod boot_source;
+
 /// Wrapper for configuring the Fs devices attached to the microVM.
-#[cfg(not(feature = "amd-sev"))]
+#[cfg(not(feature = "tee"))]
 pub mod fs;
+
 /// Wrapper over the microVM general information attached to the microVM.
 pub mod instance_info;
+
 /// Wrapper for configuring the kernel bundle to be loaded in the microVM.
 pub mod kernel_bundle;
+
 /// Wrapper for configuring the memory and CPU of the microVM.
 pub mod machine_config;
+
 /// Wrapper for configuring the vsock devices attached to the microVM.
 pub mod vsock;


### PR DESCRIPTION
This PR adds a few new features to the TEE capabilities of `libkrun`:

- Modifies the `amd-sev` module to utilize the `sev` library APIs for creating a SEV-encrypted VM.
- Introduces a new module `tee`, which serves to group all TEE-specific modules in one place.
- Introduces the ability to create AMD SEV-SNP encrypted VMs through the `amd-snp` module.

One thing missing in this PR is that although SEV-SNP VMs can be created, there is no interface for attesting a SEV-SNP VM. Attestation support is currently a WIP.