### PR TITLE
init: Fix parsing of Env in JSON

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -411,22 +411,26 @@ static int config_parse_file(char ***argv, char **workdir)
 	parsed_env = parsed_workdir = parsed_args = parsed_entrypoint = 0;
 
 	for (i = 1; i < num_tokens && (!parsed_env || !parsed_args || !parsed_workdir); i++) {
-		if (!parsed_env && jsoneq(data, &tokens[i], "Env") == 0) {
+		if (!parsed_env && jsoneq(data, &tokens[i], "Env") == 0 &&
+			(i + 1) < num_tokens && tokens[i + 1].type == JSMN_ARRAY) {
 			config_parse_env(data, &tokens[i + 1]);
 			parsed_env = 1;
 		}
 
-		if (!parsed_args && jsoneq(data, &tokens[i], "Cmd") == 0) {
+		if (!parsed_args && jsoneq(data, &tokens[i], "Cmd") == 0 &&
+			(i + 1) < num_tokens) {
 			config_argv = config_parse_args(data, &tokens[i + 1]);
 			parsed_args = 1;
 		}
 
-		if (!parsed_workdir && jsoneq(data, &tokens[i], "WorkingDir") == 0) {
+		if (!parsed_workdir && jsoneq(data, &tokens[i], "WorkingDir") == 0 &&
+			(i + 1) < num_tokens) {
 			*workdir = config_parse_string(data, &tokens[i + 1]);
 			parsed_workdir = 1;
 		}
 
-		if (!parsed_entrypoint && jsoneq(data, &tokens[i], "Entrypoint") == 0) {
+		if (!parsed_entrypoint && jsoneq(data, &tokens[i], "Entrypoint") == 0 &&
+			(i + 1) < num_tokens) {
 			entrypoint = config_parse_args(data, &tokens[i + 1]);
 			parsed_workdir = 1;
 		}


### PR DESCRIPTION
As the jsmn library doesn't differentiate between tokens that are keys and tokens that are values, if there's a value "env" in an arbitrary key, the parsing code in init.c will get confused and think that's the key containing the array of environment variables.

By ensuring the next token is a JSMN_ARRAY we can minimize the risk of this occurrence. If this still proves to be a problem, we might find the need to switch to a more complete JSON parsing library.

Fixes: #104
Signed-off-by: Sergio Lopez <slp@redhat.com>