### PR TITLE
Implement SHM region management and re-enable DAX in virtiofs

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -122,6 +122,24 @@ int32_t krun_add_virtiofs(uint32_t ctx_id,
                           const char *c_path);
 
 /**
+ * Adds an independent virtio-fs device pointing to a host's directory with a tag. This
+ * variant allows specifying the size of the DAX window.
+ *
+ * Arguments:
+ *  "ctx_id"         - the configuration context ID.
+ *  "c_tag"          - tag to identify the filesystem in the guest.
+ *  "c_path"         - full path to the directory in the host to be exposed to the guest.
+ *  "shm_size"       - size of the DAX SHM window in bytes.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_add_virtiofs2(uint32_t ctx_id,
+                           const char *c_tag,
+                           const char *c_path,
+                           uint64_t shm_size);
+
+/**
  * Configures the networking to use passt.
  * Call to this function disables TSI backend to use passt instead.
  *
@@ -154,7 +172,7 @@ int32_t krun_set_passt_fd(uint32_t ctx_id, int fd);
  * Returns:
  *  Zero on success or a negative error number on failure.
  */
-int32_t krun_set_gvproxy_path(uint32_t ctx_id, char* c_path);
+int32_t krun_set_gvproxy_path(uint32_t ctx_id, char *c_path);
 
 /**
  * Sets the MAC address for the virtio-net device when using the passt backend.
@@ -196,17 +214,17 @@ int32_t krun_set_net_mac(uint32_t ctx_id, uint8_t *const c_mac);
 int32_t krun_set_port_map(uint32_t ctx_id, const char *const port_map[]);
 
 /* Flags for virglrenderer.  Copied from virglrenderer bindings. */
-#define VIRGLRENDERER_USE_EGL            1 << 0
-#define VIRGLRENDERER_THREAD_SYNC        1 << 1
-#define VIRGLRENDERER_USE_GLX            1 << 2
-#define VIRGLRENDERER_USE_SURFACELESS    1 << 3
-#define VIRGLRENDERER_USE_GLES           1 << 4
-#define VIRGLRENDERER_USE_EXTERNAL_BLOB  1 << 5
-#define VIRGLRENDERER_VENUS              1 << 6
-#define VIRGLRENDERER_NO_VIRGL           1 << 7
+#define VIRGLRENDERER_USE_EGL 1 << 0
+#define VIRGLRENDERER_THREAD_SYNC 1 << 1
+#define VIRGLRENDERER_USE_GLX 1 << 2
+#define VIRGLRENDERER_USE_SURFACELESS 1 << 3
+#define VIRGLRENDERER_USE_GLES 1 << 4
+#define VIRGLRENDERER_USE_EXTERNAL_BLOB 1 << 5
+#define VIRGLRENDERER_VENUS 1 << 6
+#define VIRGLRENDERER_NO_VIRGL 1 << 7
 #define VIRGLRENDERER_USE_ASYNC_FENCE_CB 1 << 8
-#define VIRGLRENDERER_RENDER_SERVER      1 << 9
-#define VIRGLRENDERER_DRM                1 << 10
+#define VIRGLRENDERER_RENDER_SERVER 1 << 9
+#define VIRGLRENDERER_DRM 1 << 10
 /**
  * Enables and configures a virtio-gpu device.
  *
@@ -218,6 +236,22 @@ int32_t krun_set_port_map(uint32_t ctx_id, const char *const port_map[]);
  *  Zero on success or a negative error number on failure.
  */
 int32_t krun_set_gpu_options(uint32_t ctx_id, uint32_t virgl_flags);
+
+/**
+ * Enables and configures a virtio-gpu device. This variant allows specifying
+ * the size of the host window (acting as vRAM in the guest).
+ *
+ * Arguments:
+ *  "ctx_id"      - the configuration context ID.
+ *  "virgl_flags" - flags to pass to virglrenderer.
+ *  "shm_size"    - size of the SHM host window in bytes.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_gpu_options2(uint32_t ctx_id,
+                              uint32_t virgl_flags,
+                              uint64_t shm_size);
 
 /**
  * Enables or disables a virtio-snd device.
@@ -338,7 +372,6 @@ int32_t krun_add_vsock_port(uint32_t ctx_id,
  *  The eventfd file descriptor or a negative error number on failure.
  */
 int32_t krun_get_shutdown_eventfd(uint32_t ctx_id);
