### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each variant generates a dynamic library with a different name (and ```soname```
 
 * virtio-fs
 * virtio-balloon (only free-page reporting)
-* virtior-rng
+* virtio-rng
 
 ### libkrun-sev
 


### PR DESCRIPTION
Fix typo `virtior` -> `virtio`