### PR TITLE
virtio/fs/linux: Fix redundant close()

### DIFF
--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -1991,11 +1991,6 @@ impl FileSystem for PassthroughFs {
             return Err(io::Error::last_os_error());
         }
 
-        let ret = unsafe { libc::close(fd) };
-        if ret == -1 {
-            return Err(io::Error::last_os_error());
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
The fd is owned, so it will be closed on drop. Fixes race condition that could sometimes cause another file to be closed.