### PR TITLE
init: do a case-insensitive check for JSON fields

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -326,7 +326,7 @@ static char * config_parse_string(char *data, jsmntok_t *token)
 
 static int jsoneq(const char *json, jsmntok_t *tok, const char *s) {
 	if (tok->type == JSMN_STRING && (int)strlen(s) == tok->end - tok->start &&
-	    strncmp(json + tok->start, s, tok->end - tok->start) == 0) {
+	    strncasecmp(json + tok->start, s, tok->end - tok->start) == 0) {
 		return 0;
 	}
 	return -1;


### PR DESCRIPTION
While JSON is case sensitive, the reality is that we can find container configuration files where fields can be presented with arbitrary capitalization.

Use strncasecmp() instead of strncmp() to do a case-insensitive check when looking for fields in the JSON config file.

Signed-off-by: Sergio Lopez <slp@redhat.com>