### PR TITLE
net: Allow creating vsocks in listen mode.

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -441,6 +441,21 @@ int32_t krun_set_tee_config_file(uint32_t ctx_id, const char *filepath);
 int32_t krun_add_vsock_port(uint32_t ctx_id,
                             uint32_t port,
                             const char *c_filepath);
+
+/**
+ * Adds a port-path pairing for guest IPC with a process in the host.
+ *
+ * Arguments:
+ *  "ctx_id"    - the configuration context ID.
+ *  "port"      - a vsock port that the guest will connect to for IPC.
+ *  "filepath"  - a null-terminated string representing the path of the UNIX
+ *                socket in the host.
+ *  "listen"    - true if guest expects connections to be initiated from host side
+ */
+int32_t krun_add_vsock_port2(uint32_t ctx_id,
+                             uint32_t port,
+                             const char *c_filepath,
+                             bool listen);
 /**
  * Returns the eventfd file descriptor to signal the guest to shut down orderly. This must be
  * called before starting the microVM with "krun_start_event". Only available in libkrun-efi.

--- a/src/devices/src/virtio/vsock/device.rs
+++ b/src/devices/src/virtio/vsock/device.rs
@@ -59,7 +59,7 @@ impl Vsock {
         cid: u64,
         host_port_map: Option<HashMap<u16, u16>>,
         queues: Vec<VirtQueue>,
-        unix_ipc_port_map: Option<HashMap<u32, PathBuf>>,
+        unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     ) -> super::Result<Vsock> {
         let mut queue_events = Vec::new();
         for _ in 0..queues.len() {
@@ -103,7 +103,7 @@ impl Vsock {
     pub fn new(
         cid: u64,
         host_port_map: Option<HashMap<u16, u16>>,
-        unix_ipc_port_map: Option<HashMap<u32, PathBuf>>,
+        unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     ) -> super::Result<Vsock> {
         let queues: Vec<VirtQueue> = defs::QUEUE_SIZES
             .iter()

--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -42,11 +42,18 @@ pub enum ProxyRemoval {
 }
 
 #[derive(Default)]
+pub enum NewProxyType {
+    #[default]
+    Tcp,
+    Unix,
+}
+
+#[derive(Default)]
 pub struct ProxyUpdate {
     pub signal_queue: bool,
     pub remove_proxy: ProxyRemoval,
     pub polling: Option<(u64, RawFd, EventSet)>,
-    pub new_proxy: Option<(u32, RawFd)>,
+    pub new_proxy: Option<(u32, RawFd, NewProxyType)>,
     pub push_accept: Option<(u64, u64)>,
     pub push_credit_req: Option<MuxerRx>,
 }

--- a/src/devices/src/virtio/vsock/tcp.rs
+++ b/src/devices/src/virtio/vsock/tcp.rs
@@ -21,7 +21,9 @@ use super::muxer_rxq::MuxerRxQ;
 use super::packet::{
     TsiAcceptReq, TsiConnectReq, TsiGetnameRsp, TsiListenReq, TsiSendtoAddr, VsockPacket,
 };
-use super::proxy::{Proxy, ProxyError, ProxyRemoval, ProxyStatus, ProxyUpdate, RecvPkt};
+use super::proxy::{
+    NewProxyType, Proxy, ProxyError, ProxyRemoval, ProxyStatus, ProxyUpdate, RecvPkt,
+};
 use utils::epoll::EventSet;
 
 use vm_memory::GuestMemoryMmap;
@@ -729,7 +731,7 @@ impl Proxy for TcpProxy {
             {
                 match accept(self.fd) {
                     Ok(accept_fd) => {
-                        update.new_proxy = Some((self.peer_port, accept_fd));
+                        update.new_proxy = Some((self.peer_port, accept_fd, NewProxyType::Tcp));
                     }
                     Err(e) => warn!("error accepting connection: id={}, err={}", self.id, e),
                 };

--- a/src/vmm/src/vmm_config/vsock.rs
+++ b/src/vmm/src/vmm_config/vsock.rs
@@ -39,7 +39,7 @@ pub struct VsockDeviceConfig {
     /// An optional map of host to guest port mappings.
     pub host_port_map: Option<HashMap<u16, u16>>,
     /// An optional map of guest port to host UNIX domain sockets for IPC.
-    pub unix_ipc_port_map: Option<HashMap<u32, PathBuf>>,
+    pub unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
 }
 
 struct VsockWrapper {


### PR DESCRIPTION
Previously all vsocks were expected to be connected from the guest. This patch adds support for sockets that are listened to by the guest and are connected from the host.