### PR TITLE
Prepare to support libkrunfw 4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libkrun"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "devices",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 INIT_BINARY = init/init
 
 ABI_VERSION=1
-FULL_VERSION=1.5.1
+FULL_VERSION=1.6.0
 
 INIT_SRC = init/init.c
 SNP_INIT_SRC =	init/tee/snp_attest.c		\

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -30,7 +30,7 @@ mod defs {
     pub const VSOCK_DEV_ID: &str = "vsock";
 
     /// Number of virtio queues.
-    pub const NUM_QUEUES: usize = 5;
+    pub const NUM_QUEUES: usize = 3;
     /// Virtio queue sizes, in number of descriptor chain heads.
     /// There are 3 queues for a virtio device (in this order): RX, TX, Event
     pub const QUEUE_SIZES: &[u16] = &[256; NUM_QUEUES];
@@ -69,7 +69,7 @@ mod defs {
         /// The device conforms to the virtio spec version 1.0.
         pub const VIRTIO_F_VERSION_1: u32 = 32;
         /// The device supports DGRAM.
-        pub const VIRTIO_VSOCK_F_DGRAM: u32 = 0;
+        pub const VIRTIO_VSOCK_F_DGRAM: u32 = 3;
 
         /// Virtio vsock device ID.
         /// Defined in `include/uapi/linux/virtio_ids.h`.

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.5.1"
+version = "1.6.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -471,7 +471,7 @@ pub fn build_microvm(
     let intc = Some(Arc::new(Mutex::new(devices::legacy::Gic::new())));
 
     #[cfg(all(target_os = "linux", target_arch = "x86_64", not(feature = "tee")))]
-    let boot_ip: GuestAddress = GuestAddress(kernel_bundle.guest_addr);
+    let boot_ip: GuestAddress = GuestAddress(kernel_bundle.entry_addr);
     #[cfg(feature = "tee")]
     let boot_ip: GuestAddress = GuestAddress(arch::RESET_VECTOR);
 

--- a/src/vmm/src/vmm_config/kernel_bundle.rs
+++ b/src/vmm/src/vmm_config/kernel_bundle.rs
@@ -8,6 +8,7 @@ use std::fmt::{Display, Formatter, Result};
 pub struct KernelBundle {
     pub host_addr: u64,
     pub guest_addr: u64,
+    pub entry_addr: u64,
     pub size: usize,
 }
 


### PR DESCRIPTION
 This PR sets up the stage to support libkrunfw 4.x, which bundles a 6.4.x kernel. This is a significant update for two reasons:

- Kernel load and entry addresses no longer match, so we need to treat them independently, meaning we needed to break the API/ABI of libkrunfw.
- We've switched to a new patch series implementing datagram support for vsock, which seems very close to be accepted. This allows us to keep TSI around indefinitely, but means we needed to revamp out vsock device implementation around the semantics of this patch set.