### PR TITLE
devices/net: allow configuring a custom MAC

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -121,6 +121,18 @@ int32_t krun_set_mapped_volumes(uint32_t ctx_id, char *const mapped_volumes[]);
 int32_t krun_set_passt_fd(uint32_t ctx_id, int fd);
 
 /*
+ * Sets the MAC address for the virtio-net device when using the passt backend.
+ *
+ * Arguments:
+ *  "ctx_id"         - the configuration context ID.
+ *  "mac"            - MAC address as an array of 6 uint8_t entries.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_net_mac(uint32_t ctx_id, uint8_t *const c_mac);
+
+/*
  * Configures a map of host to guest TCP ports for the microVM.
  *
  * Arguments:

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -15,6 +15,8 @@ pub struct NetworkInterfaceConfig {
     pub iface_id: String,
     /// File descriptor of passt socket to connect this interface to
     pub passt_fd: RawFd,
+    /// MAC address.
+    pub mac: [u8; 6],
 }
 
 /// Errors associated with `NetworkInterfaceConfig`.
@@ -85,6 +87,7 @@ impl NetBuilder {
     /// Creates a Net device from a NetworkInterfaceConfig.
     pub fn create_net(cfg: NetworkInterfaceConfig) -> Result<Net> {
         // Create and return the Net device
-        Net::new(cfg.iface_id, cfg.passt_fd).map_err(NetworkInterfaceError::CreateNetworkDevice)
+        Net::new(cfg.iface_id, cfg.passt_fd, cfg.mac)
+            .map_err(NetworkInterfaceError::CreateNetworkDevice)
     }
 }


### PR DESCRIPTION
Extend the API to allow users to set a custom MAC for the virtio-net device.