-
 
 /**
  * Configures the console device to ignore stdin and write the output to "c_filepath".

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -11,7 +11,7 @@ use std::result;
 pub struct ArchMemoryInfo {
     pub ram_last_addr: u64,
     pub shm_start_addr: u64,
-    pub shm_size: u64,
+    pub page_size: usize,
 }
 
 /// Module for aarch64 related functionality.
@@ -22,7 +22,6 @@ pub mod aarch64;
 pub use aarch64::{
     arch_memory_regions, configure_system, get_kernel_start, initrd_load_addr,
     layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error, MMIO_MEM_START,
-    MMIO_SHM_SIZE,
 };
 
 /// Module for x86_64 related functionality.
@@ -33,7 +32,7 @@ pub mod x86_64;
 pub use crate::x86_64::{
     arch_memory_regions, configure_system, get_kernel_start, initrd_load_addr,
     layout::CMDLINE_MAX_SIZE, layout::IRQ_BASE, layout::IRQ_MAX, Error, BIOS_SIZE, BIOS_START,
-    MMIO_MEM_START, MMIO_SHM_SIZE, RESET_VECTOR,
+    MMIO_MEM_START, RESET_VECTOR,
 };
 
 /// Type for returning public functions outcome.
@@ -65,6 +64,15 @@ pub struct InitrdConfig {
 
 /// Default (smallest) memory page size for the supported architectures.
 pub const PAGE_SIZE: usize = 4096;
+
+pub fn round_up(size: usize, align: usize) -> usize {
+    let page_mask = align - 1;
+    (size + page_mask) & !page_mask
+}
+pub fn round_down(size: usize, align: usize) -> usize {
+    let page_mask = !(align - 1);
+    size & page_mask
+}
 
 impl fmt::Display for DeviceType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -199,6 +199,7 @@ impl VirtioDevice for Fs {
             self.intc.clone(),
             self.irq_line,
             mem.clone(),
+            self.shm_region.clone(),
             self.passthrough_cfg.clone(),
             self.worker_stopfd.try_clone().unwrap(),
         );

--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -2,6 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#[cfg(target_os = "macos")]
+use crossbeam_channel::Sender;
+#[cfg(target_os = "macos")]
+use hvf::MemoryMapping;
+
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::fs::File;
@@ -1121,6 +1126,7 @@ pub trait FileSystem {
         moffset: u64,
         host_shm_base: u64,
         shm_size: u64,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
     ) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
@@ -1131,6 +1137,7 @@ pub trait FileSystem {
         requests: Vec<RemovemappingOne>,
         host_shm_base: u64,
         shm_size: u64,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
     ) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -4,6 +4,7 @@
 
 use std::collections::btree_map;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
@@ -11,11 +12,14 @@ use std::io;
 use std::mem;
 use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::ptr::null_mut;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
+use crossbeam_channel::{unbounded, Sender};
+use hvf::MemoryMapping;
 use vm_memory::ByteValued;
 
 use crate::virtio::fs::filesystem::SecContext;
@@ -411,6 +415,8 @@ pub struct PassthroughFs {
     next_handle: AtomicU64,
     init_handle: u64,
 
+    map_windows: Mutex<HashMap<u64, u64>>,
+
     // Whether writeback caching is enabled for this directory. This will only be true when
     // `cfg.writeback` is true and `init` was called with `FsOptions::WRITEBACK_CACHE`.
     writeback: AtomicBool,
@@ -445,6 +451,8 @@ impl PassthroughFs {
             handles: RwLock::new(BTreeMap::new()),
             next_handle: AtomicU64::new(1),
             init_handle: 0,
+
+            map_windows: Mutex::new(HashMap::new()),
 
             writeback: AtomicBool::new(false),
             cfg,
@@ -1801,5 +1809,136 @@ impl FileSystem for PassthroughFs {
         } else {
             Ok(res as u64)
         }
+    }
+
+    fn setupmapping(
+        &self,
+        _ctx: Context,
+        inode: Inode,
+        _handle: Handle,
+        foffset: u64,
+        len: u64,
+        flags: u64,
+        moffset: u64,
+        guest_shm_base: u64,
+        shm_size: u64,
+        map_sender: &Option<Sender<MemoryMapping>>,
+    ) -> io::Result<()> {
+        if map_sender.is_none() {
+            return Err(linux_error(io::Error::from_raw_os_error(libc::ENOSYS)));
+        }
+
+        let prot_flags = if (flags & fuse::SetupmappingFlags::WRITE.bits()) != 0 {
+            libc::PROT_READ | libc::PROT_WRITE
+        } else {
+            libc::PROT_READ
+        };
+
+        if (moffset + len) > shm_size {
+            return Err(linux_error(io::Error::from_raw_os_error(libc::EINVAL)));
+        }
+
+        let guest_addr = guest_shm_base + moffset;
+
+        debug!(
+            "setupmapping: ino {:?} guest_addr={:x} len={}",
+            inode, guest_addr, len
+        );
+
+        let file = self.open_inode(inode, libc::O_RDWR)?;
+        let fd = file.as_raw_fd();
+
+        let host_addr = unsafe {
+            libc::mmap(
+                null_mut(),
+                len as usize,
+                prot_flags,
+                libc::MAP_SHARED,
+                fd,
+                foffset as libc::off_t,
+            )
+        };
+        if host_addr == libc::MAP_FAILED {
+            return Err(linux_error(io::Error::last_os_error()));
+        }
+
+        let ret = unsafe { libc::close(fd) };
+        if ret == -1 {
+            return Err(linux_error(io::Error::last_os_error()));
+        }
+
+        // We've checked that map_sender is something above.
+        let sender = map_sender.as_ref().unwrap();
+        let (reply_sender, reply_receiver) = unbounded();
+        sender
+            .send(MemoryMapping::AddMapping(
+                reply_sender,
+                host_addr as u64,
+                guest_addr,
+                len,
+            ))
+            .unwrap();
+        if !reply_receiver.recv().unwrap() {
+            error!("Error requesting HVF the addition of a DAX window");
+            unsafe { libc::munmap(host_addr, len as usize) };
+            return Err(linux_error(io::Error::from_raw_os_error(libc::EINVAL)));
+        }
+
+        self.map_windows
+            .lock()
+            .unwrap()
+            .insert(guest_addr, host_addr as u64);
+
+        Ok(())
+    }
+
+    fn removemapping(
+        &self,
+        _ctx: Context,
+        requests: Vec<fuse::RemovemappingOne>,
+        guest_shm_base: u64,
+        shm_size: u64,
+        map_sender: &Option<Sender<MemoryMapping>>,
+    ) -> io::Result<()> {
+        if map_sender.is_none() {
+            return Err(linux_error(io::Error::from_raw_os_error(libc::ENOSYS)));
+        }
+
+        for req in requests {
+            let guest_addr = guest_shm_base + req.moffset;
+            if (req.moffset + req.len) > shm_size {
+                return Err(linux_error(io::Error::from_raw_os_error(libc::EINVAL)));
+            }
+            let host_addr = match self.map_windows.lock().unwrap().remove(&guest_addr) {
+                Some(a) => a,
+                None => return Err(linux_error(io::Error::from_raw_os_error(libc::EINVAL))),
+            };
+            debug!(
+                "removemapping: guest_addr={:x} len={:?}",
+                guest_addr, req.len
+            );
+
+            let sender = map_sender.as_ref().unwrap();
+            let (reply_sender, reply_receiver) = unbounded();
+            sender
+                .send(MemoryMapping::RemoveMapping(
+                    reply_sender,
+                    guest_addr,
+                    req.len,
+                ))
+                .unwrap();
+            if !reply_receiver.recv().unwrap() {
+                error!("Error requesting HVF the removal of a DAX window");
+                return Err(linux_error(io::Error::from_raw_os_error(libc::EINVAL)));
+            }
+
+            let ret = unsafe { libc::munmap(host_addr as *mut libc::c_void, req.len as usize) };
+            if ret == -1 {
+                error!("Error unmapping DAX window");
+                return Err(linux_error(io::Error::last_os_error()));
+            }
+        }
+
+        Ok(())
     }
 }

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -77,7 +77,7 @@ impl<F: FileSystem + Sync> Server<F> {
         &self,
         mut r: Reader,
         w: Writer,
-        shm_region: Option<&VirtioShmRegion>,
+        shm_region: &Option<VirtioShmRegion>,
     ) -> Result<usize> {
         let in_header: InHeader = r.read_obj().map_err(Error::DecodeMessage)?;
 
@@ -136,7 +136,7 @@ impl<F: FileSystem + Sync> Server<F> {
             x if x == Opcode::Lseek as u32 => self.lseek(in_header, r, w),
             x if x == Opcode::CopyFileRange as u32 => self.copyfilerange(in_header, r, w),
             x if (x == Opcode::SetupMapping as u32) && shm_region.is_some() => {
-                let shm = shm_region.unwrap();
+                let shm = shm_region.as_ref().unwrap();
                 #[cfg(target_os = "linux")]
                 let shm_base_addr = shm.host_addr;
                 #[cfg(target_os = "macos")]
@@ -144,7 +144,7 @@ impl<F: FileSystem + Sync> Server<F> {
                 self.setupmapping(in_header, r, w, shm_base_addr, shm.size as u64)
             }
             x if (x == Opcode::RemoveMapping as u32) && shm_region.is_some() => {
-                let shm = shm_region.unwrap();
+                let shm = shm_region.as_ref().unwrap();
                 #[cfg(target_os = "linux")]
                 let shm_base_addr = shm.host_addr;
                 #[cfg(target_os = "macos")]

--- a/src/devices/src/virtio/gpu/worker.rs
+++ b/src/devices/src/virtio/gpu/worker.rs
@@ -16,7 +16,7 @@ use utils::eventfd::EventFd;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
 
 use super::super::descriptor_utils::{Reader, Writer};
-use super::super::{GpuError, Queue as VirtQueue, VirtioShmRegion, VIRTIO_MMIO_INT_VRING};
+use super::super::{GpuError, Queue as VirtQueue, VIRTIO_MMIO_INT_VRING};
 use super::protocol::{
     virtio_gpu_ctrl_hdr, virtio_gpu_mem_entry, GpuCommand, GpuResponse, VirtioGpuResult,
 };
@@ -24,6 +24,7 @@ use super::virtio_gpu::VirtioGpu;
 use crate::legacy::Gic;
 use crate::virtio::gpu::protocol::{VIRTIO_GPU_FLAG_FENCE, VIRTIO_GPU_FLAG_INFO_RING_IDX};
 use crate::virtio::gpu::virtio_gpu::VirtioGpuRing;
+use crate::virtio::VirtioShmRegion;
 use crate::Error as DeviceError;
 
 pub struct Worker {

--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -34,9 +34,9 @@ const MMIO_VERSION: u32 = 2;
 ///
 /// 1. Mmio reads and writes must be sent to this device at what is referred to here as MMIO base.
 /// 1. `Mmio::queue_evts` must be installed at `virtio::NOTIFY_REG_OFFSET` offset from the MMIO
-/// base. Each event in the array must be signaled if the index is written at that offset.
+///    base. Each event in the array must be signaled if the index is written at that offset.
 /// 1. `Mmio::interrupt_evt` must signal an interrupt that the guest driver is listening to when it
-/// is written to.
+///    is written to.
 ///
 /// Typically one page (4096 bytes) of MMIO address space is sufficient to handle this transport
 /// and inner virtio device.

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -136,20 +136,6 @@ impl VirtqUsedElem {
     }
 }
 
-#[cfg(any(test, feature = "test-utils"))]
-#[allow(clippy::len_without_is_empty)]
-impl VirtqUsedElem {
-    /// Get the index of the used descriptor chain.
-    pub fn id(&self) -> u32 {
-        self.id.into()
-    }
-
-    /// Get `length` field of the used ring entry.
-    pub fn len(&self) -> u32 {
-        self.len.into()
-    }
-}
-
 // SAFETY: This is safe because `VirtqUsedElem` contains only wrappers over POD types
 // and all accesses through safe `vm-memory` API will validate any garbage that could be
 // included in there.

--- a/src/devices/src/virtio/vsock/muxer_rxq.rs
+++ b/src/devices/src/virtio/vsock/muxer_rxq.rs
@@ -46,6 +46,7 @@ impl MuxerRxQ {
     /// A push will fail when:
     /// - trying to push a connection key onto an out-of-sync, or full queue; or
     /// - trying to push an RST onto a queue already full of RSTs.
+    ///
     /// RSTs take precedence over connections, because connections can always be queried for
     /// pending RX data later. Aside from this queue, there is no other storage for RSTs, so
     /// failing to push one means that we have to drop the packet.

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -7,6 +7,7 @@
 /// virtio queue:
 /// - the packet header; and
 /// - the packet data/buffer.
+///
 /// There is a 1:1 relation between descriptor chains and packets: the first (chain head) holds
 /// the header, and an optional second descriptor holds the data. The second descriptor is only
 /// present for data packets (VSOCK_OP_RW).

--- a/src/utils/src/linux/epoll.rs
+++ b/src/utils/src/linux/epoll.rs
@@ -179,11 +179,11 @@ impl Epoll {
     /// # Arguments
     ///
     /// * `max_events` is the maximum number of events that we want to be returned in
-    /// `events` buffer.
+    ///   `events` buffer.
     /// * `timeout` specifies for how long the `epoll_wait` system call will block
-    /// (measured in milliseconds).
+    ///   (measured in milliseconds).
     /// * `events` points to a memory area that will be used for storing the events
-    /// returned by `epoll_wait()` call.
+    ///   returned by `epoll_wait()` call.
     pub fn wait(
         &self,
         max_events: usize,

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -8,6 +8,9 @@
 /// Legacy Device Manager.
 pub mod legacy;
 
+/// Device Shared Memory Region Manager.
+pub mod shm;
+
 /// Memory Mapped I/O Manager.
 #[cfg(target_os = "linux")]
 pub mod kvm;

--- a/src/vmm/src/device_manager/shm.rs
+++ b/src/vmm/src/device_manager/shm.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use arch::{round_up, ArchMemoryInfo};
+use vm_memory::GuestAddress;
+
+#[derive(Debug)]
+pub enum Error {
+    DuplicatedGpuRegion,
+    OutOfSpace,
+}
+
+#[derive(Clone)]
+pub struct ShmRegion {
+    pub guest_addr: GuestAddress,
+    pub size: usize,
+}
+
+pub struct ShmManager {
+    next_guest_addr: u64,
+    page_size: usize,
+    fs_regions: HashMap<usize, ShmRegion>,
+    gpu_region: Option<ShmRegion>,
+}
+
+impl ShmManager {
+    pub fn new(info: &ArchMemoryInfo) -> ShmManager {
+        Self {
+            next_guest_addr: info.shm_start_addr,
+            page_size: info.page_size,
+            fs_regions: HashMap::new(),
+            gpu_region: None,
+        }
+    }
+
+    pub fn regions(&self) -> Vec<(GuestAddress, usize)> {
+        let mut regions: Vec<(GuestAddress, usize)> = Vec::new();
+
+        for region in self.fs_regions.iter() {
+            regions.push((region.1.guest_addr, region.1.size));
+        }
+
+        if let Some(region) = &self.gpu_region {
+            regions.push((region.guest_addr, region.size));
+        }
+
+        regions
+    }
+
+    #[cfg(not(feature = "tee"))]
+    pub fn fs_region(&self, index: usize) -> Option<&ShmRegion> {
+        self.fs_regions.get(&index)
+    }
+
+    #[cfg(feature = "gpu")]
+    pub fn gpu_region(&self) -> Option<&ShmRegion> {
+        self.gpu_region.as_ref()
+    }
+
+    fn create_region(&mut self, size: usize) -> Result<ShmRegion, Error> {
+        let size = round_up(size, self.page_size);
+
+        let region = ShmRegion {
+            guest_addr: GuestAddress(self.next_guest_addr),
+            size,
+        };
+
+        if let Some(addr) = self.next_guest_addr.checked_add(size as u64) {
+            self.next_guest_addr = addr;
+            Ok(region)
+        } else {
+            Err(Error::OutOfSpace)
+        }
+    }
+
+    pub fn create_gpu_region(&mut self, size: usize) -> Result<(), Error> {
+        if self.gpu_region.is_some() {
+            Err(Error::DuplicatedGpuRegion)
+        } else {
+            self.gpu_region = Some(self.create_region(size)?);
+            Ok(())
+        }
+    }
+
+    #[cfg(not(feature = "tee"))]
+    pub fn create_fs_region(&mut self, index: usize, size: usize) -> Result<(), Error> {
+        let region = self.create_region(size)?;
+        self.fs_regions.insert(index, region);
+        Ok(())
+    }
+}

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -52,9 +52,7 @@ use crate::terminal::term_set_canonical_mode;
 use crate::vstate::VcpuEvent;
 use crate::vstate::{Vcpu, VcpuHandle, VcpuResponse, Vm};
 
-use arch::ArchMemoryInfo;
-use arch::DeviceType;
-use arch::InitrdConfig;
+use arch::{ArchMemoryInfo, DeviceType, InitrdConfig};
 #[cfg(target_os = "macos")]
 use crossbeam_channel::Sender;
 use devices::virtio::VmmExitObserver;

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -1479,7 +1479,6 @@ enum VcpuEmulation {
 #[cfg(test)]
 mod tests {
     use crossbeam_channel::unbounded;
-    use std::fs::File;
     use std::sync::{Arc, Barrier};
 
     use super::*;
@@ -1676,24 +1675,6 @@ mod tests {
         assert!(vcpu
             .configure_aarch64(vm.fd(), &gm, GuestAddress(0))
             .is_ok());
-    }
-
-    #[test]
-    fn test_kvm_context() {
-        use std::os::unix::fs::MetadataExt;
-        use std::os::unix::io::{AsRawFd, FromRawFd};
-
-        let c = KvmContext::new().unwrap();
-
-        assert!(c.max_memslots >= 32);
-
-        let kvm = Kvm::new().unwrap();
-        let f = unsafe { File::from_raw_fd(kvm.as_raw_fd()) };
-        let m1 = f.metadata().unwrap();
-        let m2 = File::open("/dev/kvm").unwrap().metadata().unwrap();
-
-        assert_eq!(m1.dev(), m2.dev());
-        assert_eq!(m1.ino(), m2.ino());
     }
 
     #[test]

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 use super::super::{FC_EXIT_CODE_GENERIC_ERROR, FC_EXIT_CODE_OK};
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 
-use arch;
 use arch::aarch64::gic::GICDevice;
 use crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, Sender};
 use devices::legacy::{Gic, VcpuList};

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -1,52 +1,6 @@
-use std::collections::VecDeque;
-use std::fmt;
-use std::sync::{Arc, Mutex};
-
-use devices::virtio::{Fs, FsError};
-
-#[derive(Debug)]
-pub enum FsConfigError {
-    /// Failed to create the fs device.
-    CreateFsDevice(FsError),
-}
-
-impl fmt::Display for FsConfigError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use self::FsConfigError::*;
-        match *self {
-            CreateFsDevice(ref e) => write!(f, "Cannot create vsock device: {e:?}"),
-        }
-    }
-}
-
-type Result<T> = std::result::Result<T, FsConfigError>;
-
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug)]
 pub struct FsDeviceConfig {
     pub fs_id: String,
     pub shared_dir: String,
-}
-
-#[derive(Default)]
-pub struct FsBuilder {
-    pub list: VecDeque<Arc<Mutex<Fs>>>,
-}
-
-impl FsBuilder {
-    pub fn new() -> Self {
-        Self {
-            list: VecDeque::<Arc<Mutex<Fs>>>::new(),
-        }
-    }
-
-    pub fn insert(&mut self, config: FsDeviceConfig) -> Result<()> {
-        let fs_dev = Arc::new(Mutex::new(Self::create_fs(config)?));
-        self.list.push_back(fs_dev);
-        Ok(())
-    }
-
-    pub fn create_fs(config: FsDeviceConfig) -> Result<Fs> {
-        devices::virtio::Fs::new(config.fs_id, config.shared_dir)
-            .map_err(FsConfigError::CreateFsDevice)
-    }
+    pub shm_size: Option<usize>,
 }


### PR DESCRIPTION
    We have multiple devices (fs and gpu) that can use SHM regions. So far,
    we were creating a single SHM region so only one device could make use
    of it. In this commit, we implement SHM region management so multiple
    devices can request their own regions.

    For the moment, we're hardcoding the SHM region sizes for gpu and fs. A
    future commit will extend the API so users can configure those sizes as
    desired.