### PR TITLE
init: support other locations for krun_config

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -574,6 +574,7 @@ static int config_parse_file(char ***argv, char **workdir)
 	jsmntok_t *tokens;
 	struct stat stat;
 	char *data;
+	char *config_file;
 	char **config_argv;
 	char **entrypoint;
 	int parsed_env, parsed_workdir, parsed_args, parsed_entrypoint;
@@ -582,7 +583,12 @@ static int config_parse_file(char ***argv, char **workdir)
 	int fd;
 	int i;
 
-	fd = open(CONFIG_FILE_PATH, O_RDONLY);
+	config_file = getenv("KRUN_CONFIG");
+	if (!config_file) {
+		config_file = CONFIG_FILE_PATH;
+	}
+
+	fd = open(config_file, O_RDONLY);
 	if (fd < 0) {
 		return ret;
 	}


### PR DESCRIPTION
So far, the configuration was always expected to be in "/.krun_config.json". To support it to be located elsewhere, use the path stored in KRUN_CONFIG, falling back to the original location if not found there.