### PR TITLE
Make krun_start_enter error when root directory does not exist

### DIFF
--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -95,7 +95,7 @@ impl Fs {
             device_state: DeviceState::Inactive,
             config,
             shm_region: None,
-            server: Server::new(PassthroughFs::new(fs_cfg).unwrap()),
+            server: Server::new(PassthroughFs::new(fs_cfg).map_err(FsError::FailedToMount)?),
             intc: None,
             irq_line: None,
         })

--- a/src/devices/src/virtio/fs/mod.rs
+++ b/src/devices/src/virtio/fs/mod.rs
@@ -59,6 +59,8 @@ pub enum FsError {
     InvalidXattrSize((u32, usize)),
     QueueReader(DescriptorError),
     QueueWriter(DescriptorError),
+    /// Could not open the root directory or mapped volumes (they do not exist, permission error...)
+    FailedToMount(io::Error),
 }
 
 type Result<T> = std::result::Result<T, FsError>;

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -770,8 +770,8 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
 
     #[cfg(not(feature = "tee"))]
     if let Some(fs_cfg) = ctx_cfg.get_fs_cfg() {
-        if ctx_cfg.vmr.set_fs_device(fs_cfg).is_err() {
-            error!("Error configuring virtio-fs");
+        if let Err(e) = ctx_cfg.vmr.set_fs_device(fs_cfg) {
+            error!("Error configuring virtio-fs {e:?}");
             return -libc::EINVAL;
         }
     }


### PR DESCRIPTION
Previously krun_start_enter would succeed and the guest kernel would just panic. The root filesystem directory was opened lazily when the guest kernel used fuse init opcode.
This commit changes it so the root directory is opened when creating the fs device.

This only fixes it on Linux, but not in the macOS implementation.