### PR TITLE
virtio net bugfixes and performance improvement

### DIFF
--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -172,7 +172,12 @@ impl Net {
             .passt
             .try_finish_write(vnet_hdr_len(), &self.tx_frame_buf[..self.tx_frame_len])
         {
-            Ok(()) | Err(passt::WriteError::PartialWrite | passt::WriteError::NothingWritten) => (),
+            Ok(()) => {
+                if let Err(e) = self.process_tx() {
+                    log::error!("Failed to continue processing tx after passt socket was writable again: {e:?}");
+                }
+            }
+            Err(passt::WriteError::PartialWrite | passt::WriteError::NothingWritten) => {}
             Err(e @ passt::WriteError::Internal(_)) => {
                 log::error!("Failed to finish write: {e:?}");
             }

--- a/src/devices/src/virtio/net/passt.rs
+++ b/src/devices/src/virtio/net/passt.rs
@@ -168,7 +168,7 @@ impl Passt {
         while bytes_send < buf.len() {
             match send(
                 self.fd,
-                buf,
+                &buf[bytes_send..],
                 MsgFlags::MSG_DONTWAIT | MsgFlags::MSG_NOSIGNAL,
             ) {
                 Ok(size) => bytes_send += size,

--- a/src/devices/src/virtio/net/passt.rs
+++ b/src/devices/src/virtio/net/passt.rs
@@ -1,4 +1,4 @@
-use nix::sys::socket::{recv, send, setsockopt, sockopt, MsgFlags};
+use nix::sys::socket::{getsockopt, recv, send, setsockopt, sockopt, MsgFlags};
 use std::os::fd::{AsRawFd, RawFd};
 use vm_memory::VolatileMemory;
 
@@ -40,6 +40,12 @@ impl Passt {
         if let Err(e) = setsockopt(passt_fd, sockopt::SndBuf, &(16 * 1024 * 1024)) {
             log::warn!("Failed to increase SO_SNDBUF (performance may be decreased): {e}");
         }
+
+        log::debug!(
+            "passt socket (fd {passt_fd}) buffer sizes: SndBuf={:?} RcvBuf={:?}",
+            getsockopt(passt_fd, sockopt::SndBuf),
+            getsockopt(passt_fd, sockopt::RcvBuf)
+        );
 
         Self {
             fd: passt_fd,

--- a/src/devices/src/virtio/net/passt.rs
+++ b/src/devices/src/virtio/net/passt.rs
@@ -48,7 +48,7 @@ impl Passt {
         }
     }
 
-    /// Try to read a frame from passt. If no bytes are available reports PasstError::WouldBlock
+    /// Try to read a frame from passt. If no bytes are available reports ReadError::NothingRead
     pub fn read_frame(&mut self, buf: &mut [u8]) -> Result<usize, ReadError> {
         if self.expecting_frame_length == 0 {
             self.expecting_frame_length = {
@@ -122,7 +122,6 @@ impl Passt {
     }
 
     /// Try to read until filling the whole slice.
-    /// May return WouldBlock only if the first read fails
     fn read_loop(&self, buf: &mut [u8], block_until_has_data: bool) -> Result<(), ReadError> {
         let mut bytes_read = 0;
 

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -48,7 +48,7 @@ impl NetBuilder {
     /// Creates an empty list of Network Devices.
     pub fn new() -> Self {
         NetBuilder {
-            /// List of built network devices.
+            // List of built network devices.
             net_devices: Vec::new(),
         }
     }


### PR DESCRIPTION
Since bug https://bugs.passt.top/show_bug.cgi?id=74 is now fixed in passt, it now became possible to test with small socket buffers, doing so revealed some bugs and a performance issue on the libkrun side.

If you want to test this, please use passt  0^20231004.gf851084, because of the aforementioned bug.

Note that there is now a performance issue where increasing the socket buffer sizes to the previously recommended 16Mib decreases performance. The performance of libkrun with small socket buffers is better than QEMU+passt, with bigger buffer sizes they are both kind of slow. Curiously limiting iperf3 speed (using -b) increases the performance. This seems to be another passt issue.