### PR TITLE
Bump version to v1.4.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,7 +370,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.4.4"
+version = "1.4.5"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.4.4
+FULL_VERSION=1.4.5
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.4.4"
+version = "1.4.5"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
This release includes a fix for the irq signal logic in vsock and updates to the final version of the KBS attestation protocol. Bump release number to v1.4.5.

Signed-off-by: Sergio Lopez <slp@redhat.com>