### PR TITLE
rutabaga: cross_domain: Fix EPOLLRDHUP logic

### DIFF
--- a/src/rutabaga_gfx/src/cross_domain/sys/unix.rs
+++ b/src/rutabaga_gfx/src/cross_domain/sys/unix.rs
@@ -332,7 +332,7 @@ impl WaitContext {
                 token: self.calculate_token(e.data()).unwrap(),
                 readable: e.events() & EpollFlags::EPOLLIN == EpollFlags::EPOLLIN,
                 hung_up: e.events() & EpollFlags::EPOLLHUP == EpollFlags::EPOLLHUP
-                    || e.events() & EpollFlags::EPOLLRDHUP != EpollFlags::EPOLLRDHUP,
+                    || e.events() & EpollFlags::EPOLLRDHUP == EpollFlags::EPOLLRDHUP,
             })
             .collect();
 


### PR DESCRIPTION
This was spuriously returning hung_up: true when no hangup occurred.