### PR TITLE
virtio/snd: fix leftovers after gicv3 switch

### DIFF
--- a/src/devices/src/virtio/snd/audio_backends.rs
+++ b/src/devices/src/virtio/snd/audio_backends.rs
@@ -11,6 +11,7 @@ use super::{stream::Stream, BackendType, Result, VirtioSndPcmSetParams};
 pub trait AudioBackend {
     fn write(&self, stream_id: u32) -> Result<()>;
 
+    #[allow(dead_code)]
     fn read(&self, stream_id: u32) -> Result<()>;
 
     fn set_parameters(&self, _stream_id: u32, _: VirtioSndPcmSetParams) -> Result<()> {

--- a/src/devices/src/virtio/snd/device.rs
+++ b/src/devices/src/virtio/snd/device.rs
@@ -1,6 +1,6 @@
 use std::io::Write;
 use std::sync::atomic::AtomicUsize;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::thread::JoinHandle;
 
 use utils::eventfd::EventFd;
@@ -180,7 +180,7 @@ impl VirtioDevice for Snd {
             queue_evts,
             self.interrupt_status.clone(),
             self.interrupt_evt.try_clone().unwrap(),
-            self.intc,
+            self.intc.clone(),
             self.irq_line,
             mem.clone(),
             self.worker_stopfd.try_clone().unwrap(),

--- a/src/devices/src/virtio/snd/mod.rs
+++ b/src/devices/src/virtio/snd/mod.rs
@@ -22,7 +22,7 @@ use virtio_sound::*;
 
 use super::{Descriptor, Queue};
 use crate::{
-    legacy::Gic,
+    legacy::GicV3,
     virtio::{
         snd::virtio_sound::{VirtioSoundHeader, VirtioSoundPcmStatus},
         VIRTIO_MMIO_INT_VRING,


### PR DESCRIPTION
The fact that we haven't noticed until now makes me wonder if we really need device (muvm switched to pipeware pass-through via vsock quite a while ago).