### PR TITLE
Fix build error on missing uuid headers

### DIFF
--- a/build_on_krunvm.sh
+++ b/build_on_krunvm.sh
@@ -17,7 +17,7 @@ if [ $? != 0 ]; then
 	exit -1
 fi
 
-krunvm start libkrun-builder /usr/bin/dnf -- install -y glibc-static gcc make
+krunvm start libkrun-builder /usr/bin/dnf -- install -y glibc-static gcc make libuuid-devel
 if [ $? != 0 ]; then
     krunvm delete libkrun-builder
 	echo "Error running command on VM"


### PR DESCRIPTION
build_on_krunvm.sh was failing with an error of a missing header in the linux vm.

```
gcc -O2 -static -Wall -D__ROSETTA__ -o init/init init/init.c -D__ROSETTA__
In file included from init/init.c:26:
init/tee/snp_attest.h:8:10: fatal error: uuid/uuid.h: No such file or directory
    8 | #include <uuid/uuid.h>
      |          ^~~~~~~~~~~~~
compilation terminated.
make: *** [Makefile:64: init/init] Error 1
There was a problem building init/init in the VM
```