### PR TITLE
X11 passthrough and futex sharing

### DIFF
--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -37,3 +37,6 @@ rutabaga_gfx = { path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { path = "../hvf" }
 lru = ">=0.9"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+rutabaga_gfx = { path = "../rutabaga_gfx", features = ["x"], optional = true }

--- a/src/rutabaga_gfx/ffi/src/include/rutabaga_gfx_ffi.h
+++ b/src/rutabaga_gfx/ffi/src/include/rutabaga_gfx_ffi.h
@@ -87,6 +87,7 @@ extern "C" {
  * Rutabaga channel types
  */
 #define RUTABAGA_CHANNEL_TYPE_WAYLAND 1
+#define RUTABAGA_CHANNEL_TYPE_X11 0x11
 
 /**
  * Rutabaga WSI

--- a/src/rutabaga_gfx/ffi/src/tests/virtgpu_cross_domain_protocol.h
+++ b/src/rutabaga_gfx/ffi/src/tests/virtgpu_cross_domain_protocol.h
@@ -19,6 +19,7 @@
 // Channel types (must match rutabaga channel types)
 #define CROSS_DOMAIN_CHANNEL_TYPE_WAYLAND 0x0001
 #define CROSS_DOMAIN_CHANNEL_TYPE_CAMERA 0x0002
+#define CROSS_DOMAIN_CHANNEL_TYPE_X11 0x0011
 
 // The maximum number of identifiers (value based on wp_linux_dmabuf)
 #define CROSS_DOMAIN_MAX_IDENTIFIERS 4

--- a/src/rutabaga_gfx/src/cross_domain/cross_domain_protocol.rs
+++ b/src/rutabaga_gfx/src/cross_domain/cross_domain_protocol.rs
@@ -18,10 +18,14 @@ pub const CROSS_DOMAIN_CMD_SEND: u8 = 4;
 pub const CROSS_DOMAIN_CMD_RECEIVE: u8 = 5;
 pub const CROSS_DOMAIN_CMD_READ: u8 = 6;
 pub const CROSS_DOMAIN_CMD_WRITE: u8 = 7;
+pub const CROSS_DOMAIN_CMD_FUTEX_NEW: u8 = 8;
+pub const CROSS_DOMAIN_CMD_FUTEX_SIGNAL: u8 = 9;
+pub const CROSS_DOMAIN_CMD_FUTEX_DESTROY: u8 = 10;
 
 /// Channel types (must match rutabaga channel types)
 pub const CROSS_DOMAIN_CHANNEL_TYPE_WAYLAND: u32 = 0x0001;
 pub const CROSS_DOMAIN_CHANNEL_TYPE_CAMERA: u32 = 0x0002;
+pub const CROSS_DOMAIN_CHANNEL_TYPE_X11: u32 = 0x0011;
 
 /// The maximum number of identifiers (value inspired by wp_linux_dmabuf)
 pub const CROSS_DOMAIN_MAX_IDENTIFIERS: usize = 4;
@@ -36,6 +40,8 @@ pub const CROSS_DOMAIN_ID_TYPE_READ_PIPE: u32 = 3;
 /// ID for Wayland pipe used for writing.  The writing is done by the guest and the host proxy.
 /// The host receives the write end of the pipe over the host Wayland socket.
 pub const CROSS_DOMAIN_ID_TYPE_WRITE_PIPE: u32 = 4;
+
+pub const CROSS_DOMAIN_ID_TYPE_SHM: u32 = 5;
 
 /// No ring
 pub const CROSS_DOMAIN_RING_NONE: u32 = 0xffffffff;
@@ -118,4 +124,30 @@ pub struct CrossDomainReadWrite {
     pub opaque_data_size: u32,
     pub pad: u32,
     // Data of size "opaque data size follows"
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default, AsBytes, FromBytes)]
+pub struct CrossDomainFutexNew {
+    pub hdr: CrossDomainHeader,
+    pub fs_id: u64,
+    pub handle: u64,
+    pub id: u32,
+    pub pad: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default, AsBytes, FromBytes)]
+pub struct CrossDomainFutexSignal {
+    pub hdr: CrossDomainHeader,
+    pub id: u32,
+    pub pad: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Default, AsBytes, FromBytes)]
+pub struct CrossDomainFutexDestroy {
+    pub hdr: CrossDomainHeader,
+    pub id: u32,
+    pub pad: u32,
 }

--- a/src/rutabaga_gfx/src/cross_domain/sys/unix.rs
+++ b/src/rutabaga_gfx/src/cross_domain/sys/unix.rs
@@ -47,7 +47,7 @@ use super::super::CrossDomainJob;
 use super::super::CrossDomainState;
 use super::epoll_internal::Epoll;
 use super::epoll_internal::EpollEvent;
-use crate::cross_domain::cross_domain_protocol::CrossDomainInit;
+use crate::cross_domain::cross_domain_protocol::{CrossDomainInit, CROSS_DOMAIN_ID_TYPE_SHM};
 use crate::cross_domain::CrossDomainEvent;
 use crate::cross_domain::CrossDomainToken;
 use crate::cross_domain::WAIT_CONTEXT_MAX;
@@ -232,6 +232,12 @@ impl CrossDomainContext {
                 // can receive subsequent hang-up events.
                 write_pipe_opt = Some(write_pipe);
                 read_pipe_id_opt = Some(read_pipe_id);
+            } else if *identifier_type == CROSS_DOMAIN_ID_TYPE_SHM {
+                if let Some(ftx) = self.futexes.lock().unwrap().get(identifier) {
+                    *descriptor = ftx.handle.as_raw_descriptor();
+                } else {
+                    return Err(RutabagaError::InvalidCrossDomainItemId);
+                }
             } else {
                 // Don't know how to handle anything else yet.
                 return Err(RutabagaError::InvalidCrossDomainItemType);

--- a/src/rutabaga_gfx/src/rutabaga_utils.rs
+++ b/src/rutabaga_gfx/src/rutabaga_utils.rs
@@ -599,6 +599,7 @@ impl Transfer3D {
 /// Rutabaga channel types
 pub const RUTABAGA_CHANNEL_TYPE_WAYLAND: u32 = 0x0001;
 pub const RUTABAGA_CHANNEL_TYPE_CAMERA: u32 = 0x0002;
+pub const RUTABAGA_CHANNEL_TYPE_X11: u32 = 0x0011;
 
 /// Information needed to open an OS-specific RutabagaConnection (TBD).  Only Linux hosts are
 /// considered at the moment.


### PR DESCRIPTION
Add the X11 cross domain channel type and futex sharing. This is the new approach using explicit FD passing, which depends on #231 (will rebase once that is merged). Also includes a bunch of bug fixes over the previous PR, and CI now passes. I think this should be good to start reviewing.

This approach no longer needs the `LD_PRELOAD`. You can just use nothing (the ptrace code in x112virtgpu should be more robust now), or `xshmwrap` (packaged with x112virgpu) to avoid the ptrace hack. I also sent a [PR](https://gitlab.freedesktop.org/xorg/lib/libxshmfence/-/merge_requests/9) upstream to libxshmfence so we can do this with a simple env var in the future, without hacks.

Compared to #213, this removes the rootfs DAX enablement, but I think @slp wants to do the DAX toggle another way anyway. DAX is still required for /dev/shm for any of this to work, but best keep that out of the scope of this PR.

Supersedes #213.