### PR TITLE
Bring back DAX

### DIFF
--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -42,8 +42,8 @@ pub enum Error {
 
 /// The start of the memory area reserved for MMIO devices.
 pub const MMIO_MEM_START: u64 = layout::MAPPED_IO_START;
-/// The size of the MMIO shared memory area used by virtio-fs DAX.
-pub const MMIO_SHM_SIZE: u64 = 1 << 33;
+/// The size of the MMIO shared memory area used by virtio-fs DAX and virtio-gpu.
+pub const MMIO_SHM_SIZE: u64 = 1 << 34;
 
 pub use self::fdt::DeviceInfoForFDT;
 use crate::DeviceType;

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -60,8 +60,8 @@ const FIRST_ADDR_PAST_32BITS: u64 = 1 << 32;
 const MEM_32BIT_GAP_SIZE: u64 = 768 << 20;
 /// The start of the memory area reserved for MMIO devices.
 pub const MMIO_MEM_START: u64 = FIRST_ADDR_PAST_32BITS - MEM_32BIT_GAP_SIZE;
-/// The size of the MMIO shared memory area used by virtio-fs DAX.
-pub const MMIO_SHM_SIZE: u64 = 1 << 33;
+/// The size of the MMIO shared memory area used by virtio-fs DAX and virtio-gpu.
+pub const MMIO_SHM_SIZE: u64 = 1 << 34;
 
 /// Returns a Vec of the valid memory addresses.
 /// These should be used to configure the GuestMemoryMmap structure for the platform.

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -201,6 +201,7 @@ impl VirtioDevice for Fs {
             mem.clone(),
             self.passthrough_cfg.clone(),
             self.worker_stopfd.try_clone().unwrap(),
+            self.shm_region.clone(),
         );
         self.worker_thread = Some(worker.run());
 

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -18,7 +18,7 @@ use std::fmt::{Display, Formatter, Result};
 
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
-                                          rootfstype=virtiofs rw quiet no-kvmapf";
+                                          rootflags=dax rootfstype=virtiofs rw quiet no-kvmapf";
 
 #[cfg(feature = "amd-sev")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \


### PR DESCRIPTION
Re-add the shmem region required for DAX again (after it got removed when virtio-gpu was implemented), and enable DAX.