### PR TITLE
gpu: use resource_map() for mapping BOs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ endif
 ifeq ($(GPU),1)
     FEATURE_FLAGS += --features gpu
 endif
+ifeq ($(VIRGL_RESOURCE_MAP2),1)
+	FEATURE_FLAGS += --features virgl_resource_map2
+endif
 ifeq ($(BLK),1)
     FEATURE_FLAGS += --features blk
 endif

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -12,6 +12,7 @@ blk = []
 efi = ["blk", "net"]
 gpu = ["rutabaga_gfx", "thiserror", "zerocopy", "zerocopy-derive"]
 snd = ["pw", "thiserror"]
+virgl_resource_map2 = []
 
 [dependencies]
 bitflags = "1.2.0"

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -13,6 +13,7 @@ blk = []
 efi = [ "blk", "net" ]
 gpu = []
 snd = []
+virgl_resource_map2 = []
 
 [dependencies]
 crossbeam-channel = "0.5"

--- a/src/rutabaga_gfx/Cargo.toml
+++ b/src/rutabaga_gfx/Cargo.toml
@@ -12,6 +12,7 @@ gfxstream_stub = []
 gpu = []
 virgl_renderer = []
 virgl_renderer_next = []
+virgl_resource_map2 = []
 minigbm = []
 # To try out Vulkano, delete the following line and uncomment the line in "dependencies". Vulkano
 # features are just a prototype and not integrated yet into the ChromeOS build system.

--- a/src/rutabaga_gfx/src/generated/virgl_renderer_bindings.rs
+++ b/src/rutabaga_gfx/src/generated/virgl_renderer_bindings.rs
@@ -378,6 +378,16 @@ extern "C" {
         out_size: *mut u64,
     ) -> ::std::os::raw::c_int;
 }
+#[cfg(feature = "virgl_resource_map2")]
+extern "C" {
+    pub fn virgl_renderer_resource_map2(
+        res_handle: u32,
+        map: *const ::std::os::raw::c_void,
+        size: u64,
+        prot: i32,
+        flags: i32,
+    ) -> ::std::os::raw::c_int;
+}
 extern "C" {
     pub fn virgl_renderer_resource_unmap(res_handle: u32) -> ::std::os::raw::c_int;
 }

--- a/src/rutabaga_gfx/src/virgl_renderer.rs
+++ b/src/rutabaga_gfx/src/virgl_renderer.rs
@@ -694,6 +694,35 @@ impl RutabagaComponent for VirglRenderer {
         Err(RutabagaError::Unsupported)
     }
 
+    fn resource_map(
+        &self,
+        _resource_id: u32,
+        _addr: u64,
+        _size: u64,
+        _prot: i32,
+        _flags: i32,
+    ) -> RutabagaResult<()> {
+        #[cfg(feature = "virgl_resource_map2")]
+        {
+            let ret = unsafe {
+                virgl_renderer_resource_map2(
+                    _resource_id,
+                    _addr as *mut libc::c_void,
+                    _size,
+                    _prot,
+                    _flags,
+                )
+            };
+            if ret != 0 {
+                return Err(RutabagaError::MappingFailed(ret));
+            }
+
+            Ok(())
+        }
+        #[cfg(not(feature = "virgl_resource_map2"))]
+        Err(RutabagaError::Unsupported)
+    }
+
     fn map(&self, resource_id: u32) -> RutabagaResult<RutabagaMapping> {
         #[cfg(feature = "virgl_renderer_next")]
         {


### PR DESCRIPTION
    Use rutabaga's resource_map() to delegate mappings to virglrenderer.
    This allows libkrun + virglrenderer to map BOs without relying on PRIME
    fds, simplifying the ability to honor BO sharing semantics
    
    The feature is gated behind "virgl_resource_map2" until
    https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1374
    gets merged.
