### PR TITLE
Introduce the krun_set_data_disk API.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.4.10"
+version = "1.5.0"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.4.10
+FULL_VERSION=1.5.0
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/examples/launch-tee.c
+++ b/examples/launch-tee.c
@@ -38,9 +38,9 @@ int main(int argc, char *const argv[])
     int err;
     int i;
 
-    if (argc != 3) {
+    if (argc < 3 || argc > 4) {
         printf("Invalid arguments\n");
-        printf("Usage: %s DISK_IMAGE TEE_CONFIG_FILE\n", argv[0]);
+        printf("Usage: %s ROOT_DISK_IMAGE TEE_CONFIG_FILE [DATA_DISK_IMAGE]\n", argv[0]);
         return -1;
     }
 
@@ -72,6 +72,15 @@ int main(int argc, char *const argv[])
         errno = -err;
         perror("Error configuring root disk image");
         return -1;
+    }
+
+    // Use the third (optional) command line argument as the disk image containing a data disk.
+    if (argc > 3) {
+        if (err = krun_set_data_disk(ctx_id, argv[3])) {
+            errno = -err;
+            perror("Error configuring data disk image");
+            return -1;
+        }
     }
 
     if (getcwd(&current_path[0], MAX_PATH) == NULL) {

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -76,6 +76,20 @@ int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
 int32_t krun_set_root_disk(uint32_t ctx_id, const char *disk_path);
 
 /*
+ * Sets the path to the disk image that contains the file-system to be used as a data partition for the microVM.
+ * The only supported image format is "raw". Only available in libkrun-SEV.
+ *
+ * Arguments:
+ *  "ctx_id"    - the configuration context ID.
+ *  "disk_path" - a null-terminated string representing the path leading to the disk image that
+ *                contains the root file-system.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_data_disk(uint32_t ctx_id, const char *disk_path);
+
+/*
  * Configures the mapped volumes for the microVM. Only supported on macOS, on Linux use
  * user_namespaces and bind-mounts instead. Not available in libkrun-SEV.
  *

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.4.10"
+version = "1.5.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -229,7 +229,7 @@ impl VmResources {
     }
 
     #[cfg(feature = "tee")]
-    pub fn set_block_device(&mut self, config: BlockDeviceConfig) -> Result<BlockConfigError> {
+    pub fn add_block_device(&mut self, config: BlockDeviceConfig) -> Result<BlockConfigError> {
         self.block.insert(config)
     }
 


### PR DESCRIPTION
This API adds the possibility to introduce a second block device, to a TEE.

It is assumed that the root disk contains a symmetric key (secret), and code to encrypt/decrypt the data disk before use. The recommended setup is to included cryptsetup on the root disk and use that to safely access the data disk.
