### PR TITLE
Implement `krun_add_vsock_port()` and `UnixProxy` for guest communication with host UNIX sockets.

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -220,6 +220,19 @@ int32_t krun_set_env(uint32_t ctx_id, char *const envp[]);
 int32_t krun_set_tee_config_file(uint32_t ctx_id, const char *filepath);
 
 /*
+ * Adds a port-path pairing for guest IPC with a process in the host.
+ *
+ * Arguments:
+ *  "ctx_id"    - the configuration context ID.
+ *  "port"      - a vsock port that the guest will connect to for IPC.
+ *  "filepath"  - a null-terminated string representing the path of the UNIX
+ *                socket in the host.
+ */
+int32_t krun_add_vsock_port(uint32_t ctx_id,
+                            uint32_t port,
+                            const char *c_filepath);
+
+/*
  * Starts and enters the microVM with the configured parameters. The VMM will attempt to take over
  * stdin/stdout to manage them on behalf of the process running inside the isolated environment,
  * simulating that the latter has direct control of the terminal.

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -6,6 +6,7 @@
 // found in the THIRD-PARTY file.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -58,6 +59,7 @@ impl Vsock {
         cid: u64,
         host_port_map: Option<HashMap<u16, u16>>,
         queues: Vec<VirtQueue>,
+        unix_ipc_port_map: Option<HashMap<u32, PathBuf>>,
     ) -> super::Result<Vsock> {
         let mut queue_events = Vec::new();
         for _ in 0..queues.len() {
@@ -79,6 +81,7 @@ impl Vsock {
                 host_port_map,
                 interrupt_evt.try_clone().unwrap(),
                 interrupt_status.clone(),
+                unix_ipc_port_map,
             ),
             queue_rx,
             queue_tx,
@@ -97,12 +100,16 @@ impl Vsock {
     }
 
     /// Create a new virtio-vsock device with the given VM CID.
-    pub fn new(cid: u64, host_port_map: Option<HashMap<u16, u16>>) -> super::Result<Vsock> {
+    pub fn new(
+        cid: u64,
+        host_port_map: Option<HashMap<u16, u16>>,
+        unix_ipc_port_map: Option<HashMap<u32, PathBuf>>,
+    ) -> super::Result<Vsock> {
         let queues: Vec<VirtQueue> = defs::QUEUE_SIZES
             .iter()
             .map(|&max_size| VirtQueue::new(max_size))
             .collect();
-        Self::with_queues(cid, host_port_map, queues)
+        Self::with_queues(cid, host_port_map, queues, unix_ipc_port_map)
     }
 
     pub fn id(&self) -> &str {

--- a/src/devices/src/virtio/vsock/mod.rs
+++ b/src/devices/src/virtio/vsock/mod.rs
@@ -18,6 +18,7 @@ mod tcp;
 #[cfg(target_os = "macos")]
 mod timesync;
 mod udp;
+mod unix;
 
 pub use self::defs::uapi::VIRTIO_ID_VSOCK as TYPE_VSOCK;
 pub use self::device::Vsock;

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -518,9 +518,10 @@ impl VsockMuxer {
                     addr: Ipv4Addr::new(0, 0, 0, 0),
                     port: 0,
                 };
-                unix.connect(pkt, tsi);
+                let update = unix.connect(pkt, tsi);
                 unix.confirm_connect(pkt);
                 proxy_map.insert(id, Mutex::new(Box::new(unix)));
+                self.process_proxy_update(id, update);
             }
         }
     }

--- a/src/devices/src/virtio/vsock/unix.rs
+++ b/src/devices/src/virtio/vsock/unix.rs
@@ -1,0 +1,331 @@
+use super::defs;
+
+use std::collections::HashMap;
+use std::num::Wrapping;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use nix::fcntl::{fcntl, FcntlArg, OFlag};
+use nix::sys::socket::{
+    connect, send, setsockopt, socket, sockopt, AddressFamily, MsgFlags, SockFlag, SockType,
+    UnixAddr,
+};
+use nix::unistd::close;
+
+#[cfg(target_os = "macos")]
+use super::super::linux_errno::linux_errno_raw;
+use super::super::Queue as VirtQueue;
+use super::muxer::{push_packet, MuxerRx};
+use super::muxer_rxq::MuxerRxQ;
+use super::packet::{TsiAcceptReq, TsiConnectReq, TsiListenReq, TsiSendtoAddr, VsockPacket};
+use super::proxy::{Proxy, ProxyError, ProxyStatus, ProxyUpdate};
+use utils::epoll::EventSet;
+
+use vm_memory::GuestMemoryMmap;
+
+pub struct UnixProxy {
+    id: u64,
+    cid: u64,
+    fd: RawFd,
+    pub status: ProxyStatus,
+    mem: GuestMemoryMmap,
+    queue: Arc<Mutex<VirtQueue>>,
+    rxq: Arc<Mutex<MuxerRxQ>>,
+    path: PathBuf,
+    peer_port: u32,
+    local_port: u32,
+    control_port: u32,
+    peer_fwd_cnt: Wrapping<u32>,
+    peer_buf_alloc: u32,
+    tx_cnt: Wrapping<u32>,
+    last_tx_cnt_sent: Wrapping<u32>,
+}
+
+impl UnixProxy {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: u64,
+        cid: u64,
+        local_port: u32,
+        control_port: u32,
+        mem: GuestMemoryMmap,
+        queue: Arc<Mutex<VirtQueue>>,
+        rxq: Arc<Mutex<MuxerRxQ>>,
+        path: PathBuf,
+    ) -> Result<Self, ProxyError> {
+        let fd = socket(
+            AddressFamily::Unix,
+            SockType::Stream,
+            SockFlag::empty(),
+            None,
+        )
+        .map_err(ProxyError::CreatingSocket)?;
+
+        // macOS forces us to do this here instead of just using SockFlag::SOCK_NONBLOCK above.
+        match fcntl(fd, FcntlArg::F_GETFL) {
+            Ok(flags) => match OFlag::from_bits(flags) {
+                Some(flags) => {
+                    if let Err(e) = fcntl(fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK)) {
+                        warn!("error switching to non-blocking: id={}, err={}", id, e);
+                    }
+                }
+                None => error!("invalid fd flags id={}", id),
+            },
+            Err(e) => error!("couldn't obtain fd flags id={}, err={}", id, e),
+        };
+
+        setsockopt(fd, sockopt::ReusePort, &true).map_err(ProxyError::SettingReusePort)?;
+        #[cfg(target_os = "macos")]
+        {
+            // nix doesn't provide an abstraction for SO_NOSIGPIPE, fall back to libc.
+            let option_value: libc::c_int = 1;
+            unsafe {
+                libc::setsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    libc::SO_NOSIGPIPE,
+                    &option_value as *const _ as *const libc::c_void,
+                    std::mem::size_of_val(&option_value) as libc::socklen_t,
+                )
+            };
+        }
+
+        Ok(UnixProxy {
+            id,
+            cid,
+            local_port,
+            peer_port: 0,
+            control_port,
+            fd,
+            status: ProxyStatus::Idle,
+            mem,
+            queue,
+            rxq,
+            peer_buf_alloc: 0,
+            peer_fwd_cnt: Wrapping(0),
+            path,
+            tx_cnt: Wrapping(0),
+            last_tx_cnt_sent: Wrapping(0),
+        })
+    }
+
+    fn switch_to_connected(&mut self) {
+        self.status = ProxyStatus::Connected;
+        match fcntl(self.fd, FcntlArg::F_GETFL) {
+            Ok(flags) => match OFlag::from_bits(flags) {
+                Some(flags) => {
+                    if let Err(e) = fcntl(self.fd, FcntlArg::F_SETFL(flags & !OFlag::O_NONBLOCK)) {
+                        warn!("error switching to blocking: id={}, err={}", self.id, e);
+                    }
+                }
+                None => error!("invalid fd flags id={}", self.id),
+            },
+            Err(e) => error!("couldn't obtain fd flags id={}, err={}", self.id, e),
+        };
+    }
+
+    fn push_connect_rsp(&self, result: i32) {
+        debug!(
+            "push_connect_rsp: id: {}, control_port: {}, result: {}",
+            self.id, self.control_port, result
+        );
+
+        // This response goes to the control port (DGRAM).
+        let rx = MuxerRx::ConnResponse {
+            local_port: 1025,
+            peer_port: self.control_port,
+            result,
+        };
+        push_packet(self.cid, rx, &self.rxq, &self.queue, &self.mem);
+    }
+}
+
+impl Proxy for UnixProxy {
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn status(&self) -> ProxyStatus {
+        self.status
+    }
+
+    fn connect(&mut self, _pkt: &VsockPacket, _req: TsiConnectReq) -> ProxyUpdate {
+        let mut update = ProxyUpdate::default();
+
+        let addr = UnixAddr::new(&self.path).unwrap();
+
+        let result = match connect(self.fd, &addr) {
+            Ok(()) => {
+                debug!("vsock: connect: Connected");
+                self.switch_to_connected();
+                0
+            }
+            Err(nix::errno::Errno::EINPROGRESS) => {
+                debug!("vsock: connect: Connecting");
+                self.status = ProxyStatus::Connecting;
+                0
+            }
+            Err(e) => {
+                debug!("vsock: UnixProxy: Error connecting: {}", e);
+                #[cfg(target_os = "macos")]
+                let errno = -linux_errno_raw(nix::errno::errno());
+                #[cfg(target_os = "linux")]
+                let errno = -nix::errno::errno();
+                errno
+            }
+        };
+
+        if self.status == ProxyStatus::Connecting {
+            update.polling = Some((self.id, self.fd, EventSet::IN | EventSet::OUT));
+        } else {
+            if self.status == ProxyStatus::Connected {
+                update.polling = Some((self.id, self.fd, EventSet::IN));
+            }
+            self.push_connect_rsp(result);
+        }
+
+        update
+    }
+
+    fn confirm_connect(&mut self, pkt: &VsockPacket) {
+        debug!(
+            "tcp: confirm_connect: local_port={} peer_port={}, src_port={}, dst_port={}",
+            pkt.dst_port(),
+            pkt.src_port(),
+            self.local_port,
+            self.peer_port,
+        );
+
+        self.peer_buf_alloc = pkt.buf_alloc();
+        self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
+
+        self.local_port = pkt.dst_port();
+        self.peer_port = pkt.src_port();
+
+        // This response goes to the connection.
+        let rx = MuxerRx::OpResponse {
+            local_port: pkt.dst_port(),
+            peer_port: pkt.src_port(),
+        };
+        push_packet(self.cid, rx, &self.rxq, &self.queue, &self.mem);
+    }
+
+    fn getpeername(&mut self, _pkt: &VsockPacket) {
+        todo!();
+    }
+
+    fn sendmsg(&mut self, pkt: &VsockPacket) -> ProxyUpdate {
+        let mut update = ProxyUpdate::default();
+
+        let ret = if let Some(buf) = pkt.buf() {
+            #[cfg(target_os = "macos")]
+            let flags = MsgFlags::empty();
+
+            #[cfg(target_os = "linux")]
+            let flags = MsgFlags::MSG_NOSIGNAL;
+
+            match send(self.fd, buf, flags) {
+                Ok(sent) => {
+                    if sent != buf.len() {
+                        error!("couldn't set everything: buf={}, sent={}", buf.len(), sent);
+                    }
+                    self.tx_cnt += Wrapping(sent as u32);
+                    sent as i32
+                }
+                Err(err) => {
+                    #[cfg(target_os = "macos")]
+                    let errno = -linux_errno_raw(err as i32);
+
+                    #[cfg(target_os = "linux")]
+                    let errno = -(err as i32);
+                    errno
+                }
+            }
+        } else {
+            -libc::EINVAL
+        };
+
+        if ret > 0
+            && (self.tx_cnt - self.last_tx_cnt_sent).0 as usize >= (defs::CONN_TX_BUF_SIZE / 2)
+        {
+            debug!(
+                "sending credit update: id={}, tx_cnt={}, last_tx_cnt={}",
+                self.id, self.tx_cnt, self.last_tx_cnt_sent
+            );
+            self.last_tx_cnt_sent = self.tx_cnt;
+
+            let rx = MuxerRx::CreditUpdate {
+                local_port: pkt.dst_port(),
+                peer_port: pkt.src_port(),
+                fwd_cnt: self.tx_cnt.0,
+            };
+
+            push_packet(self.cid, rx, &self.rxq, &self.queue, &self.mem);
+            update.signal_queue = true;
+        }
+
+        debug!("vsock: tcp_proxy: sendmsg ret={}", ret);
+
+        update
+    }
+
+    fn sendto_addr(&mut self, _req: TsiSendtoAddr) -> ProxyUpdate {
+        todo!();
+    }
+
+    fn listen(
+        &mut self,
+        _pkt: &VsockPacket,
+        _req: TsiListenReq,
+        _host_port_map: &Option<HashMap<u16, u16>>,
+    ) -> ProxyUpdate {
+        todo!();
+    }
+
+    fn accept(&mut self, _req: TsiAcceptReq) -> ProxyUpdate {
+        todo!();
+    }
+
+    fn update_peer_credit(&mut self, _pkt: &VsockPacket) -> ProxyUpdate {
+        todo!();
+    }
+
+    fn push_op_request(&self) {
+        todo!();
+    }
+
+    fn process_op_response(&mut self, _pkt: &VsockPacket) -> ProxyUpdate {
+        todo!();
+    }
+
+    fn enqueue_accept(&mut self) {
+        todo!();
+    }
+
+    fn shutdown(&mut self, _pkt: &VsockPacket) {
+        todo!();
+    }
+
+    fn release(&mut self) -> ProxyUpdate {
+        todo!();
+    }
+
+    fn process_event(&mut self, _evset: EventSet) -> ProxyUpdate {
+        todo!();
+    }
+}
+
+impl AsRawFd for UnixProxy {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
+    }
+}
+
+impl Drop for UnixProxy {
+    fn drop(&mut self) {
+        if let Err(e) = close(self.fd) {
+            warn!("error closing proxy fd: {}", e);
+        }
+    }
+}

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -12,7 +12,6 @@ use std::ffi::CString;
 use std::os::fd::RawFd;
 #[cfg(not(feature = "tee"))]
 use std::path::Path;
-#[cfg(feature = "tee")]
 use std::path::PathBuf;
 use std::slice;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -88,6 +87,7 @@ struct ContextConfig {
     data_block_cfg: Option<BlockDeviceConfig>,
     #[cfg(feature = "tee")]
     tee_config_file: Option<PathBuf>,
+    unix_ipc_port_map: Option<HashMap<u32, PathBuf>>,
 }
 
 impl ContextConfig {
@@ -200,6 +200,16 @@ impl ContextConfig {
     #[cfg(feature = "tee")]
     fn get_tee_config_file(&self) -> Option<PathBuf> {
         self.tee_config_file.clone()
+    }
+
+    fn add_vsock_port(&mut self, port: u32, filepath: PathBuf) {
+        if let Some(ref mut map) = &mut self.unix_ipc_port_map {
+            map.insert(port, filepath);
+        } else {
+            let mut map: HashMap<u32, PathBuf> = HashMap::new();
+            map.insert(port, filepath);
+            self.unix_ipc_port_map = Some(map);
+        }
     }
 }
 
@@ -746,6 +756,30 @@ pub unsafe extern "C" fn krun_set_tee_config_file(ctx_id: u32, c_filepath: *cons
     KRUN_SUCCESS
 }
 
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_add_vsock_port(
+    ctx_id: u32,
+    port: u32,
+    c_filepath: *const c_char,
+) -> i32 {
+    let filepath = match CStr::from_ptr(c_filepath).to_str() {
+        Ok(f) => f,
+        Err(_) => return -libc::EINVAL,
+    };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+            cfg.add_vsock_port(port, PathBuf::from(filepath.to_string()));
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[allow(unused_assignments)]
 #[no_mangle]
 pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     #[cfg(target_os = "linux")]
@@ -828,14 +862,23 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         return -libc::EINVAL;
     }
 
+    let mut vsock_set = false;
+    let mut vsock_config = VsockDeviceConfig {
+        vsock_id: "vsock0".to_string(),
+        guest_cid: 3,
+        host_port_map: None,
+        unix_ipc_port_map: None,
+    };
+
+    if let Some(map) = ctx_cfg.unix_ipc_port_map {
+        vsock_config.unix_ipc_port_map = Some(map);
+        vsock_set = true;
+    }
+
     match ctx_cfg.net_cfg {
         NetworkConfig::Tsi(tsi_cfg) => {
-            let vsock_device_config = VsockDeviceConfig {
-                vsock_id: "vsock0".to_string(),
-                guest_cid: 3,
-                host_port_map: tsi_cfg.port_map,
-            };
-            ctx_cfg.vmr.set_vsock_device(vsock_device_config).unwrap();
+            vsock_config.host_port_map = tsi_cfg.port_map;
+            vsock_set = true;
         }
         #[cfg(feature = "net")]
         NetworkConfig::Passt(passt_cfg) => {
@@ -848,6 +891,10 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
                 .add_network_interface(network_interface_config)
                 .expect("Failed to create network interface");
         }
+    }
+
+    if vsock_set {
+        ctx_cfg.vmr.set_vsock_device(vsock_config).unwrap();
     }
 
     let _vmm = match vmm::builder::build_microvm(&ctx_cfg.vmr, &mut event_manager) {

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::fmt;
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use devices::virtio::{Vsock, VsockError};
@@ -37,6 +38,8 @@ pub struct VsockDeviceConfig {
     pub guest_cid: u32,
     /// An optional map of host to guest port mappings.
     pub host_port_map: Option<HashMap<u16, u16>>,
+    /// An optional map of guest port to host UNIX domain sockets for IPC.
+    pub unix_ipc_port_map: Option<HashMap<u32, PathBuf>>,
 }
 
 struct VsockWrapper {
@@ -71,8 +74,12 @@ impl VsockBuilder {
 
     /// Creates a Vsock device from a VsockDeviceConfig.
     pub fn create_vsock(cfg: VsockDeviceConfig) -> Result<Vsock> {
-        Vsock::new(u64::from(cfg.guest_cid), cfg.host_port_map)
-            .map_err(VsockConfigError::CreateVsockDevice)
+        Vsock::new(
+            u64::from(cfg.guest_cid),
+            cfg.host_port_map,
+            cfg.unix_ipc_port_map,
+        )
+        .map_err(VsockConfigError::CreateVsockDevice)
     }
 }
 
@@ -107,6 +114,7 @@ pub(crate) mod tests {
             vsock_id: vsock_dev_id.to_string(),
             guest_cid: 3,
             host_port_map: None,
+            unix_ipc_port_map: None,
         }
     }
 


### PR DESCRIPTION
This PR introduces two main components:

1) `krun_add_vsock_port()`, which allows a user to map guest vsock port numbers to UNIX IPC sockets running on the host. With this, users can enable VM guest IPC with UNIX sockets running on a host.

2) `vsock::unix` module, implementing the `UnixProxy`, a vsock proxy that facilitates the communication between a guest vsock and UNIX IPC socket running on the host.