### PR TITLE
virtio/fs: Munge device number into inode number

### DIFF
--- a/src/devices/src/virtio/fs/fuse.rs
+++ b/src/devices/src/virtio/fs/fuse.rs
@@ -546,7 +546,8 @@ unsafe impl ByteValued for Attr {}
 impl From<bindings::stat64> for Attr {
     fn from(st: bindings::stat64) -> Attr {
         Attr {
-            ino: st.st_ino,
+            #[allow(clippy::unnecessary_cast)]
+            ino: st.st_ino ^ ((st.st_dev as u64) << 32),
             size: st.st_size as u64,
             blocks: st.st_blocks as u64,
             atime: st.st_atime as u64,


### PR DESCRIPTION
virtio-fs can expose multiple host mounts as a single mount. This means that all st_dev numbers from the host get collapsed into a single st_dev, breaking st_ino/st_dev comparisons for file identity.

Short of replicating the mount hierarchy with separate virtio-fs mounts, there's no good way to fix this in all cases. So, do a best-effort hack by XORing st_dev into the top bits of st_ino. This can still have collisions, but it's a lot better than ignoring st_dev entirely (which is very likely to have collisions with multiple mounted filesystems).

Fixes Wine in krun on Fedora systems with separate btrfs subvolumes for / and /home (which causes Wine to think / and /home are the same path, breaking DOS device selection).