### PR TITLE
Add pipewire cross domain channel type.

### DIFF
--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -24,8 +24,8 @@ use rutabaga_gfx::{
 };
 #[cfg(target_os = "linux")]
 use rutabaga_gfx::{
-    RUTABAGA_CHANNEL_TYPE_X11, RUTABAGA_MAP_ACCESS_MASK, RUTABAGA_MAP_ACCESS_READ,
-    RUTABAGA_MAP_ACCESS_RW, RUTABAGA_MAP_ACCESS_WRITE,
+    RUTABAGA_CHANNEL_TYPE_PW, RUTABAGA_CHANNEL_TYPE_X11, RUTABAGA_MAP_ACCESS_MASK,
+    RUTABAGA_MAP_ACCESS_READ, RUTABAGA_MAP_ACCESS_RW, RUTABAGA_MAP_ACCESS_WRITE,
 };
 use utils::eventfd::EventFd;
 use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, VolatileSlice};
@@ -209,6 +209,19 @@ impl VirtioGpu {
                     channel_type: RUTABAGA_CHANNEL_TYPE_X11,
                 });
             }
+        }
+        #[cfg(target_os = "linux")]
+        if let Ok(pw_sock_dir) = env::var("PIPEWIRE_RUNTIME_DIR")
+            .or_else(|_| env::var("XDG_RUNTIME_DIR"))
+            .or_else(|_| env::var("USERPROFILE"))
+        {
+            let name = env::var("PIPEWIRE_REMOTE").unwrap_or_else(|_| "pipewire-0".to_string());
+            let mut pw_path = PathBuf::from(pw_sock_dir);
+            pw_path.push(name);
+            rutabaga_channels.push(RutabagaChannel {
+                base_channel: pw_path,
+                channel_type: RUTABAGA_CHANNEL_TYPE_PW,
+            });
         }
         let rutabaga_channels_opt = Some(rutabaga_channels);
 

--- a/src/rutabaga_gfx/ffi/src/include/rutabaga_gfx_ffi.h
+++ b/src/rutabaga_gfx/ffi/src/include/rutabaga_gfx_ffi.h
@@ -87,6 +87,7 @@ extern "C" {
  * Rutabaga channel types
  */
 #define RUTABAGA_CHANNEL_TYPE_WAYLAND 1
+#define RUTABAGA_CHANNEL_TYPE_PW 0x10
 #define RUTABAGA_CHANNEL_TYPE_X11 0x11
 
 /**

--- a/src/rutabaga_gfx/ffi/src/tests/virtgpu_cross_domain_protocol.h
+++ b/src/rutabaga_gfx/ffi/src/tests/virtgpu_cross_domain_protocol.h
@@ -19,6 +19,7 @@
 // Channel types (must match rutabaga channel types)
 #define CROSS_DOMAIN_CHANNEL_TYPE_WAYLAND 0x0001
 #define CROSS_DOMAIN_CHANNEL_TYPE_CAMERA 0x0002
+#define CROSS_DOMAIN_CHANNEL_TYPE_PW 0x0010
 #define CROSS_DOMAIN_CHANNEL_TYPE_X11 0x0011
 
 // The maximum number of identifiers (value based on wp_linux_dmabuf)

--- a/src/rutabaga_gfx/src/cross_domain/sys/mod.rs
+++ b/src/rutabaga_gfx/src/cross_domain/sys/mod.rs
@@ -18,7 +18,6 @@ cfg_if::cfg_if! {
 pub use platform::channel;
 pub use platform::channel_signal;
 pub use platform::channel_wait;
-pub use platform::descriptor_analysis;
 pub use platform::read_volatile;
 pub use platform::write_volatile;
 pub use platform::Receiver;

--- a/src/rutabaga_gfx/src/cross_domain/sys/stub.rs
+++ b/src/rutabaga_gfx/src/cross_domain/sys/stub.rs
@@ -3,9 +3,10 @@
 // found in the LICENSE file.
 
 use std::fs::File;
+use std::sync::Arc;
 
-use super::super::cross_domain_protocol::CrossDomainInit;
-use super::super::cross_domain_protocol::CrossDomainSendReceive;
+use super::super::cross_domain_protocol::CrossDomainInitV1;
+use super::super::cross_domain_protocol::CrossDomainSendReceiveBase;
 use super::super::CrossDomainContext;
 use super::super::CrossDomainState;
 use crate::cross_domain::CrossDomainEvent;
@@ -16,17 +17,8 @@ use crate::rutabaga_utils::RutabagaResult;
 pub struct Stub(());
 pub type SystemStream = Stub;
 
-// Determine type of OS-specific descriptor.
-pub fn descriptor_analysis(
-    _descriptor: &mut File,
-    _descriptor_type: &mut u32,
-    _size: &mut u32,
-) -> RutabagaResult<()> {
-    Err(RutabagaError::Unsupported)
-}
-
 impl CrossDomainState {
-    pub(crate) fn receive_msg(
+    pub(crate) fn receive_msg<const MAX_IDENTIFIERS: usize>(
         &self,
         _opaque_data: &mut [u8],
     ) -> RutabagaResult<(usize, Vec<File>)> {
@@ -37,14 +29,14 @@ impl CrossDomainState {
 impl CrossDomainContext {
     pub(crate) fn get_connection(
         &mut self,
-        _cmd_init: &CrossDomainInit,
+        _cmd_init: &CrossDomainInitV1,
     ) -> RutabagaResult<Option<SystemStream>> {
         Err(RutabagaError::Unsupported)
     }
 
-    pub(crate) fn send(
+    pub(crate) fn send<T: CrossDomainSendReceiveBase, const MAX_IDENTIFIERS: usize>(
         &self,
-        _cmd_send: &CrossDomainSendReceive,
+        _cmd_send: &mut T,
         _opaque_data: &[u8],
     ) -> RutabagaResult<()> {
         Err(RutabagaError::Unsupported)
@@ -79,6 +71,7 @@ pub type WaitContext = Stub;
 pub trait WaitTrait {}
 impl WaitTrait for Stub {}
 impl WaitTrait for &Stub {}
+impl WaitTrait for Arc<Stub> {}
 impl WaitTrait for File {}
 impl WaitTrait for &File {}
 impl WaitTrait for &mut File {}

--- a/src/rutabaga_gfx/src/rutabaga_utils.rs
+++ b/src/rutabaga_gfx/src/rutabaga_utils.rs
@@ -599,6 +599,7 @@ impl Transfer3D {
 /// Rutabaga channel types
 pub const RUTABAGA_CHANNEL_TYPE_WAYLAND: u32 = 0x0001;
 pub const RUTABAGA_CHANNEL_TYPE_CAMERA: u32 = 0x0002;
+pub const RUTABAGA_CHANNEL_TYPE_PW: u32 = 0x0010;
 pub const RUTABAGA_CHANNEL_TYPE_X11: u32 = 0x0011;
 
 /// Information needed to open an OS-specific RutabagaConnection (TBD).  Only Linux hosts are


### PR DESCRIPTION
This extends the already existing wayland/x11 cross domain channel to also work for sharing pipewire between host and guest. The necessary changes are eventfd support (inspired by how wayland pipes are handled), a few fixes to sharing shm buffers, and a new protocol version that supports more fds per message (pw can sometimes send more than 4). 