### PR TITLE
Update kbs-types dependency to 0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -133,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.13.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
 
 [[package]]
 name = "bitflags"
@@ -623,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55194540478bd16e46f6a14f6d7af8e561a9b665511056038b5033e472bb7d6"
+checksum = "9b6441ed73b0faa50707d4de41c6b45c76654b661b96aaf7b26a41331eedc0a5"
 dependencies = [
  "serde",
  "serde_json",
@@ -1191,18 +1197,21 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "1.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd749a01c88a51ac718b59fe571177b31e478dfe059267977042477a0531224"
+checksum = "35156eab65ff1b63432b5a11a06b770e92120033e2831c7dee064865de5dbbbd"
 dependencies = [
+ "base64",
  "bincode",
  "bitfield",
  "bitflags 1.3.2",
+ "byteorder",
  "codicon",
  "dirs",
  "hex",
  "iocuddle",
- "kvm-ioctls",
+ "lazy_static",
+ "libc",
  "openssl",
  "serde",
  "serde-big-array",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libkrun"
-version = "1.9.3"
+version = "1.9.4"
 dependencies = [
  "crossbeam-channel",
  "devices",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LIBRARY_HEADER = include/libkrun.h
 
 ABI_VERSION=1
-FULL_VERSION=1.9.3
+FULL_VERSION=1.9.4
 
 INIT_SRC = init/init.c
 KBS_INIT_SRC =	init/tee/kbs/kbs.h		\

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.9.3"
+version = "1.9.4"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -28,11 +28,11 @@ polly = { path = "../polly" }
 
 # Dependencies for amd-sev
 codicon = { version = "3.0.0", optional = true }
-kbs-types = { version = "0.5.1, < 0.5.3", features = ["tee-sev", "tee-snp"], optional = true }
+kbs-types = { version = "0.7.0", features = ["tee-sev", "tee-snp"], optional = true }
 procfs = { version = "0.12", optional = true }
 serde = { version = "1.0.125", optional = true }
 serde_json = { version = "1.0.64", optional = true }
-sev = { version = "1.2.0", features = ["openssl"], optional = true }
+sev = { version = "3.2.0", features = ["openssl"], optional = true }
 curl = { version = "0.4", optional = true }
 nix = "0.24.1"
 

--- a/src/vmm/src/linux/tee/amdsev.rs
+++ b/src/vmm/src/linux/tee/amdsev.rs
@@ -290,7 +290,7 @@ impl AmdSev {
             let request = Request {
                 version: "0.0.0".to_string(),
                 tee: tee_config.tee,
-                extra_params: serde_json::json!(sev_request).to_string(),
+                extra_params: serde_json::json!(sev_request),
             };
 
             let response = curl_agent
@@ -302,7 +302,7 @@ impl AmdSev {
 
             let challenge: Challenge =
                 serde_json::from_slice(&response).map_err(Error::ParseSessionResponse)?;
-            let sev_challenge: SevChallenge = serde_json::from_str(&challenge.extra_params)
+            let sev_challenge: SevChallenge = serde_json::from_value(challenge.extra_params)
                 .map_err(Error::ParseSessionResponse)?;
 
             if sev_challenge
@@ -408,8 +408,7 @@ impl AmdSev {
         let measurement = launcher.measurement();
 
         if !self.tee_config.attestation_url.is_empty() {
-            let tee_pubkey = TeePubKey {
-                kty: "".to_string(),
+            let tee_pubkey = TeePubKey::RSA {
                 alg: "".to_string(),
                 k_mod: "".to_string(),
                 k_exp: "".to_string(),
@@ -417,7 +416,7 @@ impl AmdSev {
 
             let attestation = Attestation {
                 tee_pubkey,
-                tee_evidence: serde_json::json!(measurement).to_string(),
+                tee_evidence: serde_json::json!(measurement),
             };
 
             let mut curl_agent = self.curl_agent.lock().unwrap();

--- a/src/vmm/src/linux/tee/amdsnp.rs
+++ b/src/vmm/src/linux/tee/amdsnp.rs
@@ -3,7 +3,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use crate::vstate::MeasuredRegion;
 use arch::x86_64::layout::*;
 
-use sev::firmware::host::Firmware;
+use sev::firmware::{guest::GuestPolicy, host::Firmware};
 use sev::launch::snp::*;
 
 use kvm_bindings::{kvm_enc_region, CpuId, KVM_CPUID_FLAG_SIGNIFCANT_INDEX};
@@ -101,15 +101,7 @@ impl AmdSnp {
                 .map_err(|_| Error::MemoryEncryptRegion)?;
         }
 
-        let start = Start::new(
-            None,
-            Policy {
-                flags: PolicyFlags::SMT,
-                ..Default::default()
-            },
-            false,
-            [0; 16],
-        );
+        let start = Start::new(None, GuestPolicy(0), false, [0; 16]);
 
         let launcher = launcher.start(start).map_err(Error::LaunchStart)?;
 


### PR DESCRIPTION
This allows us to also update sev to the latest version, 3.2.0.