### PR TITLE
Update SEV-SNP implementation to run on upstream kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
  "polly",
  "rand",
  "rutabaga_gfx",
- "thiserror",
+ "thiserror 1.0.69",
  "utils",
  "virtio-bindings",
  "vm-memory",
@@ -689,13 +689,15 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21350cefefc9715198c3c5319a5eb23ce4cc89b4b567599fb88f0d4a011c1d2d"
+checksum = "f7b7dad1b68c1fee4a7749f9163f4ac7c7f9cd21df3f6dcc5790f8978e12ccf1"
 dependencies = [
+ "base64",
  "serde",
  "serde_json",
  "sev",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -1021,7 +1023,7 @@ dependencies = [
  "nix 0.27.1",
  "once_cell",
  "pipewire-sys",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1138,7 +1140,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1213,7 +1215,7 @@ dependencies = [
  "nix 0.26.4",
  "pkg-config",
  "remain",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
  "zerocopy 0.6.6",
 ]
@@ -1300,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "sev"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97bd0b2e2d937951add10c8512a2dacc6ad29b39e5c5f26565a3e443329857d"
+checksum = "b06afe5192a43814047ea0072f4935f830a1de3c8cb43b56c90ae6918468b94d"
 dependencies = [
  "base64",
  "bincode",
@@ -1413,7 +1415,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
+dependencies = [
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
@@ -1421,6 +1432,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,7 +1593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1720e7240cdc739f935456eb77f370d7e9b2a3909204da1e2b47bef1137a013"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
  "winapi",
 ]
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -28,12 +28,12 @@ polly = { path = "../polly" }
 
 # Dependencies for amd-sev
 codicon = { version = "3.0.0", optional = true }
-kbs-types = { version = "0.8.0", features = ["tee-sev", "tee-snp"], optional = true }
+kbs-types = { version = "0.9.2", features = ["tee-sev", "tee-snp"], optional = true }
 procfs = { version = "0.12", optional = true }
 rdrand = { version = "^0.8", optional = true }
 serde = { version = "1.0.125", optional = true }
 serde_json = { version = "1.0.64", optional = true }
-sev = { version = "4.0.0", features = ["openssl"], optional = true }
+sev = { version = "5.0.0", features = ["openssl"], optional = true }
 curl = { version = "0.4", optional = true }
 nix = "0.24.1"
 

--- a/src/vmm/src/linux/tee/amdsnp.rs
+++ b/src/vmm/src/linux/tee/amdsnp.rs
@@ -9,7 +9,10 @@ use arch::x86_64::layout::*;
 use sev::firmware::{guest::GuestPolicy, host::Firmware};
 use sev::launch::snp::*;
 
-use kvm_bindings::{kvm_enc_region, CpuId, KVM_CPUID_FLAG_SIGNIFCANT_INDEX};
+use kvm_bindings::{
+    kvm_create_guest_memfd, kvm_userspace_memory_region2, CpuId, KVM_CPUID_FLAG_SIGNIFCANT_INDEX,
+    KVM_MEM_GUEST_MEMFD,
+};
 use kvm_ioctls::VmFd;
 use vm_memory::{
     Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
@@ -86,23 +89,43 @@ impl AmdSnp {
         vm_fd: &VmFd,
         guest_mem: &GuestMemoryMmap,
     ) -> Result<Launcher<Started, RawFd, RawFd>, Error> {
+        for region in guest_mem.iter() {
+            // It's safe to unwrap because the guest address is valid.
+            let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap();
+
+            // Create guest_memfd struct.
+            let gmem = kvm_create_guest_memfd {
+                size: region.len(),
+                flags: 0, //Unused.
+                reserved: [0; 6],
+            };
+
+            // Create KVM guest_memfd.
+            let fd = vm_fd.create_guest_memfd(gmem).unwrap();
+
+            // Create memory region.
+            let mem_region = kvm_userspace_memory_region2 {
+                slot: 0,
+                flags: KVM_MEM_GUEST_MEMFD,
+                guest_phys_addr: region.start_addr().0,
+                memory_size: region.len(),
+                userspace_addr: host_addr as u64,
+                guest_memfd_offset: 0,
+                guest_memfd: fd as u32,
+                pad1: 0,
+                pad2: [0; 14],
+            };
+
+            // Set the memory region.
+            unsafe {
+                vm_fd.set_user_memory_region2(mem_region).unwrap();
+            }
+        }
+
         let vm_rfd = vm_fd.as_raw_fd();
         let fw_rfd = self.fw.as_raw_fd();
 
         let launcher = Launcher::new(vm_rfd, fw_rfd).map_err(Error::CreateLauncher)?;
-
-        for region in guest_mem.iter() {
-            // It's safe to unwrap because the guest address is valid.
-            let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap();
-            let enc_region = kvm_enc_region {
-                addr: host_addr as u64,
-                size: region.len(),
-            };
-
-            vm_fd
-                .register_enc_memory_region(&enc_region)
-                .map_err(|_| Error::MemoryEncryptRegion)?;
-        }
 
         let mut policy = GuestPolicy(0);
         policy.set_smt_allowed(1);

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -507,8 +507,12 @@ impl Vm {
 
     #[cfg(feature = "amd-sev")]
     pub fn new(kvm: &Kvm, tee_config: &TeeConfig) -> Result<Self> {
+        const KVM_X86_SNP_VM: u64 = 4;
+
         //create fd for interacting with kvm-vm specific functions
-        let vm_fd = kvm.create_vm().map_err(Error::VmFd)?;
+        let vm_fd = kvm
+            .create_vm_with_type(KVM_X86_SNP_VM)
+            .map_err(Error::VmFd)?;
 
         let supported_cpuid = kvm
             .get_supported_cpuid(KVM_MAX_CPUID_ENTRIES)


### PR DESCRIPTION
Modify the SEV-SNP launch implementation to:

- Create VMs with the KVM_X86_SNP_VM type.
- Use KVM guest_memfd for memory regions.
- Use KVM_SET_USER_MEMORY_REGION2.
- Update the sev library dependency to 5.0.0.

With this, libkrun should be able to run on stock Linux kernels with version >= 6.11. Still completing some testing. Once tested, I will mark this PR as ready for review.