### PR TITLE
init: tell the kernel to reap our children for us

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -902,6 +902,9 @@ int main(int argc, char **argv)
             exit(-3);
         }
     } else { // parent
+        // tell the kernel we don't want to be notified on SIGCHLD so it'll reap
+        // our children for us
+        signal(SIGCHLD, SIG_IGN);
         // wait for children since we can't exit init
         waitpid(pid, NULL, 0);
     }


### PR DESCRIPTION
Tell the kernel that we want to ignore SIGCHLD so it'll reap our children for us to avoid leaving zombie objects.

Fixes #189