### PR TITLE
vsock: Fix signal logic in Muxer

### DIFF
--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -242,7 +242,9 @@ impl VsockMuxer {
         if update.signal_queue {
             self.interrupt_status
                 .fetch_or(VIRTIO_MMIO_INT_VRING as usize, Ordering::SeqCst);
-            if let Err(e) = self.interrupt_evt.write(1) {
+            if let Some(intc) = &self.intc {
+                intc.lock().unwrap().set_irq(self.irq_line.unwrap());
+            } else if let Err(e) = self.interrupt_evt.write(1) {
                 warn!("failed to signal used queue: {:?}", e);
             }
         }


### PR DESCRIPTION
The signal logic in Muxer was missing the ability to signal through an intc, if present. Fix it here.

Signed-off-by: Sergio Lopez <slp@redhat.com>