### PR TITLE
Add krun_add_disk() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,16 +40,13 @@ Each variant generates a dynamic library with a different name (and ```soname```
 
 * virtio-console
 * virtio-vsock (specialized for TSI, Transparent Socket Impersonation)
+* virtio-block
 
 ### libkrun
 
 * virtio-fs
 * virtio-balloon (only free-page reporting)
 * virtio-rng
-
-### libkrun-sev
-
-* virtio-block
 
 ## Networking
 

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -64,7 +64,7 @@ int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
 
 /**
  * Sets the path to the disk image that contains the file-system to be used as root for the microVM.
- * The only supported image format is "raw". Only available in libkrun-SEV.
+ * The only supported image format is "raw".
  *
  * Arguments:
  *  "ctx_id"    - the configuration context ID.
@@ -78,7 +78,7 @@ int32_t krun_set_root_disk(uint32_t ctx_id, const char *disk_path);
 
 /**
  * Sets the path to the disk image that contains the file-system to be used as a data partition for the microVM.
- * The only supported image format is "raw". Only available in libkrun-SEV.
+ * The only supported image format is "raw".
  *
  * Arguments:
  *  "ctx_id"    - the configuration context ID.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -63,6 +63,8 @@ int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib)
 int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
 
 /**
+ * DEPRECATED. Use krun_add_disk instead.
+ *
  * Sets the path to the disk image that contains the file-system to be used as root for the microVM.
  * The only supported image format is "raw".
  *
@@ -77,8 +79,10 @@ int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
 int32_t krun_set_root_disk(uint32_t ctx_id, const char *disk_path);
 
 /**
- * Sets the path to the disk image that contains the file-system to be used as a data partition for the microVM.
- * The only supported image format is "raw".
+ * DEPRECATED. Use krun_add_disk instead.
+ *
+ * Sets the path to the disk image that contains the file-system to be used as
+ * a data partition for the microVM.  The only supported image format is "raw".
  *
  * Arguments:
  *  "ctx_id"    - the configuration context ID.
@@ -89,6 +93,25 @@ int32_t krun_set_root_disk(uint32_t ctx_id, const char *disk_path);
  *  Zero on success or a negative error number on failure.
  */
 int32_t krun_set_data_disk(uint32_t ctx_id, const char *disk_path);
+
+/**
+ * Adds a disk image to be used as a general partition for the microVM.
+ *
+ * This API is mutually exclusive with the deprecated krun_set_root_disk and
+ * krun_set_data_disk methods and must not be used together.
+ *
+ * Arguments:
+ *  "ctx_id"    - the configuration context ID.
+ *  "block_id"  - a null-terminated string representing the partition.
+ *  "disk_path" - a null-terminated string representing the path leading to the disk image that
+ *                contains the root file-system.
+ *  "read_only" - whether the mount should be read-only. Required if the caller does not have
+ *                write permissions (for disk images in /usr/share).
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_add_disk(uint32_t ctx_id, const char *block_id, const char *disk_path, bool read_only);
 
 /**
  * NO LONGER SUPPORTED. DO NOT USE.

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -501,7 +501,6 @@ pub unsafe extern "C" fn krun_set_root_disk(ctx_id: u32, c_disk_path: *const c_c
                 cache_type: CacheType::Writeback,
                 disk_image_path: disk_path.to_string(),
                 is_disk_read_only: false,
-                is_disk_root: true,
             };
             cfg.set_root_block_cfg(block_device_config);
         }
@@ -531,7 +530,6 @@ pub unsafe extern "C" fn krun_set_data_disk(ctx_id: u32, c_disk_path: *const c_c
                 cache_type: CacheType::Writeback,
                 disk_image_path: disk_path.to_string(),
                 is_disk_read_only: false,
-                is_disk_root: false,
             };
             cfg.set_data_block_cfg(block_device_config);
         }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -490,8 +490,6 @@ pub unsafe extern "C" fn krun_set_root_disk(ctx_id: u32, c_disk_path: *const c_c
         Err(_) => return -libc::EINVAL,
     };
 
-    //let fs_id = "/dev/root".to_string();
-    //let shared_dir = root_path.to_string();
 
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
@@ -518,9 +516,6 @@ pub unsafe extern "C" fn krun_set_data_disk(ctx_id: u32, c_disk_path: *const c_c
         Ok(disk) => disk,
         Err(_) => return -libc::EINVAL,
     };
-
-    //let fs_id = "/dev/root".to_string();
-    //let shared_dir = root_path.to_string();
 
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -27,7 +27,6 @@ pub struct BlockDeviceConfig {
     pub cache_type: CacheType,
     pub disk_image_path: String,
     pub is_disk_read_only: bool,
-    pub is_disk_root: bool,
 }
 
 #[derive(Default)]


### PR DESCRIPTION
    This generalizes over krun_set_{root,data}_disk(). Notably:
    
    * It allows arbitrarily many disk images.
    * It allows mounting disks read-only.
    
    To implement, we refactor a bit the existing handling while allowing
    both APIs to be used together.

This is required to mount systemwide squashfs images which Asahi will use for FEX.