### PR TITLE
virtio/fs/macos: fix submounts

### DIFF
--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -37,6 +37,9 @@ pub struct Entry {
     /// If this value is not correct, incorrect data will be returned.
     pub attr: bindings::stat64,
 
+    /// Flags for `fuse::Attr.flags`.
+    pub attr_flags: u32,
+
     /// How long the values in `attr` should be considered valid. If the attributes of the `Entry`
     /// are only modified by the FUSE client, then this should be set to a very large value.
     pub attr_timeout: Duration,
@@ -56,7 +59,7 @@ impl From<Entry> for fuse::EntryOut {
             attr_valid: entry.attr_timeout.as_secs(),
             entry_valid_nsec: entry.entry_timeout.subsec_nanos(),
             attr_valid_nsec: entry.attr_timeout.subsec_nanos(),
-            attr: entry.attr.into(),
+            attr: fuse::Attr::with_flags(entry.attr, entry.attr_flags),
         }
     }
 }

--- a/src/devices/src/virtio/fs/fuse.rs
+++ b/src/devices/src/virtio/fs/fuse.rs
@@ -518,6 +518,11 @@ pub const FUSE_COMPAT_STATFS_SIZE: u32 = 48;
 pub const FUSE_COMPAT_INIT_OUT_SIZE: u32 = 8;
 pub const FUSE_COMPAT_22_INIT_OUT_SIZE: u32 = 24;
 
+// Attr.flags flags.
+
+/// Object is a submount root
+pub const ATTR_SUBMOUNT: u32 = 1;
+
 // Message definitions follow.  It is safe to implement ByteValued for all of these
 // because they are POD types.
 
@@ -539,12 +544,18 @@ pub struct Attr {
     pub gid: u32,
     pub rdev: u32,
     pub blksize: u32,
-    pub padding: u32,
+    pub flags: u32,
 }
 unsafe impl ByteValued for Attr {}
 
 impl From<bindings::stat64> for Attr {
     fn from(st: bindings::stat64) -> Attr {
+        Attr::with_flags(st, 0)
+    }
+}
+
+impl Attr {
+    pub fn with_flags(st: bindings::stat64, flags: u32) -> Attr {
         Attr {
             ino: st.st_ino,
             size: st.st_size as u64,
@@ -569,7 +580,7 @@ impl From<bindings::stat64> for Attr {
             gid: st.st_gid,
             rdev: st.st_rdev as u32,
             blksize: st.st_blksize as u32,
-            ..Default::default()
+            flags,
         }
     }
 }

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -446,6 +446,7 @@ impl PassthroughFs {
             inode,
             generation: 0,
             attr: st,
+            attr_flags: 0,
             attr_timeout: self.cfg.attr_timeout,
             entry_timeout: self.cfg.entry_timeout,
         })
@@ -770,6 +771,7 @@ impl FileSystem for PassthroughFs {
                 inode: self.init_inode,
                 generation: 0,
                 attr: st,
+                attr_flags: 0,
                 attr_timeout: self.cfg.attr_timeout,
                 entry_timeout: self.cfg.entry_timeout,
             })

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -586,6 +586,7 @@ impl PassthroughFs {
             inode,
             generation: 0,
             attr: st,
+            attr_flags: 0,
             attr_timeout: self.cfg.attr_timeout,
             entry_timeout: self.cfg.entry_timeout,
         })
@@ -957,6 +958,7 @@ impl FileSystem for PassthroughFs {
                 inode: self.init_inode,
                 generation: 0,
                 attr: st,
+                attr_flags: 0,
                 attr_timeout: self.cfg.attr_timeout,
                 entry_timeout: self.cfg.entry_timeout,
             })

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -859,6 +859,7 @@ impl<F: FileSystem + Sync> Server<F> {
             | FsOptions::HAS_IOCTL_DIR
             | FsOptions::ATOMIC_O_TRUNC
             | FsOptions::MAX_PAGES
+            | FsOptions::SUBMOUNTS
             | FsOptions::INIT_EXT;
 
         if cfg!(target_os = "macos") {


### PR DESCRIPTION
Fix submount navigation by decoupling host<->guest inode numbers and implementing support for FUSE SUBMOUNTS, based on virtiofsd implementation.