### PR TITLE
hvf: ensure vcpus run in the right thread

### DIFF
--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -267,6 +267,14 @@ impl HvfVcpu<'_> {
             return Err(Error::VcpuCreate);
         }
 
+        // We write vcpuid to Aff1 as otherwise it won't match the redistributor ID
+        // when using HVF in-kernel GICv3.
+        let ret =
+            unsafe { hv_vcpu_set_sys_reg(vcpuid, hv_sys_reg_t_HV_SYS_REG_MPIDR_EL1, vcpuid << 8) };
+        if ret != HV_SUCCESS {
+            return Err(Error::VcpuCreate);
+        }
+
         let vcpu_exit: &hv_vcpu_exit_t = unsafe { vcpu_exit_ptr.as_mut().unwrap() };
 
         Ok(Self {


### PR DESCRIPTION
For correctness and to support IPIs in future GICv3 implementations, we need to ensure each HVF vCPU runs in the right thread, so their respective IDs match each other.

We can't supply an ID to hv_vcpu_create. Instead, it'll return an incremental integer each time we call it. In order to have deterministic IDs, we need to serialize each call.

As we already have a Sender for notifying each vCPU TLS initialization, let's reuse and simply deplay writting to it until hv_vcpu_create has been called.

While there, also set MPIDR to the same vCPU ID, as this will be needed to properly support the in-kernel HVF GICv3 implementation.