### PR TITLE
X11 cross-domain prep work

### DIFF
--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -7,11 +7,13 @@ use crossbeam_channel::Sender;
 #[cfg(target_os = "macos")]
 use hvf::MemoryMapping;
 
+use std::collections::BTreeMap;
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
 use std::mem;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use super::bindings;
@@ -340,6 +342,8 @@ pub struct SecContext {
     /// Actual security context
     pub secctx: Vec<u8>,
 }
+
+pub type ExportTable = Arc<Mutex<BTreeMap<(u64, u64), File>>>;
 
 /// The main trait that connects a file system with a transport.
 #[allow(unused_variables)]

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -26,8 +26,8 @@ use crate::virtio::fs::filesystem::SecContext;
 use super::super::super::linux_errno::{linux_error, LINUX_ERANGE};
 use super::super::bindings;
 use super::super::filesystem::{
-    Context, DirEntry, Entry, Extensions, FileSystem, FsOptions, GetxattrReply, ListxattrReply,
-    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+    Context, DirEntry, Entry, ExportTable, Extensions, FileSystem, FsOptions, GetxattrReply,
+    ListxattrReply, OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
 };
 use super::super::fuse;
 use super::super::multikey::MultikeyBTreeMap;
@@ -388,6 +388,11 @@ pub struct Config {
     ///
     /// The default is `None`.
     pub proc_sfd_rawfd: Option<RawFd>,
+
+    /// ID of this filesystem to uniquely identify exports. Not supported for macos.
+    pub export_fsid: u64,
+    /// Table of exported FDs to share with other subsystems. Not supported for macos.
+    pub export_table: Option<ExportTable>,
 }
 
 impl Default for Config {
@@ -400,6 +405,8 @@ impl Default for Config {
             root_dir: String::from("/"),
             xattr: true,
             proc_sfd_rawfd: None,
+            export_fsid: 0,
+            export_table: None,
         }
     }
 }

--- a/src/devices/src/virtio/fs/mod.rs
+++ b/src/devices/src/virtio/fs/mod.rs
@@ -25,6 +25,7 @@ use super::descriptor_utils;
 
 pub use self::defs::uapi::VIRTIO_ID_FS as TYPE_FS;
 pub use self::device::Fs;
+pub use self::filesystem::ExportTable;
 
 mod defs {
     pub const FS_DEV_ID: &str = "virtio_fs";

--- a/src/devices/src/virtio/gpu/worker.rs
+++ b/src/devices/src/virtio/gpu/worker.rs
@@ -22,6 +22,7 @@ use super::protocol::{
 };
 use super::virtio_gpu::VirtioGpu;
 use crate::legacy::Gic;
+use crate::virtio::fs::ExportTable;
 use crate::virtio::gpu::protocol::{VIRTIO_GPU_FLAG_FENCE, VIRTIO_GPU_FLAG_INFO_RING_IDX};
 use crate::virtio::gpu::virtio_gpu::VirtioGpuRing;
 use crate::virtio::VirtioShmRegion;
@@ -39,6 +40,7 @@ pub struct Worker {
     virgl_flags: u32,
     #[cfg(target_os = "macos")]
     map_sender: Sender<MemoryMapping>,
+    export_table: Option<ExportTable>,
 }
 
 impl Worker {
@@ -54,6 +56,7 @@ impl Worker {
         shm_region: VirtioShmRegion,
         virgl_flags: u32,
         #[cfg(target_os = "macos")] map_sender: Sender<MemoryMapping>,
+        export_table: Option<ExportTable>,
     ) -> Self {
         Self {
             receiver,
@@ -67,6 +70,7 @@ impl Worker {
             virgl_flags,
             #[cfg(target_os = "macos")]
             map_sender,
+            export_table,
         }
     }
 
@@ -88,6 +92,7 @@ impl Worker {
             self.virgl_flags,
             #[cfg(target_os = "macos")]
             self.map_sender.clone(),
+            self.export_table.take(),
         );
 
         loop {

--- a/src/rutabaga_gfx/src/cross_domain/mod.rs
+++ b/src/rutabaga_gfx/src/cross_domain/mod.rs
@@ -31,6 +31,7 @@ use crate::cross_domain::sys::Receiver;
 use crate::cross_domain::sys::Sender;
 use crate::cross_domain::sys::SystemStream;
 use crate::cross_domain::sys::WaitContext;
+use crate::rutabaga_core::ExportTable;
 use crate::rutabaga_core::RutabagaComponent;
 use crate::rutabaga_core::RutabagaContext;
 use crate::rutabaga_core::RutabagaResource;
@@ -128,6 +129,8 @@ pub(crate) struct CrossDomainContext {
     pub(crate) context_resources: CrossDomainResources,
     pub(crate) item_state: CrossDomainItemState,
     fence_handler: RutabagaFenceHandler,
+    #[allow(dead_code)]
+    export_table: Option<ExportTable>,
     worker_thread: Option<thread::JoinHandle<RutabagaResult<()>>>,
     pub(crate) resample_evt: Option<Sender>,
     kill_evt: Option<Sender>,
@@ -139,6 +142,7 @@ pub struct CrossDomain {
     channels: Option<Vec<RutabagaChannel>>,
     gralloc: Arc<Mutex<RutabagaGralloc>>,
     fence_handler: RutabagaFenceHandler,
+    export_table: Option<ExportTable>,
 }
 
 // TODO(gurchetansingh): optimize the item tracker.  Each requirements blob is long-lived and can
@@ -463,12 +467,14 @@ impl CrossDomain {
     pub fn init(
         channels: Option<Vec<RutabagaChannel>>,
         fence_handler: RutabagaFenceHandler,
+        export_table: Option<ExportTable>,
     ) -> RutabagaResult<Box<dyn RutabagaComponent>> {
         let gralloc = RutabagaGralloc::new()?;
         Ok(Box::new(CrossDomain {
             channels,
             gralloc: Arc::new(Mutex::new(gralloc)),
             fence_handler,
+            export_table,
         }))
     }
 }
@@ -967,6 +973,7 @@ impl RutabagaComponent for CrossDomain {
             worker_thread: None,
             resample_evt: None,
             kill_evt: None,
+            export_table: self.export_table.clone(),
         }))
     }
 


### PR DESCRIPTION
Prep work for the X11 channel type that does not strictly implement the code. This will be a dependency of #213.

Most of this is implementing support for sharing file handles between the FS code and the GPU code, to implement fence passing. Please let me know if this approach looks sensible.