### PR TITLE
Remove contention on the Gic

### DIFF
--- a/src/devices/src/legacy/gic.rs
+++ b/src/devices/src/legacy/gic.rs
@@ -31,6 +31,12 @@ pub struct VcpuList {
     vtimer_irq: u32,
 }
 
+impl Default for VcpuList {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl VcpuList {
     pub fn new() -> Self {
         let mut vcpus = Vec::with_capacity(MAX_CPUS as usize);

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -23,7 +23,7 @@ use aarch64::gpio;
 use aarch64::serial;
 
 #[cfg(target_os = "macos")]
-pub use self::gic::Gic;
+pub use self::gic::{Gic, VcpuList};
 #[cfg(target_arch = "aarch64")]
 pub use self::gpio::Gpio;
 pub use self::i8042::Error as I8042DeviceError;


### PR DESCRIPTION
Instead of locking a single Gic, we move the contention down to the vCPU level.
This gives us better performance for CPU bound tasks.

On a 8 cores M3:
+ Building the Linux Kernel: 7m21s -> 6:58s
+ Building Wasmer: 3m13s -> 2m30s
