### PR TITLE
Read TEE config from the end of the block device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,15 +16,15 @@ SNP_INIT_SRC =	init/tee/snp_attest.c		\
 SEV_LD_FLAGS =	-lcurl -lidn2 -lssl -lcrypto -lzstd -lz -lbrotlidec-static \
 		-lbrotlicommon-static
 
+INIT_DEFS =
 ifeq ($(SEV),1)
     VARIANT = -sev
     FEATURE_FLAGS := --features amd-sev
-    INIT_DEFS := -DSEV=1
+    INIT_DEFS += -DSEV=1
     INIT_DEFS += $(SEV_LD_FLAGS)
     INIT_SRC += $(SNP_INIT_SRC)
 endif
 
-INIT_DEFS =
 ifeq ($(ROSETTA),1)
     INIT_DEFS += -D__ROSETTA__
 endif


### PR DESCRIPTION
Read the TEE config file from the end of "/dev/vda" to avoid the need of an additional block device.

This is the complement to https://github.com/virtee/oci2cw/commit/1502d5be33c2fa82d49aaa95781bbab2aa932781