### PR TITLE
init: Report an error when execution of the user binary fails

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -848,7 +848,10 @@ int main(int argc, char **argv)
 	}
 #endif
 
-	execvp(exec_argv[0], exec_argv);
+	if (execvp(exec_argv[0], exec_argv) < 0) {
+		printf("Couldn't execute '%s' inside the vm: %s\n", exec_argv[0], strerror(errno));
+		exit(-3);
+	}
 
 	return 0;
 }


### PR DESCRIPTION
Previously running a non existing binary would just silently fail, now it reports an error.

Not sure about the exit code, but there are two previous exit calls, with values -1 and -2, so I just put -3 here.
