### PR TITLE
console: send a resize event on PORT_READY

### DIFF
--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -234,6 +234,9 @@ impl Console {
                     if self.ports[cmd.id as usize].is_console() {
                         self.control.mark_console_port(mem, cmd.id);
                         self.control.port_open(cmd.id, true);
+                        let (cols, rows) = get_win_size();
+                        self.control
+                            .console_resize(cmd.id, VirtioConsoleResize { cols, rows });
                     } else {
                         // We start with all ports open, this makes sense for now,
                         // because underlying file descriptors STDIN, STDOUT, STDERR are always open too


### PR DESCRIPTION
When multiport is enabled the guest doesn't read the console size from the device config. This implies that, until SIGWINCH is received, the guest is potentially operating with a wrong console size.

To fix this issue, send a resize message on PORT_READY.