### PR TITLE
virtio/fs/macos: overhaul to use macos inodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -465,7 +465,7 @@ checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libkrun"
-version = "1.7.2"
+version = "1.8.0"
 dependencies = [
  "crossbeam-channel",
  "devices",

--- a/Makefile
+++ b/Makefile
@@ -36,9 +36,6 @@ ifeq ($(EFI),1)
 	BUILD_INIT = 0
 endif
 
-ifeq ($(ROSETTA),1)
-    INIT_DEFS += -D__ROSETTA__
-endif
 ifeq ($(TIMESYNC),1)
     INIT_DEFS += -D__TIMESYNC__
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LIBRARY_HEADER = include/libkrun.h
 
 ABI_VERSION=1
-FULL_VERSION=1.7.2
+FULL_VERSION=1.8.0
 
 INIT_SRC = init/init.c
 KBS_INIT_SRC =	init/tee/kbs/kbs.h		\

--- a/build_on_krunvm.sh
+++ b/build_on_krunvm.sh
@@ -24,7 +24,7 @@ if [ $? != 0 ]; then
 	exit -1
 fi
 
-krunvm start libkrun-builder /usr/bin/make -- ROSETTA=1 init/init
+krunvm start libkrun-builder /usr/bin/make -- init/init
 if [ $? != 0 ]; then
     krunvm delete libkrun-builder
 	echo "Error running command on VM"

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -90,6 +90,8 @@ int32_t krun_set_root_disk(uint32_t ctx_id, const char *disk_path);
 int32_t krun_set_data_disk(uint32_t ctx_id, const char *disk_path);
 
 /*
+ * NO LONGER SUPPORTED. DO NOT USE.
+ *
  * Configures the mapped volumes for the microVM. Only supported on macOS, on Linux use
  * user_namespaces and bind-mounts instead. Not available in libkrun-SEV.
  *

--- a/init/init.c
+++ b/init/init.c
@@ -676,32 +676,6 @@ cleanup_fd:
 	return ret;
 }
 
-#ifdef __ROSETTA__
-char rosetta_binary[] = "/.rosetta/rosetta\0";
-char binfmt_rosetta[] = ":rosetta:M:0:\\x7fELF\\x02\\x01\\x01\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x02\\x00\\x3e\\x00:\\xff\\xff\\xff\\xff\\xff\\xfe\\xfe\\x00\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xff\\xfe\\xff\\xff\\xff:/.rosetta/rosetta:CF\n";
-
-static void enable_rosetta()
-{
-	int fd;
-
-	if (mount("binfmt_misc", "/proc/sys/fs/binfmt_misc", "binfmt_misc",
-		  MS_NOEXEC | MS_NOSUID | MS_RELATIME, NULL) < 0) {
-		perror("mount(binfmt_misc)");
-		exit(-1);
-	} else {
-		fd = open("/proc/sys/fs/binfmt_misc/register", O_WRONLY);
-		if (fd >= 0) {
-			if (write(fd, &binfmt_rosetta[0], strlen(binfmt_rosetta)) < 0) {
-				perror("write to binfmt_misc");
-			}
-			close(fd);
-		} else {
-			perror("open binfmt_misc");
-		}
-	}
-}
-#endif
-
 #ifdef __TIMESYNC__
 
 #define TSYNC_PORT 123
@@ -868,12 +842,6 @@ int main(int argc, char **argv)
 	config_workdir = NULL;
 
 	config_parse_file(&config_argv, &config_workdir);
-
-#ifdef __ROSETTA__
-	if (access(rosetta_binary, F_OK) == 0) {
-		enable_rosetta();
-	}
-#endif
 
 	krun_home = getenv("KRUN_HOME");
 	if (krun_home) {

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -1,6 +1,5 @@
 use std::cmp;
 use std::io::Write;
-use std::path::PathBuf;
 use std::result;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
@@ -64,7 +63,6 @@ impl Fs {
     pub(crate) fn with_queues(
         fs_id: String,
         shared_dir: String,
-        mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
         queues: Vec<VirtQueue>,
     ) -> super::Result<Fs> {
         let mut queue_events = Vec::new();
@@ -80,7 +78,6 @@ impl Fs {
 
         let fs_cfg = passthrough::Config {
             root_dir: shared_dir,
-            mapped_volumes,
             ..Default::default()
         };
 
@@ -101,16 +98,12 @@ impl Fs {
         })
     }
 
-    pub fn new(
-        fs_id: String,
-        shared_dir: String,
-        mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
-    ) -> super::Result<Fs> {
+    pub fn new(fs_id: String, shared_dir: String) -> super::Result<Fs> {
         let queues: Vec<VirtQueue> = defs::QUEUE_SIZES
             .iter()
             .map(|&max_size| VirtQueue::new(max_size))
             .collect();
-        Self::with_queues(fs_id, shared_dir, mapped_volumes, queues)
+        Self::with_queues(fs_id, shared_dir, queues)
     }
 
     pub fn id(&self) -> &str {

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -10,7 +10,6 @@ use std::fs::File;
 use std::io;
 use std::mem::{self, size_of, MaybeUninit};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
@@ -243,12 +242,6 @@ pub struct Config {
     ///
     /// The default is `None`.
     pub proc_sfd_rawfd: Option<RawFd>,
-
-    /// Optional list of tuples of (host_path, guest_path) elements, representing paths from the host
-    /// to be exposed in the guest.
-    ///
-    /// The default in `None`.
-    pub mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
 }
 
 impl Default for Config {
@@ -261,7 +254,6 @@ impl Default for Config {
             root_dir: String::from("/"),
             xattr: true,
             proc_sfd_rawfd: None,
-            mapped_volumes: None,
         }
     }
 }

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -11,7 +11,6 @@ use std::io;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
-use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
@@ -382,12 +381,6 @@ pub struct Config {
     ///
     /// The default is `None`.
     pub proc_sfd_rawfd: Option<RawFd>,
-
-    /// Optional list of tuples of (host_path, guest_path) elements, representing paths from the host
-    /// to be exposed in the guest.
-    ///
-    /// The default in `None`.
-    pub mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
 }
 
 impl Default for Config {
@@ -400,7 +393,6 @@ impl Default for Config {
             root_dir: String::from("/"),
             xattr: true,
             proc_sfd_rawfd: None,
-            mapped_volumes: None,
         }
     }
 }

--- a/src/devices/src/virtio/fs/mod.rs
+++ b/src/devices/src/virtio/fs/mod.rs
@@ -3,6 +3,7 @@ mod event_handler;
 #[allow(dead_code)]
 mod filesystem;
 pub mod fuse;
+#[allow(dead_code)]
 mod multikey;
 mod server;
 

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -87,7 +87,7 @@ impl<F: FileSystem + Sync> Server<F> {
                 w,
             );
         }
-        //println!("opcode: {}", in_header.opcode);
+        debug!("opcode: {}", in_header.opcode);
         match in_header.opcode {
             x if x == Opcode::Lookup as u32 => self.lookup(in_header, r, w),
             x if x == Opcode::Forget as u32 => self.forget(in_header, r), // No reply.

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.7.2"
+version = "1.8.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"

--- a/src/rutabaga_gfx/src/virgl_renderer.rs
+++ b/src/rutabaga_gfx/src/virgl_renderer.rs
@@ -387,7 +387,7 @@ impl VirglRenderer {
         #[cfg(feature = "virgl_renderer_next")]
         {
             let mut fd_type = 0;
-            let mut fd = 0;
+            let mut fd = -1;
             let ret =
                 unsafe { virgl_renderer_resource_export_blob(resource_id, &mut fd_type, &mut fd) };
             ret_to_res(ret)?;

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -1,6 +1,5 @@
 use std::collections::VecDeque;
 use std::fmt;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use devices::virtio::{Fs, FsError};
@@ -26,7 +25,6 @@ type Result<T> = std::result::Result<T, FsConfigError>;
 pub struct FsDeviceConfig {
     pub fs_id: String,
     pub shared_dir: String,
-    pub mapped_volumes: Option<Vec<(PathBuf, PathBuf)>>,
 }
 
 #[derive(Default)]
@@ -48,7 +46,7 @@ impl FsBuilder {
     }
 
     pub fn create_fs(config: FsDeviceConfig) -> Result<Fs> {
-        devices::virtio::Fs::new(config.fs_id, config.shared_dir, config.mapped_volumes)
+        devices::virtio::Fs::new(config.fs_id, config.shared_dir)
             .map_err(FsConfigError::CreateFsDevice)
     }
 }

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -1,11 +1,9 @@
 use std::collections::VecDeque;
 use std::fmt;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use devices::virtio::{Fs, FsError};
-
-const ROSETTA_DIR: &str = "/Library/Apple/usr/libexec/oah/RosettaLinux";
 
 #[derive(Debug)]
 pub enum FsConfigError {
@@ -50,25 +48,7 @@ impl FsBuilder {
     }
 
     pub fn create_fs(config: FsDeviceConfig) -> Result<Fs> {
-        let mapped_volumes = if cfg!(target_os = "macos") && std::fs::metadata(ROSETTA_DIR).is_ok()
-        {
-            if let Some(config_mapped_volumes) = config.mapped_volumes {
-                let mut mapped_volumes = config_mapped_volumes.to_vec();
-                mapped_volumes.push((
-                    Path::new(ROSETTA_DIR).to_path_buf(),
-                    Path::new("/.rosetta").to_path_buf(),
-                ));
-                Some(mapped_volumes)
-            } else {
-                Some(vec![(
-                    Path::new(ROSETTA_DIR).to_path_buf(),
-                    Path::new("/.rosetta").to_path_buf(),
-                )])
-            }
-        } else {
-            config.mapped_volumes
-        };
-        devices::virtio::Fs::new(config.fs_id, config.shared_dir, mapped_volumes)
+        devices::virtio::Fs::new(config.fs_id, config.shared_dir, config.mapped_volumes)
             .map_err(FsConfigError::CreateFsDevice)
     }
 }


### PR DESCRIPTION
    The hardest problem of virtio-fs is keeping a relationship between
    inodes in virtio-fs (guest's perspective) and inodes in the backing
    filesystem (host's perspective).

    On Linux, this forces us to keep a fd open per each alive dirent in the
    guest (hence the "forget/batch_forget" logic). Trying to use the same
    strategy of macOS proved to be very difficult as the process can easily
    reach a limit in the number of open files that can't be easily
    increased.

    To overcome this difficuly, we were using a complex combination of both
    fd and paths caches. In this commit, we overhaul the whole
    implementation to remove the use of those caches to take advange instead
    of macOS ability to access inodes directly through "/.vol".

    This strategy simplifies the code, reduces the cost of each operation
    and makes the implementation significantly more robust. Its main
    drawback is that we can't support traversing mutiple filesystems through
    the same mountpoint on the host, but that's a reasonable limitation on
    macOS that shouldn't affect the vast majority of users.