### PR TITLE
hvf: support ARM PSCI SYSTEM_OFF

### DIFF
--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -389,7 +389,8 @@ impl<'a> HvfVcpu<'a> {
                         let ret = match val {
                             0x8400_0000 => Some(2),
                             0x8400_0006 => Some(2),
-                            0x8400_0009 => return Ok(VcpuExit::Shutdown),
+                            0x8400_0008 => return Ok(VcpuExit::Shutdown), // ARM Power State Coordination Interface SYSTEM_OFF
+                            0x8400_0009 => return Ok(VcpuExit::Shutdown), // ARM Power State Coordination Interface SYSTEM_RESET
                             0xc400_0003 => {
                                 let mpidr = self.read_reg(hv_reg_t_HV_REG_X1)?;
                                 let entry = self.read_reg(hv_reg_t_HV_REG_X2)?;


### PR DESCRIPTION
This is part of the ARM Power State Coordination Interface, see https://developer.arm.com/documentation/den0022/f/?lang=en

There are 2 calls: 1 for "system off" and one for "system reset". Previously we supported only "system reset", add support for "system off" as well.

I tested with a small Go `init` process which ran:
```
func main() {
        _ = syscall.Reboot(syscall.LINUX_REBOOT_CMD_POWER_OFF)
}
```
Before the patch it would keep running. After this patch it powers off as expected.