### PR TITLE
virtio/fs: Fix corrupted dirents due to trailing garbage

### DIFF
--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -527,6 +527,11 @@ impl PassthroughFs {
             debug_assert!(namelen <= back.len(), "back is smaller than `namelen`");
 
             let name = &back[..namelen];
+            let term = name
+                .iter()
+                .position(|&a| a == 0)
+                .expect("LinuxDirent64 name not NUL-terminated");
+            let name = &name[..term];
             let res = if name.starts_with(CURRENT_DIR_CSTR) || name.starts_with(PARENT_DIR_CSTR) {
                 // We don't want to report the "." and ".." entries. However, returning `Ok(0)` will
                 // break the loop so return `Ok` with a non-zero value instead.


### PR DESCRIPTION
The dirent name length is supposed to be the actual `strlen()` of the name, without any padding. `SYS_getdents64`, however, will pad the records it returns (for alignment, etc.) as well as NUL-terminate the name.

This was causing dirents in the guest kernel to have spurious NUL padding treated as part of the name, which in turn was breaking `getcwd()` under some conditions (and probably other more subtle things).