### PR TITLE
vmm: Fix the nomodule kernel parameter

### DIFF
--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -7,27 +7,27 @@ use std::fmt::{Display, Formatter, Result};
 /// - `reboot=k` shut down the guest on reboot, instead of well... rebooting;
 /// - `panic=1` on panic, reboot after 1 second;
 /// - `pci=off` do not scan for PCI devices (save boot time);
-/// - `nomodules` disable loadable kernel module support;
+/// - `nomodule` disable loadable kernel module support;
 /// - `8250.nr_uarts=0` disable 8250 serial interface;
 /// - `i8042.noaux` do not probe the i8042 controller for an attached mouse (save boot time);
 /// - `i8042.nomux` do not probe i8042 for a multiplexing controller (save boot time);
 /// - `i8042.nopnp` do not use ACPIPnP to discover KBD/AUX controllers (save boot time);
 /// - `i8042.dumbkbd` do not attempt to control kbd state via the i8042 (save boot time).
-//pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0 \
+//pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0 \
 //                                          i8042.noaux i8042.nomux i8042.nopnp i8042.dumbkbd";
 
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
-pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
+pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
                                           rootfstype=virtiofs rw quiet no-kvmapf";
 
 #[cfg(feature = "amd-sev")]
-pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
+pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
                                           root=/dev/vda rw quiet no-kvmapf";
 #[cfg(target_os = "macos")]
-pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodules console=hvc0 \
+pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
                                           rootfstype=virtiofs rw quiet no-kvmapf";
 
-//pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodules earlyprintk=ttyS0 \
+//pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=1 pci=off nomodule earlyprintk=ttyS0 \
 //                                          console=ttyS0";
 
 /// Strongly typed data structure used to configure the boot source of the
@@ -35,7 +35,7 @@ pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodu
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct BootSourceConfig {
     /// The boot arguments to pass to the kernel. If this field is uninitialized, the default
-    /// kernel command line is used: `reboot=k panic=1 pci=off nomodules 8250.nr_uarts=0`.
+    /// kernel command line is used: `reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0`.
     pub kernel_cmdline_prolog: Option<String>,
     pub kernel_cmdline_epilog: Option<String>,
 }


### PR DESCRIPTION
I noticed this kernel parameter was incorrect in the command-line (torvalds/linux@02608bef8f774c058779546926889a2f2717a499).  It looks like it will have no effect since the default libkrunfw configs disable `CONFIG_MODULES`, so the code that handles this parameter isn't built.  Maybe the parameter could be dropped, but this corrects it to take effect if anyone tries to use a modular kernel.