### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "libkrun"
-version = "1.9.8"
+version = "1.10.0"
 dependencies = [
  "crossbeam-channel",
  "devices",

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 LIBRARY_HEADER = include/libkrun.h
 
 ABI_VERSION=1
-FULL_VERSION=1.9.8
+FULL_VERSION=1.10.0
 
 INIT_SRC = init/init.c
 KBS_INIT_SRC =	init/tee/kbs/kbs.h		\

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.9.8"
+version = "1.10.0"
 authors = ["Sergio Lopez <slp@redhat.com>"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
This version includes a new GICv3 for macOS and a new API for using qcow2 disks based on the imago crate. I think these changes justify bumping the minor number too.