### PR TITLE
virtio/net: implement gvproxy backend

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -136,6 +136,24 @@ int32_t krun_add_virtiofs(uint32_t ctx_id,
 int32_t krun_set_passt_fd(uint32_t ctx_id, int fd);
 
 /*
+ * Configures the networking to use gvproxy in vfkit mode.
+ * Call to this function disables TSI backend to use gvproxy instead.
+ *
+ * Arguments:
+ *  "ctx_id"  - the configuration context ID.
+ *  "c_path"  - a null-terminated string representing the path for
+ *              gvproxy's listen-vfkit unixdgram socket.
+ *
+ * Notes:
+ * If you never call this function, networking uses the TSI backend.
+ * This function should be called before krun_set_port_map.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_gvproxy_path(uint32_t ctx_id, char* c_path);
+
+/*
  * Sets the MAC address for the virtio-net device when using the passt backend.
  *
  * Arguments:

--- a/src/devices/src/virtio/net/backend.rs
+++ b/src/devices/src/virtio/net/backend.rs
@@ -1,0 +1,29 @@
+use std::os::fd::RawFd;
+
+#[derive(Debug)]
+pub enum ReadError {
+    /// Nothing was written
+    NothingRead,
+    /// Another internal error occurred
+    Internal(nix::Error),
+}
+
+#[derive(Debug)]
+pub enum WriteError {
+    /// Nothing was written, you can drop the frame or try to resend it later
+    NothingWritten,
+    /// Part of the buffer was written, the write has to be finished using try_finish_write
+    PartialWrite,
+    /// Passt doesnt seem to be running (received EPIPE)
+    ProcessNotRunning,
+    /// Another internal error occurred
+    Internal(nix::Error),
+}
+
+pub trait NetBackend {
+    fn read_frame(&mut self, buf: &mut [u8]) -> Result<usize, ReadError>;
+    fn write_frame(&mut self, hdr_len: usize, buf: &mut [u8]) -> Result<(), WriteError>;
+    fn has_unfinished_write(&self) -> bool;
+    fn try_finish_write(&mut self, hdr_len: usize, buf: &[u8]) -> Result<(), WriteError>;
+    fn raw_socket_fd(&self) -> RawFd;
+}

--- a/src/devices/src/virtio/net/backend.rs
+++ b/src/devices/src/virtio/net/backend.rs
@@ -1,6 +1,14 @@
 use std::os::fd::RawFd;
 
 #[derive(Debug)]
+pub enum ConnectError {
+    InvalidAddress(nix::Error),
+    CreateSocket(nix::Error),
+    Binding(nix::Error),
+    SendingMagic(nix::Error),
+}
+
+#[derive(Debug)]
 pub enum ReadError {
     /// Nothing was written
     NothingRead,

--- a/src/devices/src/virtio/net/gvproxy.rs
+++ b/src/devices/src/virtio/net/gvproxy.rs
@@ -1,0 +1,136 @@
+use nix::fcntl::{fcntl, FcntlArg, OFlag};
+use nix::sys::socket::{
+    bind, getsockopt, recv, sendto, setsockopt, socket, sockopt, AddressFamily, MsgFlags, SockFlag,
+    SockType, UnixAddr,
+};
+use nix::unistd::unlink;
+use std::os::fd::{AsRawFd, RawFd};
+use std::path::PathBuf;
+
+use super::backend::{ConnectError, NetBackend, ReadError, WriteError};
+
+const VFKIT_MAGIC: [u8; 4] = *b"VFKT";
+
+pub struct Gvproxy {
+    fd: RawFd,
+    peer_addr: UnixAddr,
+}
+
+impl Gvproxy {
+    /// Connect to a running gvproxy instance, given a socket file descriptor
+    pub fn new(path: PathBuf) -> Result<Self, ConnectError> {
+        let fd = socket(
+            AddressFamily::Unix,
+            SockType::Datagram,
+            SockFlag::empty(),
+            None,
+        )
+        .map_err(ConnectError::CreateSocket)?;
+        let peer_addr = UnixAddr::new(&path).map_err(ConnectError::InvalidAddress)?;
+        let local_addr = UnixAddr::new(&PathBuf::from(format!("{}-krun.sock", path.display())))
+            .map_err(ConnectError::InvalidAddress)?;
+        if let Some(path) = local_addr.path() {
+            _ = unlink(path);
+        }
+        bind(fd, &local_addr).map_err(ConnectError::Binding)?;
+
+        sendto(fd, &VFKIT_MAGIC, &peer_addr, MsgFlags::empty())
+            .map_err(ConnectError::SendingMagic)?;
+
+        // macOS forces us to do this here instead of just using SockFlag::SOCK_NONBLOCK above.
+        match fcntl(fd, FcntlArg::F_GETFL) {
+            Ok(flags) => match OFlag::from_bits(flags) {
+                Some(flags) => {
+                    if let Err(e) = fcntl(fd, FcntlArg::F_SETFL(flags | OFlag::O_NONBLOCK)) {
+                        warn!("error switching to non-blocking: id={}, err={}", fd, e);
+                    }
+                }
+                None => error!("invalid fd flags id={}", fd),
+            },
+            Err(e) => error!("couldn't obtain fd flags id={}, err={}", fd, e),
+        };
+
+        setsockopt(fd, sockopt::ReusePort, &true).unwrap();
+        #[cfg(target_os = "macos")]
+        {
+            // nix doesn't provide an abstraction for SO_NOSIGPIPE, fall back to libc.
+            let option_value: libc::c_int = 1;
+            unsafe {
+                libc::setsockopt(
+                    fd,
+                    libc::SOL_SOCKET,
+                    libc::SO_NOSIGPIPE,
+                    &option_value as *const _ as *const libc::c_void,
+                    std::mem::size_of_val(&option_value) as libc::socklen_t,
+                )
+            };
+        }
+
+        if let Err(e) = setsockopt(fd, sockopt::SndBuf, &(4 * 1024 * 1024)) {
+            log::warn!("Failed to increase SO_SNDBUF (performance may be decreased): {e}");
+        }
+        if let Err(e) = setsockopt(fd, sockopt::RcvBuf, &(4 * 1024 * 1024)) {
+            log::warn!("Failed to increase SO_SNDBUF (performance may be decreased): {e}");
+        }
+
+        log::debug!(
+            "passt socket (fd {fd}) buffer sizes: SndBuf={:?} RcvBuf={:?}",
+            getsockopt(fd, sockopt::SndBuf),
+            getsockopt(fd, sockopt::RcvBuf)
+        );
+
+        Ok(Self { fd, peer_addr })
+    }
+}
+
+impl NetBackend for Gvproxy {
+    /// Try to read a frame from passt. If no bytes are available reports ReadError::NothingRead
+    fn read_frame(&mut self, buf: &mut [u8]) -> Result<usize, ReadError> {
+        let frame_length = match recv(self.fd, buf, MsgFlags::empty()) {
+            Ok(f) => f,
+            #[allow(unreachable_patterns)]
+            Err(nix::Error::EAGAIN | nix::Error::EWOULDBLOCK) => {
+                return Err(ReadError::NothingRead)
+            }
+            Err(e) => {
+                return Err(ReadError::Internal(e));
+            }
+        };
+        debug!("Read eth frame from passt: {} bytes", frame_length);
+        Ok(frame_length)
+    }
+
+    /// Try to write a frame to passt.
+    /// (Will mutate and override parts of buf, with a passt header!)
+    ///
+    /// * `hdr_len` - specifies the size of any existing headers encapsulating the ethernet frame,
+    ///               (such as vnet header), that can be overwritten.
+    ///               must be >= PASST_HEADER_LEN
+    /// * `buf` - the buffer to write to passt, `buf[..hdr_len]` may be overwritten
+    ///
+    /// If this function returns WriteError::PartialWrite, you have to finish the write using
+    /// try_finish_write.
+    fn write_frame(&mut self, hdr_len: usize, buf: &mut [u8]) -> Result<(), WriteError> {
+        let ret = sendto(self.fd, &buf[hdr_len..], &self.peer_addr, MsgFlags::empty())
+            .map_err(WriteError::Internal)?;
+        debug!(
+            "Written frame size={}, written={}",
+            buf.len() - hdr_len,
+            ret
+        );
+        Ok(())
+    }
+
+    fn has_unfinished_write(&self) -> bool {
+        false
+    }
+
+    fn try_finish_write(&mut self, _hdr_len: usize, _buf: &[u8]) -> Result<(), WriteError> {
+        // The gvproxy backend doesn't do partial writes.
+        Ok(())
+    }
+
+    fn raw_socket_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -11,6 +11,7 @@ pub const RX_INDEX: usize = 0;
 // The index of the tx queue from Net device queues/queues_evts vector.
 pub const TX_INDEX: usize = 1;
 
+mod backend;
 pub mod device;
 pub mod event_handler;
 mod passt;

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -14,6 +14,7 @@ pub const TX_INDEX: usize = 1;
 mod backend;
 pub mod device;
 pub mod event_handler;
+mod gvproxy;
 mod passt;
 
 pub use self::device::Net;

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -2,20 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;
-use std::os::fd::RawFd;
 use std::result;
 use std::sync::{Arc, Mutex};
 
 use devices::virtio::net::device::VirtioNetBackend;
 use devices::virtio::Net;
 
-#[derive(Debug, PartialEq)]
-//#[serde(deny_unknown_fields)]
 pub struct NetworkInterfaceConfig {
     /// ID of the guest network interface.
     pub iface_id: String,
-    /// File descriptor of passt socket to connect this interface to
-    pub passt_fd: RawFd,
+    /// Backend to transport data to/from the host.
+    pub backend: VirtioNetBackend,
     /// MAC address.
     pub mac: [u8; 6],
 }
@@ -88,7 +85,7 @@ impl NetBuilder {
     /// Creates a Net device from a NetworkInterfaceConfig.
     pub fn create_net(cfg: NetworkInterfaceConfig) -> Result<Net> {
         // Create and return the Net device
-        Net::new(cfg.iface_id, VirtioNetBackend::Passt(cfg.passt_fd), cfg.mac)
+        Net::new(cfg.iface_id, cfg.backend, cfg.mac)
             .map_err(NetworkInterfaceError::CreateNetworkDevice)
     }
 }

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -6,6 +6,7 @@ use std::os::fd::RawFd;
 use std::result;
 use std::sync::{Arc, Mutex};
 
+use devices::virtio::net::device::VirtioNetBackend;
 use devices::virtio::Net;
 
 #[derive(Debug, PartialEq)]
@@ -87,7 +88,7 @@ impl NetBuilder {
     /// Creates a Net device from a NetworkInterfaceConfig.
     pub fn create_net(cfg: NetworkInterfaceConfig) -> Result<Net> {
         // Create and return the Net device
-        Net::new(cfg.iface_id, cfg.passt_fd, cfg.mac)
+        Net::new(cfg.iface_id, VirtioNetBackend::Passt(cfg.passt_fd), cfg.mac)
             .map_err(NetworkInterfaceError::CreateNetworkDevice)
     }
 }


### PR DESCRIPTION
Implement a backend in virtio-net compatible with the "-listen-vfkit" mode in gvproxy. In this mode, the transport operates at L2 without adding any headers, and the UNIX socket between libkrun and gvproxy operates in DGRAM mode.