### PR TITLE
virtio, krun: Name all the worker threads

### DIFF
--- a/src/devices/src/virtio/block/worker.rs
+++ b/src/devices/src/virtio/block/worker.rs
@@ -87,7 +87,10 @@ impl BlockWorker {
     }
 
     pub fn run(self) -> thread::JoinHandle<()> {
-        thread::spawn(|| self.work())
+        thread::Builder::new()
+            .name("block worker".into())
+            .spawn(|| self.work())
+            .unwrap()
     }
 
     fn work(mut self) {

--- a/src/devices/src/virtio/console/port.rs
+++ b/src/devices/src/virtio/console/port.rs
@@ -131,18 +131,21 @@ impl Port {
             let port_id = self.port_id;
             let stopfd = stopfd.try_clone().unwrap();
             let stop = stop.clone();
-            thread::spawn(move || {
-                process_rx(
-                    mem,
-                    rx_queue,
-                    irq_signaler,
-                    input,
-                    control,
-                    port_id,
-                    stopfd,
-                    stop,
-                )
-            })
+            thread::Builder::new()
+                .name("console port".into())
+                .spawn(move || {
+                    process_rx(
+                        mem,
+                        rx_queue,
+                        irq_signaler,
+                        input,
+                        control,
+                        port_id,
+                        stopfd,
+                        stop,
+                    )
+                })
+                .unwrap()
         });
 
         let tx_thread = output.map(|output| {

--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -69,7 +69,10 @@ impl FsWorker {
     }
 
     pub fn run(self) -> thread::JoinHandle<()> {
-        thread::spawn(|| self.work())
+        thread::Builder::new()
+            .name("fs worker".into())
+            .spawn(|| self.work())
+            .unwrap()
     }
 
     fn work(mut self) {

--- a/src/devices/src/virtio/gpu/worker.rs
+++ b/src/devices/src/virtio/gpu/worker.rs
@@ -71,7 +71,10 @@ impl Worker {
     }
 
     pub fn run(self) {
-        thread::spawn(|| self.work());
+        thread::Builder::new()
+            .name("gpu worker".into())
+            .spawn(|| self.work())
+            .unwrap();
     }
 
     fn work(mut self) {

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -92,7 +92,10 @@ impl NetWorker {
     }
 
     pub fn run(self) {
-        thread::spawn(|| self.work());
+        thread::Builder::new()
+            .name("virtio-net worker".into())
+            .spawn(|| self.work())
+            .unwrap();
     }
 
     fn work(mut self) {

--- a/src/devices/src/virtio/snd/worker.rs
+++ b/src/devices/src/virtio/snd/worker.rs
@@ -126,7 +126,10 @@ impl SndWorker {
     }
 
     pub fn run(self) -> thread::JoinHandle<()> {
-        thread::spawn(|| self.work())
+        thread::Builder::new()
+            .name("virtio-snd worker".into())
+            .spawn(|| self.work())
+            .unwrap()
     }
 
     fn work(mut self) {

--- a/src/devices/src/virtio/vsock/muxer_thread.rs
+++ b/src/devices/src/virtio/vsock/muxer_thread.rs
@@ -62,7 +62,10 @@ impl MuxerThread {
     }
 
     pub fn run(self) {
-        thread::spawn(|| self.work());
+        thread::Builder::new()
+            .name("vsock muxer".into())
+            .spawn(|| self.work())
+            .unwrap();
     }
 
     fn send_credit_request(&self, credit_rx: MuxerRx) {

--- a/src/devices/src/virtio/vsock/reaper.rs
+++ b/src/devices/src/virtio/vsock/reaper.rs
@@ -66,6 +66,9 @@ impl ReaperThread {
     }
 
     pub fn run(mut self) {
-        thread::spawn(move || self.work());
+        thread::Builder::new()
+            .name("vsock reaper".into())
+            .spawn(move || self.work())
+            .unwrap();
     }
 }

--- a/src/devices/src/virtio/vsock/timesync.rs
+++ b/src/devices/src/virtio/vsock/timesync.rs
@@ -98,6 +98,9 @@ impl TimesyncThread {
     }
 
     pub fn run(mut self) {
-        thread::spawn(move || self.work());
+        thread::Builder::new()
+            .name("vsock timesync".into())
+            .spawn(move || self.work())
+            .unwrap();
     }
 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1172,19 +1172,22 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     let mapper_vmm = _vmm.clone();
 
     #[cfg(target_os = "macos")]
-    std::thread::spawn(move || loop {
-        match receiver.recv() {
-            Err(e) => error!("Error in receiver: {:?}", e),
-            Ok(m) => match m {
-                MemoryMapping::AddMapping(s, h, g, l) => {
-                    mapper_vmm.lock().unwrap().add_mapping(s, h, g, l)
-                }
-                MemoryMapping::RemoveMapping(s, g, l) => {
-                    mapper_vmm.lock().unwrap().remove_mapping(s, g, l)
-                }
-            },
-        }
-    });
+    std::thread::Builder::new()
+        .name("mapping worker".into())
+        .spawn(move || loop {
+            match receiver.recv() {
+                Err(e) => error!("Error in receiver: {:?}", e),
+                Ok(m) => match m {
+                    MemoryMapping::AddMapping(s, h, g, l) => {
+                        mapper_vmm.lock().unwrap().add_mapping(s, h, g, l)
+                    }
+                    MemoryMapping::RemoveMapping(s, g, l) => {
+                        mapper_vmm.lock().unwrap().remove_mapping(s, g, l)
+                    }
+                },
+            }
+        })
+        .unwrap();
 
     loop {
         match event_manager.run() {


### PR DESCRIPTION
Helps debugging with gdb, otherwise they inherit another thread name and it gets confusing.