### PR TITLE
devices/legacy: use pl011 for earlycon in aarch64

### DIFF
--- a/src/vmm/src/device_manager/kvm/mmio.rs
+++ b/src/vmm/src/device_manager/kvm/mmio.rs
@@ -179,7 +179,10 @@ impl MMIODeviceManager {
             .map_err(Error::BusError)?;
 
         cmdline
-            .insert("earlycon", &format!("uart,mmio,0x{:08x}", self.mmio_base))
+            .insert(
+                "earlycon",
+                &format!("pl011,mmio32,0x{:08x}", self.mmio_base),
+            )
             .map_err(Error::Cmdline)?;
 
         let ret = self.mmio_base;


### PR DESCRIPTION
Follow up of 5329be7 commit. It is more common to have a PL011 than UART.