### PR TITLE
Fix kernel command line for non-TEE targets

### DIFF
--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -17,8 +17,8 @@ use std::fmt::{Display, Formatter, Result};
 //                                          i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd";
 
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
-pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console= \
-                                          rootfstype=virtiofs rw no-kvmapf tsi_hijack";
+pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
+                                          rootfstype=virtiofs rw quiet no-kvmapf tsi_hijack";
 
 #[cfg(feature = "amd-sev")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \


### PR DESCRIPTION
Commit "00bd4c9" accidentally broke the kernel command line for non-TEE targets. Fix it here.

Signed-off-by: Sergio Lopez <slp@redhat.com>