### PR TITLE
Don't use SO_REUSEPORT with UNIX sockets

### DIFF
--- a/src/devices/src/virtio/net/gvproxy.rs
+++ b/src/devices/src/virtio/net/gvproxy.rs
@@ -50,7 +50,6 @@ impl Gvproxy {
             Err(e) => error!("couldn't obtain fd flags id={}, err={}", fd, e),
         };
 
-        setsockopt(fd, sockopt::ReusePort, &true).unwrap();
         #[cfg(target_os = "macos")]
         {
             // nix doesn't provide an abstraction for SO_NOSIGPIPE, fall back to libc.

--- a/src/devices/src/virtio/vsock/unix.rs
+++ b/src/devices/src/virtio/vsock/unix.rs
@@ -5,8 +5,8 @@ use super::{
 
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::sys::socket::{
-    accept, bind, connect, listen, recv, send, setsockopt, shutdown, socket, sockopt,
-    AddressFamily, MsgFlags, Shutdown, SockFlag, SockType, UnixAddr,
+    accept, bind, connect, listen, recv, send, shutdown, socket, AddressFamily, MsgFlags, Shutdown,
+    SockFlag, SockType, UnixAddr,
 };
 use nix::unistd::close;
 use std::collections::HashMap;
@@ -68,7 +68,6 @@ fn proxy_fd_create(id: u64) -> Result<RawFd, ProxyError> {
         Err(e) => error!("couldn't obtain fd flags id={}, err={}", id, e),
     };
 
-    setsockopt(fd, sockopt::ReusePort, &true).map_err(ProxyError::SettingReusePort)?;
     #[cfg(target_os = "macos")]
     {
         // nix doesn't provide an abstraction for SO_NOSIGPIPE, fall back to libc.


### PR DESCRIPTION
It's invalid, useless, and will generate an error from 6.12.9 onwards:

https://lore.kernel.org/all/20241231160527.3994168-1-edumazet@google.com/

Fixes: #250
Suggested-by: Janne Grunau <j@jannau.net>