### PR TITLE
Bump version to v1.4.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.4.9"
+version = "1.4.10"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.4.9
+FULL_VERSION=1.4.10
 
 ifeq ($(SEV),1)
     VARIANT = -sev

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.4.9"
+version = "1.4.10"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
This release includes a fix for JSON config parsing and makes us compatible with kvm-bindings v0.12.0, bump release number to v1.4.10

Signed-off-by: Sergio Lopez <slp@redhat.com>