### PR TITLE
Add a pkgconf file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ target
 __pycache__
 *.pyc
 *~
+/libkrun.pc
 init/init
 examples/chroot_vm

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ endif
 
 .PHONY: install clean
 
-all: $(LIBRARY_RELEASE_$(OS))
+all: $(LIBRARY_RELEASE_$(OS)) libkrun.pc
 
-debug: $(LIBRARY_DEBUG_$(OS))
+debug: $(LIBRARY_DEBUG_$(OS)) libkrun.pc
 
 $(INIT_BINARY): init/init.c
 	gcc -O2 -static -Wall $(INIT_DEFS) -o $@ init/init.c
@@ -67,10 +67,22 @@ else
 	cp target/debug/$(KRUN_BASE_$(OS)) $(LIBRARY_DEBUG_$(OS))
 endif
 
+libkrun.pc: libkrun.pc.in Makefile
+	rm -f $@ $@-t
+	sed -e 's|@prefix@|$(PREFIX)|' \
+	    -e 's|@libdir@|$(PREFIX)/$(LIBDIR_$(OS))|' \
+	    -e 's|@includedir@|$(PREFIX)/include|' \
+	    -e 's|@PACKAGE_NAME@|libkrun|' \
+	    -e 's|@PACKAGE_VERSION@|$(FULL_VERSION)|' \
+	    libkrun.pc.in > $@-t
+	mv $@-t $@
+
 install:
 	install -d $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/
+	install -d $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/pkgconfig
 	install -d $(DESTDIR)$(PREFIX)/include
 	install -m 644 $(LIBRARY_HEADER) $(DESTDIR)$(PREFIX)/include
+	install -m 644 libkrun.pc $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/pkgconfig
 	install -m 755 $(LIBRARY_RELEASE_$(OS)) $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/
 	cd $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/ ; ln -sf $(KRUN_BINARY_$(OS)) $(KRUN_SONAME_$(OS)) ; ln -sf $(KRUN_SONAME_$(OS)) $(KRUN_BASE_$(OS))
 

--- a/libkrun.pc.in
+++ b/libkrun.pc.in
@@ -1,0 +1,24 @@
+# Copyright (C) 2023 Red Hat Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+prefix=@prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: @PACKAGE_NAME@
+Version: @PACKAGE_VERSION@
+Description: Library providing Virtualization-based process isolation
+Requires:
+Cflags:
+Libs: -lkrun


### PR DESCRIPTION
This allows easy detection of the package through many common build systems.  For example from autotools you might use:

```
  PKG_CHECK_MODULES([LIBKRUN], [libkrun >= 1.5.0])
```

to define `$(LIBKRUN_CFLAGS)` and `$(LIBKRUN_LIBS)`.