### PR TITLE
virtio/fs: translate raw errors in server.rs

### DIFF
--- a/src/devices/src/virtio/linux_errno.rs
+++ b/src/devices/src/virtio/linux_errno.rs
@@ -167,6 +167,7 @@ pub fn linux_errno_raw(errno: i32) -> i32 {
         libc::EIDRM => LINUX_EIDRM,
         libc::ENOMSG => LINUX_ENOMSG,
         libc::EILSEQ => LINUX_EILSEQ,
+        #[cfg(target_os = "macos")]
         libc::ENOATTR => LINUX_ENODATA,
         libc::EBADMSG => LINUX_EBADMSG,
         libc::EMULTIHOP => LINUX_EMULTIHOP,

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -25,7 +25,6 @@ pub mod file_traits;
 pub mod fs;
 #[cfg(feature = "gpu")]
 pub mod gpu;
-#[cfg(target_os = "macos")]
 pub mod linux_errno;
 mod mmio;
 #[cfg(feature = "net")]


### PR DESCRIPTION
Translate raw errors in server.rs to Linux errnos. This fixes bogus ENOSYS when running on macOS.