### PR TITLE
Support loading external kernels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,6 +191,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "bzip2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafdbf26611df8c14810e268ddceda071c297570a5fb360ceddf617fe417ef58"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -206,6 +227,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -689,6 +712,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -830,6 +862,15 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "linux-loader"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "870c3814345f050991f99869417779f6062542bcf4ed81db7a1b926ad1306638"
+dependencies = [
+ "vm-memory",
 ]
 
 [[package]]
@@ -1591,18 +1632,21 @@ name = "vmm"
 version = "0.1.0"
 dependencies = [
  "arch",
+ "bzip2",
  "codicon",
  "cpuid",
  "crossbeam-channel",
  "curl",
  "devices",
  "env_logger",
+ "flate2",
  "hvf",
  "kbs-types",
  "kernel",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
+ "linux-loader",
  "log",
  "nix 0.24.3",
  "polly",
@@ -1614,6 +1658,7 @@ dependencies = [
  "utils",
  "vm-memory",
  "vmm-sys-util",
+ "zstd",
 ]
 
 [[package]]
@@ -1933,4 +1978,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -764,6 +764,7 @@ dependencies = [
  "env_logger",
  "hvf",
  "libc",
+ "libloading",
  "log",
  "once_cell",
  "polly",

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -11,7 +11,7 @@ ROOTFS_DIR = rootfs_$(ROOTFS_DISTRO)
 
 .PHONY: clean rootfs
 
-EXAMPLES := chroot_vm
+EXAMPLES := chroot_vm external_kernel
 ifeq ($(SEV),1)
     EXAMPLES := launch-tee
 endif
@@ -36,6 +36,12 @@ ifeq ($(OS),Darwin)
 	codesign --entitlements chroot_vm.entitlements --force -s - $@
 endif
 
+external_kernel: external_kernel.c
+	gcc -o $@ $< $(CFLAGS) $(LDFLAGS_$(ARCH)_$(OS))
+ifeq ($(OS),Darwin)
+	codesign --entitlements chroot_vm.entitlements --force -s - $@
+endif
+
 # Build the rootfs to be used with chroot_vm.
 rootfs:
 	mkdir -p $(ROOTFS_DIR)
@@ -44,4 +50,4 @@ rootfs:
 	podman rm libkrun_chroot_vm
 
 clean:
-	rm -rf chroot_vm $(ROOTFS_DIR) launch-tee boot_efi
+	rm -rf chroot_vm $(ROOTFS_DIR) launch-tee boot_efi external_kernel

--- a/examples/external_kernel.c
+++ b/examples/external_kernel.c
@@ -1,0 +1,321 @@
+/*
+ * This is an example implementing chroot-like functionality with libkrun.
+ *
+ * It executes the requested command (relative to NEWROOT) inside a fresh
+ * Virtual Machine created and managed by libkrun.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <libkrun.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <pthread.h>
+
+#define MAX_ARGS_LEN 4096
+#ifndef MAX_PATH
+#define MAX_PATH 4096
+#endif
+
+enum net_mode
+{
+    NET_MODE_PASST = 0,
+    NET_MODE_TSI,
+};
+
+#if defined(__x86_64__)
+#define KERNEL_FORMAT KRUN_KERNEL_FORMAT_ELF
+#else
+#define KERNEL_FORMAT KRUN_KERNEL_FORMAT_RAW
+#endif
+
+static void print_help(char *const name)
+{
+    fprintf(stderr,
+            "Usage: %s [OPTIONS] KERNEL\n"
+            "OPTIONS: \n"
+            "        -b    --boot-disk           Path to a boot disk in raw format\n"
+            "        -c    --kernel-cmdline      Kernel command line\n"
+            "        -d    --data-disk           Path to a data disk in raw format\n"
+            "        -h    --help                Show help\n"
+            "        -i    --initrd              Path to initramfs\n"
+            "              --net=NET_MODE        Set network mode\n"
+            "              --passt-socket=PATH   Connect to passt socket at PATH"
+            "\n"
+            "NET_MODE can be either TSI (default) or PASST\n"
+            "\n"
+#if defined(__x86_64__)
+            "KERNEL:   path to the kernel image in ELF format\n",
+#else
+            "KERNEL:   path to the kernel image in RAW format\n",
+#endif
+            name);
+}
+
+static const struct option long_options[] = {
+    {"boot-disk", required_argument, NULL, 'b'},
+    {"kernel-cmdline", required_argument, NULL, 'c'},
+    {"data-disk", required_argument, NULL, 'd'},
+    {"initrd-path", required_argument, NULL, 'i'},
+    {"help", no_argument, NULL, 'h'},
+    {"passt-socket", required_argument, NULL, 'P'},
+    {NULL, 0, NULL, 0}};
+
+struct cmdline
+{
+    bool show_help;
+    enum net_mode net_mode;
+    char const *boot_disk;
+    char const *data_disk;
+    char const *passt_socket_path;
+    char const *kernel_path;
+    char const *kernel_cmdline;
+    char const *initrd_path;
+};
+
+bool parse_cmdline(int argc, char *const argv[], struct cmdline *cmdline)
+{
+    assert(cmdline != NULL);
+
+    // set the defaults
+    *cmdline = (struct cmdline){
+        .show_help = false,
+        .net_mode = NET_MODE_TSI,
+        .passt_socket_path = "/tmp/network.sock",
+        .boot_disk = NULL,
+        .data_disk = NULL,
+        .kernel_path = NULL,
+        .kernel_cmdline = NULL,
+        .initrd_path = NULL,
+    };
+
+    int option_index = 0;
+    int c;
+    // the '+' in optstring is a GNU extension that disables permutating argv
+    while ((c = getopt_long(argc, argv, "+hb:c:d:i:", long_options, &option_index)) != -1)
+    {
+        switch (c)
+        {
+        case 'b':
+            cmdline->boot_disk = optarg;
+            break;
+        case 'c':
+            cmdline->kernel_cmdline = optarg;
+            break;
+        case 'd':
+            cmdline->data_disk = optarg;
+            break;
+        case 'h':
+            cmdline->show_help = true;
+            return true;
+        case 'i':
+            cmdline->initrd_path = optarg;
+            break;
+        case 'P':
+            cmdline->passt_socket_path = optarg;
+            break;
+        case '?':
+            return false;
+        default:
+            fprintf(stderr, "internal argument parsing error (returned character code 0x%x)\n", c);
+            return false;
+        }
+    }
+
+    if (optind <= argc - 1)
+    {
+        cmdline->kernel_path = argv[optind];
+        return true;
+    }
+
+    if (optind == argc)
+    {
+        fprintf(stderr, "Missing KERNEL argument\n");
+    }
+
+    return false;
+}
+
+int connect_to_passt(char *socket_path)
+{
+    struct sockaddr_un addr;
+    int socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (socket_fd < 0)
+    {
+        perror("Failed to create passt socket fd");
+        return -1;
+    }
+
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+
+    if (connect(socket_fd, (const struct sockaddr *)&addr, sizeof(addr)) < 0)
+    {
+        perror("Failed to bind passt socket");
+        return -1;
+    }
+
+    return socket_fd;
+}
+
+int start_passt()
+{
+    int socket_fds[2];
+    const int PARENT = 0;
+    const int CHILD = 1;
+
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds) < 0)
+    {
+        perror("Failed to create passt socket fd");
+        return -1;
+    }
+
+    int pid = fork();
+    if (pid < 0)
+    {
+        perror("fork");
+        return -1;
+    }
+
+    if (pid == 0)
+    { // child
+        if (close(socket_fds[PARENT]) < 0)
+        {
+            perror("close PARENT");
+        }
+
+        char fd_as_str[16];
+        snprintf(fd_as_str, sizeof(fd_as_str), "%d", socket_fds[CHILD]);
+
+        printf("passing fd %s to passt", fd_as_str);
+
+        if (execlp("passt", "passt", "-f", "--fd", fd_as_str, NULL) < 0)
+        {
+            perror("execlp");
+            return -1;
+        }
+    }
+    else
+    { // parent
+        if (close(socket_fds[CHILD]) < 0)
+        {
+            perror("close CHILD");
+        }
+
+        return socket_fds[PARENT];
+    }
+}
+
+int main(int argc, char *const argv[])
+{
+    int ctx_id;
+    int err;
+    pthread_t thread;
+    struct cmdline cmdline;
+
+    if (!parse_cmdline(argc, argv, &cmdline))
+    {
+        putchar('\n');
+        print_help(argv[0]);
+        return -1;
+    }
+
+    if (cmdline.show_help)
+    {
+        print_help(argv[0]);
+        return 0;
+    }
+
+    // Set the log level to "off".
+    err = krun_set_log_level(0);
+    if (err)
+    {
+        errno = -err;
+        perror("Error configuring log level");
+        return -1;
+    }
+
+    // Create the configuration context.
+    ctx_id = krun_create_ctx();
+    if (ctx_id < 0)
+    {
+        errno = -ctx_id;
+        perror("Error creating configuration context");
+        return -1;
+    }
+
+    // Configure the number of vCPUs (2) and the amount of RAM (1024 MiB).
+    if (err = krun_set_vm_config(ctx_id, 2, 2048))
+    {
+        errno = -err;
+        perror("Error configuring the number of vCPUs and/or the amount of RAM");
+        return -1;
+    }
+
+    if (cmdline.boot_disk)
+    {
+        if (err = krun_add_disk(ctx_id, "boot", cmdline.boot_disk, 0))
+        {
+            errno = -err,
+            perror("Error configuring boot disk");
+            return -1;
+        }
+    }
+    if (cmdline.data_disk)
+    {
+        if (err = krun_add_disk(ctx_id, "data", cmdline.data_disk, 0))
+        {
+            errno = -err,
+            perror("Error configuring data disk");
+            return -1;
+        }
+    }
+
+    if (cmdline.net_mode == NET_MODE_PASST)
+    {
+        int passt_fd = cmdline.passt_socket_path ? connect_to_passt(cmdline.passt_socket_path) : start_passt();
+
+        if (passt_fd < 0)
+        {
+            return -1;
+        }
+
+        if (err = krun_set_passt_fd(ctx_id, passt_fd))
+        {
+            errno = -err;
+            perror("Error configuring net mode");
+            return -1;
+        }
+    }
+
+    fprintf(stderr, "kernel_path: %s\n", cmdline.kernel_path);
+    fprintf(stderr, "kernel_cmdline: %s\n", cmdline.kernel_cmdline);
+    fflush(stderr);
+
+    if (err = krun_set_kernel(ctx_id, cmdline.kernel_path, KERNEL_FORMAT,
+                              cmdline.initrd_path, cmdline.kernel_cmdline))
+    {
+        errno = -err;
+        perror("Error configuring kernel");
+        return -1;
+    }
+
+    // Start and enter the microVM. Unless there is some error while creating the microVM
+    // this function never returns.
+    if (err = krun_start_enter(ctx_id))
+    {
+        errno = -err;
+        perror("Error creating the microVM");
+        return -1;
+    }
+
+    // Not reached.
+    return 0;
+}

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -403,18 +403,26 @@ int32_t krun_set_exec(uint32_t ctx_id,
                       const char *const argv[],
                       const char *const envp[]);
 
+#define KRUN_KERNEL_FORMAT_RAW 0
+#define KRUN_KERNEL_FORMAT_ELF 1
+#define KRUN_KERNEL_FORMAT_PE_GZ 2
+#define KRUN_KERNEL_FORMAT_IMAGE_BZ2 3
+#define KRUN_KERNEL_FORMAT_IMAGE_GZ 4
+#define KRUN_KERNEL_FORMAT_IMAGE_ZSTD 5
 /**
  * Sets the path to the kernel to be loaded in the microVM.
  *
  * Arguments:
- *  "ctx_id"    - the configuration context ID.
- *  "kernel_path" - the path to the kernel, relative to the host's filesystem.
+ *  "ctx_id"        - the configuration context ID.
+ *  "kernel_path"   - the path to the kernel, relative to the host's filesystem.
+ *  "kernel_format" - the kernel format.
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
  */
 int32_t krun_set_kernel(uint32_t ctx_id,
-                        const char *kernel_path);
+                        const char *kernel_path,
+                        uint32_t kernel_format);
 
 /**
  * Sets environment variables to be configured in the context of the executable.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -404,6 +404,19 @@ int32_t krun_set_exec(uint32_t ctx_id,
                       const char *const envp[]);
 
 /**
+ * Sets the path to the kernel to be loaded in the microVM.
+ *
+ * Arguments:
+ *  "ctx_id"    - the configuration context ID.
+ *  "kernel_path" - the path to the kernel, relative to the host's filesystem.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_kernel(uint32_t ctx_id,
+                        const char *kernel_path);
+
+/**
  * Sets environment variables to be configured in the context of the executable.
  *
  * Arguments:

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -416,13 +416,17 @@ int32_t krun_set_exec(uint32_t ctx_id,
  *  "ctx_id"        - the configuration context ID.
  *  "kernel_path"   - the path to the kernel, relative to the host's filesystem.
  *  "kernel_format" - the kernel format.
+ *  "initramfs"     - the path to the initramfs, relative to the host's filesystem.
+ *  "cmdline"       - the kernel command line.
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
  */
 int32_t krun_set_kernel(uint32_t ctx_id,
                         const char *kernel_path,
-                        uint32_t kernel_format);
+                        uint32_t kernel_format,
+                        const char *initramfs,
+                        const char *cmdline);
 
 /**
  * Sets environment variables to be configured in the context of the executable.

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -47,7 +47,10 @@ use crate::DeviceType;
 
 /// Returns a Vec of the valid memory addresses for aarch64.
 /// See [`layout`](layout) module for a drawing of the specific memory model for this platform.
-pub fn arch_memory_regions(size: usize) -> (ArchMemoryInfo, Vec<(GuestAddress, usize)>) {
+pub fn arch_memory_regions(
+    size: usize,
+    initrd_size: u64,
+) -> (ArchMemoryInfo, Vec<(GuestAddress, usize)>) {
     let page_size: usize = unsafe { libc::sysconf(libc::_SC_PAGESIZE).try_into().unwrap() };
     let dram_size = round_up(size, page_size);
     let ram_last_addr = layout::DRAM_MEM_START + (dram_size as u64);
@@ -57,6 +60,7 @@ pub fn arch_memory_regions(size: usize) -> (ArchMemoryInfo, Vec<(GuestAddress, u
         ram_last_addr,
         shm_start_addr,
         page_size,
+        initrd_addr: ram_last_addr - layout::FDT_MAX_SIZE as u64 - initrd_size,
     };
     let regions = if cfg!(feature = "efi") {
         vec![

--- a/src/arch/src/lib.rs
+++ b/src/arch/src/lib.rs
@@ -12,6 +12,7 @@ pub struct ArchMemoryInfo {
     pub ram_last_addr: u64,
     pub shm_start_addr: u64,
     pub page_size: usize,
+    pub initrd_addr: u64,
 }
 
 /// Module for aarch64 related functionality.

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -19,6 +19,7 @@ virgl_resource_map2 = []
 crossbeam-channel = "0.5"
 env_logger = "0.9.0"
 libc = ">=0.2.39"
+libloading = "0.8"
 log = "0.4.0"
 once_cell = "1.4.1"
 

--- a/src/libkrun/build.rs
+++ b/src/libkrun/build.rs
@@ -1,10 +1,4 @@
 fn main() {
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-lib=framework=Hypervisor");
-    #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-search=/opt/homebrew/lib");
-    #[cfg(all(not(feature = "tee"), not(feature = "efi")))]
-    println!("cargo:rustc-link-lib=krunfw");
-    #[cfg(feature = "tee")]
-    println!("cargo:rustc-link-lib=krunfw-sev");
 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1082,7 +1082,7 @@ fn create_virtio_net(ctx_cfg: &mut ContextConfig, backend: VirtioNetBackend) {
 }
 
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
-fn map_kernel(ctx_id: u32, kernel_path: &str) -> i32 {
+fn map_kernel(ctx_id: u32, kernel_path: &PathBuf) -> i32 {
     let file = match File::options().read(true).write(false).open(kernel_path) {
         Ok(file) => file,
         Err(err) => {
@@ -1143,9 +1143,11 @@ pub unsafe extern "C" fn krun_set_kernel(
     ctx_id: u32,
     c_kernel_path: *const c_char,
     kernel_format: u32,
+    c_initramfs_path: *const c_char,
+    c_cmdline: *const c_char,
 ) -> i32 {
-    let kernel_path = match CStr::from_ptr(c_kernel_path).to_str() {
-        Ok(path) => path,
+    let path = match CStr::from_ptr(c_kernel_path).to_str() {
+        Ok(path) => PathBuf::from(path),
         Err(e) => {
             error!("Error parsing kernel_path: {:?}", e);
             return -libc::EINVAL;
@@ -1156,7 +1158,7 @@ pub unsafe extern "C" fn krun_set_kernel(
         // For raw kernels in x86_64, we map the kernel into the
         // process and treat it as a bundled kernel.
         #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
-        0 => return map_kernel(ctx_id, kernel_path),
+        0 => return map_kernel(ctx_id, &path),
         #[cfg(target_arch = "aarch64")]
         0 => KernelFormat::Raw,
         1 => KernelFormat::Elf,
@@ -1169,9 +1171,46 @@ pub unsafe extern "C" fn krun_set_kernel(
         }
     };
 
+    let (initramfs_path, initramfs_size) = if !c_initramfs_path.is_null() {
+        match CStr::from_ptr(c_initramfs_path).to_str() {
+            Ok(path) => {
+                let path = PathBuf::from(path);
+                let size = match std::fs::metadata(&path) {
+                    Ok(metadata) => metadata.len(),
+                    Err(e) => {
+                        error!("Can't read initramfs metadata: {:?}", e);
+                        return -libc::EINVAL;
+                    }
+                };
+                (Some(path), size)
+            }
+            Err(e) => {
+                error!("Error parsing initramfs path: {:?}", e);
+                return -libc::EINVAL;
+            }
+        }
+    } else {
+        (None, 0)
+    };
+
+    let cmdline = if !c_cmdline.is_null() {
+        match CStr::from_ptr(c_cmdline).to_str() {
+            Ok(cmdline) => Some(cmdline.to_string()),
+            Err(e) => {
+                error!("Error parsing kernel cmdline: {:?}", e);
+                return -libc::EINVAL;
+            }
+        }
+    } else {
+        None
+    };
+
     let external_kernel = ExternalKernel {
-        path: PathBuf::from(kernel_path),
+        path,
         format,
+        initramfs_path,
+        initramfs_size,
+        cmdline,
     };
 
     match CTX_MAP.lock().unwrap().entry(ctx_id) {

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -8,9 +8,9 @@ use std::env;
 use std::ffi::CStr;
 #[cfg(target_os = "linux")]
 use std::ffi::CString;
-#[cfg(all(target_arch = "aarch64", not(feature = "efi")))]
+#[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
 use std::fs::File;
-#[cfg(not(feature = "efi"))]
+#[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 use std::os::fd::RawFd;
 use std::path::PathBuf;
@@ -41,6 +41,8 @@ use vmm::resources::VmResources;
 #[cfg(feature = "blk")]
 use vmm::vmm_config::block::BlockDeviceConfig;
 use vmm::vmm_config::boot_source::{BootSourceConfig, DEFAULT_KERNEL_CMDLINE};
+#[cfg(not(feature = "tee"))]
+use vmm::vmm_config::external_kernel::{ExternalKernel, KernelFormat};
 #[cfg(not(feature = "tee"))]
 use vmm::vmm_config::fs::FsDeviceConfig;
 #[cfg(not(feature = "efi"))]
@@ -150,8 +152,6 @@ struct ContextConfig {
     gpu_shm_size: Option<usize>,
     enable_snd: bool,
     console_output: Option<PathBuf>,
-    #[cfg(not(feature = "efi"))]
-    external_kernel: bool,
 }
 
 impl ContextConfig {
@@ -1081,27 +1081,8 @@ fn create_virtio_net(ctx_cfg: &mut ContextConfig, backend: VirtioNetBackend) {
         .expect("Failed to create network interface");
 }
 
-#[cfg(any(target_arch = "x86_64", feature = "tee", feature = "efi"))]
-#[allow(clippy::format_collect)]
-#[allow(clippy::missing_safety_doc)]
-#[no_mangle]
-pub unsafe extern "C" fn krun_set_kernel(_ctx_id: u32, _c_kernel_path: *const c_char) -> i32 {
-    -libc::EOPNOTSUPP
-}
-
-#[cfg(all(target_arch = "aarch64", not(feature = "efi")))]
-#[allow(clippy::format_collect)]
-#[allow(clippy::missing_safety_doc)]
-#[no_mangle]
-pub unsafe extern "C" fn krun_set_kernel(ctx_id: u32, c_kernel_path: *const c_char) -> i32 {
-    let kernel_path = match CStr::from_ptr(c_kernel_path).to_str() {
-        Ok(path) => path,
-        Err(e) => {
-            error!("Error parsing kernel_path: {:?}", e);
-            return -libc::EINVAL;
-        }
-    };
-
+#[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
+fn map_kernel(ctx_id: u32, kernel_path: &str) -> i32 {
     let file = match File::options().read(true).write(false).open(kernel_path) {
         Ok(file) => file,
         Err(err) => {
@@ -1135,16 +1116,66 @@ pub unsafe extern "C" fn krun_set_kernel(ctx_id: u32, c_kernel_path: *const c_ch
     };
 
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
-        Entry::Occupied(mut ctx_cfg) => {
-            let ctx_cfg = ctx_cfg.get_mut();
-            if ctx_cfg.external_kernel {
-                error!("An extenal kernel was already configured");
-                return -libc::EINVAL;
-            } else {
-                ctx_cfg.external_kernel = true;
-            }
-            ctx_cfg.vmr.set_kernel_bundle(kernel_bundle).unwrap()
+        Entry::Occupied(mut ctx_cfg) => ctx_cfg
+            .get_mut()
+            .vmr
+            .set_kernel_bundle(kernel_bundle)
+            .unwrap(),
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[cfg(feature = "tee")]
+#[allow(clippy::format_collect)]
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_set_kernel(_ctx_id: u32, _c_kernel_path: *const c_char) -> i32 {
+    -libc::EOPNOTSUPP
+}
+
+#[cfg(not(feature = "tee"))]
+#[allow(clippy::format_collect)]
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_set_kernel(
+    ctx_id: u32,
+    c_kernel_path: *const c_char,
+    kernel_format: u32,
+) -> i32 {
+    let kernel_path = match CStr::from_ptr(c_kernel_path).to_str() {
+        Ok(path) => path,
+        Err(e) => {
+            error!("Error parsing kernel_path: {:?}", e);
+            return -libc::EINVAL;
         }
+    };
+
+    let format = match kernel_format {
+        // For raw kernels in x86_64, we map the kernel into the
+        // process and treat it as a bundled kernel.
+        #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
+        0 => return map_kernel(ctx_id, kernel_path),
+        #[cfg(target_arch = "aarch64")]
+        0 => KernelFormat::Raw,
+        1 => KernelFormat::Elf,
+        2 => KernelFormat::PeGz,
+        3 => KernelFormat::ImageBz2,
+        4 => KernelFormat::ImageGz,
+        5 => KernelFormat::ImageZstd,
+        _ => {
+            return -libc::EINVAL;
+        }
+    };
+
+    let external_kernel = ExternalKernel {
+        path: PathBuf::from(kernel_path),
+        format,
+    };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => ctx_cfg.get_mut().vmr.set_external_kernel(external_kernel),
         Entry::Vacant(_) => return -libc::ENOENT,
     }
 
@@ -1221,7 +1252,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     };
 
     #[cfg(not(feature = "efi"))]
-    if !ctx_cfg.external_kernel {
+    if ctx_cfg.vmr.external_kernel.is_none() && ctx_cfg.vmr.kernel_bundle.is_none() {
         if let Some(ref krunfw) = ctx_cfg.krunfw {
             if let Err(err) = unsafe { load_krunfw_payload(krunfw, &mut ctx_cfg.vmr) } {
                 eprintln!("Can't load libkrunfw symbols: {err}");

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -8,7 +8,9 @@ use std::env;
 use std::ffi::CStr;
 #[cfg(target_os = "linux")]
 use std::ffi::CString;
-#[cfg(target_os = "linux")]
+#[cfg(all(target_arch = "aarch64", not(feature = "efi")))]
+use std::fs::File;
+#[cfg(not(feature = "efi"))]
 use std::os::fd::AsRawFd;
 use std::os::fd::RawFd;
 use std::path::PathBuf;
@@ -60,7 +62,7 @@ const MAX_ARGS: usize = 4096;
 const KRUNFW_NAME: &str = "libkrunfw.so.4";
 #[cfg(all(target_os = "linux", feature = "amd-sev"))]
 const KRUNFW_NAME: &str = "libkrunfw-sev.so.4";
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(feature = "efi")))]
 const KRUNFW_NAME: &str = "libkrunfw.4.dylib";
 
 // Path to the init binary to be executed inside the VM.
@@ -148,6 +150,8 @@ struct ContextConfig {
     gpu_shm_size: Option<usize>,
     enable_snd: bool,
     console_output: Option<PathBuf>,
+    #[cfg(not(feature = "efi"))]
+    external_kernel: bool,
 }
 
 impl ContextConfig {
@@ -1077,6 +1081,77 @@ fn create_virtio_net(ctx_cfg: &mut ContextConfig, backend: VirtioNetBackend) {
         .expect("Failed to create network interface");
 }
 
+#[cfg(any(target_arch = "x86_64", feature = "tee", feature = "efi"))]
+#[allow(clippy::format_collect)]
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_set_kernel(_ctx_id: u32, _c_kernel_path: *const c_char) -> i32 {
+    -libc::EOPNOTSUPP
+}
+
+#[cfg(all(target_arch = "aarch64", not(feature = "efi")))]
+#[allow(clippy::format_collect)]
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_set_kernel(ctx_id: u32, c_kernel_path: *const c_char) -> i32 {
+    let kernel_path = match CStr::from_ptr(c_kernel_path).to_str() {
+        Ok(path) => path,
+        Err(e) => {
+            error!("Error parsing kernel_path: {:?}", e);
+            return -libc::EINVAL;
+        }
+    };
+
+    let file = match File::options().read(true).write(false).open(kernel_path) {
+        Ok(file) => file,
+        Err(err) => {
+            error!("Error opening external kernel: {err}");
+            return -libc::EINVAL;
+        }
+    };
+
+    let kernel_size = file.metadata().unwrap().len();
+
+    let kernel_host_addr = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            kernel_size as usize,
+            libc::PROT_READ,
+            libc::MAP_SHARED,
+            file.as_raw_fd(),
+            0_i64,
+        )
+    };
+    if kernel_host_addr == libc::MAP_FAILED {
+        error!("Can't load kernel into process map");
+        return -libc::EINVAL;
+    }
+
+    let kernel_bundle = KernelBundle {
+        host_addr: kernel_host_addr as u64,
+        guest_addr: 0x8000_0000,
+        entry_addr: 0x8000_0000,
+        size: kernel_size as usize,
+    };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let ctx_cfg = ctx_cfg.get_mut();
+            if ctx_cfg.external_kernel {
+                error!("An extenal kernel was already configured");
+                return -libc::EINVAL;
+            } else {
+                ctx_cfg.external_kernel = true;
+            }
+            ctx_cfg.vmr.set_kernel_bundle(kernel_bundle).unwrap()
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[cfg(not(feature = "efi"))]
 unsafe fn load_krunfw_payload(
     krunfw: &KrunfwBindings,
     vmr: &mut VmResources,
@@ -1107,7 +1182,7 @@ unsafe fn load_krunfw_payload(
             host_addr: qboot_host_addr as u64,
             size: qboot_size,
         };
-        ctx_cfg.vmr.set_qboot_bundle(qboot_bundle).unwrap();
+        vmr.set_qboot_bundle(qboot_bundle).unwrap();
 
         let mut initrd_size: usize = 0;
         let initrd_host_addr = unsafe { (krunfw.get_initrd)(&mut initrd_size as *mut usize) };
@@ -1115,7 +1190,7 @@ unsafe fn load_krunfw_payload(
             host_addr: initrd_host_addr as u64,
             size: initrd_size,
         };
-        ctx_cfg.vmr.set_initrd_bundle(initrd_bundle).unwrap();
+        vmr.set_initrd_bundle(initrd_bundle).unwrap();
     }
 
     Ok(())
@@ -1145,14 +1220,17 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         None => return -libc::ENOENT,
     };
 
-    if let Some(ref krunfw) = ctx_cfg.krunfw {
-        if let Err(err) = unsafe { load_krunfw_payload(krunfw, &mut ctx_cfg.vmr) } {
-            eprintln!("Can't load libkrunfw symbols: {err}");
+    #[cfg(not(feature = "efi"))]
+    if !ctx_cfg.external_kernel {
+        if let Some(ref krunfw) = ctx_cfg.krunfw {
+            if let Err(err) = unsafe { load_krunfw_payload(krunfw, &mut ctx_cfg.vmr) } {
+                eprintln!("Can't load libkrunfw symbols: {err}");
+                return -libc::ENOENT;
+            }
+        } else {
+            eprintln!("Couldn't find or load {}", KRUNFW_NAME);
             return -libc::ENOENT;
         }
-    } else {
-        eprintln!("Couldn't find or load {}", KRUNFW_NAME);
-        return -libc::ENOENT;
     }
 
     #[cfg(feature = "blk")]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -16,7 +16,9 @@ snd = []
 [dependencies]
 crossbeam-channel = "0.5"
 env_logger = "0.9.0"
+flate2 = "1.0.35"
 libc = ">=0.2.39"
+linux-loader = { version = "0.13.0", features = ["bzimage", "elf", "pe"] }
 log = "0.4.0"
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
 
@@ -38,7 +40,9 @@ curl = { version = "0.4", optional = true }
 nix = "0.24.1"
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
+bzip2 = "0.5"
 cpuid = { path = "../cpuid" }
+zstd = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.10", features = ["fam-wrappers"] }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -5,6 +5,7 @@
 
 #[cfg(target_os = "macos")]
 use crossbeam_channel::{unbounded, Sender};
+use kernel::cmdline::Cmdline;
 use std::fmt::{Display, Formatter};
 use std::fs::File;
 use std::io::{self, Read};
@@ -51,9 +52,7 @@ use crate::vstate::KvmContext;
 #[cfg(all(target_os = "linux", feature = "tee"))]
 use crate::vstate::MeasuredRegion;
 use crate::vstate::{Error as VstateError, Vcpu, VcpuConfig, Vm};
-use arch::ArchMemoryInfo;
-#[cfg(feature = "tee")]
-use arch::InitrdConfig;
+use arch::{ArchMemoryInfo, InitrdConfig};
 use device_manager::shm::ShmManager;
 #[cfg(not(feature = "tee"))]
 use devices::virtio::{fs::ExportTable, VirtioShmRegion};
@@ -70,7 +69,6 @@ use utils::eventfd::EventFd;
 use vm_memory::mmap::MmapRegion;
 #[cfg(not(feature = "tee"))]
 use vm_memory::Address;
-#[cfg(any(target_arch = "aarch64", feature = "tee"))]
 use vm_memory::Bytes;
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
 use vm_memory::GuestRegionMmap;
@@ -490,7 +488,7 @@ pub fn build_microvm(
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     let payload = choose_payload(vm_resources)?;
 
-    let (guest_memory, entry_addr, arch_memory_info, mut _shm_manager) = create_guest_memory(
+    let (guest_memory, arch_memory_info, mut _shm_manager, payload_config) = create_guest_memory(
         vm_resources
             .vm_config()
             .mem_size_mib
@@ -502,11 +500,14 @@ pub fn build_microvm(
 
     // Clone the command-line so that a failed boot doesn't pollute the original.
     #[allow(unused_mut)]
-    let mut kernel_cmdline = kernel::cmdline::Cmdline::new(arch::CMDLINE_MAX_SIZE);
-    match &vm_resources.boot_config.kernel_cmdline_prolog {
-        None => kernel_cmdline.insert_str(DEFAULT_KERNEL_CMDLINE).unwrap(),
-        Some(s) => kernel_cmdline.insert_str(s).unwrap(),
-    };
+    let mut kernel_cmdline = Cmdline::new(arch::CMDLINE_MAX_SIZE);
+    if let Some(cmdline) = payload_config.kernel_cmdline {
+        kernel_cmdline.insert_str(cmdline.as_str()).unwrap();
+    } else if let Some(cmdline) = &vm_resources.boot_config.kernel_cmdline_prolog {
+        kernel_cmdline.insert_str(cmdline).unwrap();
+    } else {
+        kernel_cmdline.insert_str(DEFAULT_KERNEL_CMDLINE).unwrap();
+    }
 
     #[cfg(not(feature = "tee"))]
     #[allow(unused_mut)]
@@ -548,8 +549,9 @@ pub fn build_microvm(
             } else {
                 return Err(StartMicrovmError::MissingKernelConfig);
             };
-        let initrd_size = if let Some(initrd_bundle) = &vm_resources.initrd_bundle {
-            initrd_bundle.size
+        let (initrd_addr, initrd_size) = if let Some(initrd_config) = &payload_config.initrd_config
+        {
+            (initrd_config.address, initrd_config.size)
         } else {
             return Err(StartMicrovmError::MissingKernelConfig);
         };
@@ -570,10 +572,8 @@ pub fn build_microvm(
                 size: kernel_size,
             },
             MeasuredRegion {
-                guest_addr: arch::x86_64::layout::INITRD_SEV_START,
-                host_addr: guest_memory
-                    .get_host_address(GuestAddress(arch::x86_64::layout::INITRD_SEV_START))
-                    .unwrap() as u64,
+                guest_addr: initrd_addr.0,
+                host_addr: guest_memory.get_host_address(initrd_addr).unwrap() as u64,
                 size: initrd_size,
             },
             MeasuredRegion {
@@ -649,7 +649,7 @@ pub fn build_microvm(
             &vm,
             &vcpu_config,
             &guest_memory,
-            entry_addr,
+            payload_config.entry_addr,
             &pio_device_manager.io_bus,
             &exit_evt,
         )
@@ -662,8 +662,14 @@ pub fn build_microvm(
     // Search for `kvm_arch_vcpu_create` in arch/arm/kvm/arm.c.
     #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
     {
-        vcpus = create_vcpus_aarch64(&vm, &vcpu_config, &guest_memory, entry_addr, &exit_evt)
-            .map_err(StartMicrovmError::Internal)?;
+        vcpus = create_vcpus_aarch64(
+            &vm,
+            &vcpu_config,
+            &guest_memory,
+            payload_config.entry_addr,
+            &exit_evt,
+        )
+        .map_err(StartMicrovmError::Internal)?;
 
         setup_interrupt_controller(&mut vm, vcpu_config.vcpu_count)?;
         attach_legacy_devices(
@@ -680,7 +686,7 @@ pub fn build_microvm(
             &vm,
             &vcpu_config,
             &guest_memory,
-            entry_addr,
+            payload_config.entry_addr,
             &exit_evt,
             vcpu_list.clone(),
         )
@@ -787,30 +793,9 @@ pub fn build_microvm(
     #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
     load_cmdline(&vmm)?;
 
-    #[cfg(feature = "tee")]
-    let initrd_config = {
-        match payload {
-            Payload::Tee => {
-                let initrd_size = if let Some(initrd_bundle) = &vm_resources.initrd_bundle {
-                    initrd_bundle.size
-                } else {
-                    return Err(StartMicrovmError::MissingKernelConfig);
-                };
-                Some(InitrdConfig {
-                    address: GuestAddress(arch::x86_64::layout::INITRD_SEV_START),
-                    size: initrd_size,
-                })
-            }
-            _ => return Err(StartMicrovmError::MissingKernelConfig),
-        }
-    };
-
-    #[cfg(not(feature = "tee"))]
-    let initrd_config = None;
-
     vmm.configure_system(
         vcpus.as_slice(),
-        &initrd_config,
+        &payload_config.initrd_config,
         &vm_resources.smbios_oem_strings,
     )
     .map_err(StartMicrovmError::Internal)?;
@@ -855,8 +840,9 @@ pub fn build_microvm(
 
 fn load_external_kernel(
     guest_mem: &GuestMemoryMmap,
+    arch_mem_info: &ArchMemoryInfo,
     external_kernel: &ExternalKernel,
-) -> std::result::Result<GuestAddress, StartMicrovmError> {
+) -> std::result::Result<(GuestAddress, Option<InitrdConfig>, Option<String>), StartMicrovmError> {
     let entry_addr = match external_kernel.format {
         // Raw images are treated as bundled kernels on x86_64
         #[cfg(target_arch = "x86_64")]
@@ -982,14 +968,36 @@ fn load_external_kernel(
 
     debug!("load_external_kernel: 0x{:x}", entry_addr.0);
 
-    Ok(entry_addr)
+    let initrd_config = if let Some(initramfs_path) = &external_kernel.initramfs_path {
+        let data = std::fs::read(initramfs_path).map_err(StartMicrovmError::InitrdRead)?;
+        guest_mem
+            .write(&data, GuestAddress(arch_mem_info.initrd_addr))
+            .unwrap();
+        Some(InitrdConfig {
+            address: GuestAddress(arch_mem_info.initrd_addr),
+            size: data.len(),
+        })
+    } else {
+        None
+    };
+
+    Ok((entry_addr, initrd_config, external_kernel.cmdline.clone()))
 }
 
 fn load_payload(
     _vm_resources: &VmResources,
     guest_mem: GuestMemoryMmap,
+    _arch_mem_info: &ArchMemoryInfo,
     payload: &Payload,
-) -> std::result::Result<(GuestMemoryMmap, GuestAddress), StartMicrovmError> {
+) -> std::result::Result<
+    (
+        GuestMemoryMmap,
+        GuestAddress,
+        Option<InitrdConfig>,
+        Option<String>,
+    ),
+    StartMicrovmError,
+> {
     match payload {
         #[cfg(target_arch = "aarch64")]
         Payload::KernelCopy => {
@@ -1010,7 +1018,7 @@ fn load_payload(
             guest_mem
                 .write(kernel_data, GuestAddress(kernel_guest_addr))
                 .unwrap();
-            Ok((guest_mem, GuestAddress(kernel_entry_addr)))
+            Ok((guest_mem, GuestAddress(kernel_entry_addr), None, None))
         }
         #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
         Payload::KernelMmap => {
@@ -1039,14 +1047,17 @@ fn load_payload(
                     ))
                     .map_err(StartMicrovmError::GuestMemoryMmap)?,
                 GuestAddress(kernel_entry_addr),
+                None,
+                None,
             ))
         }
         Payload::ExternalKernel(external_kernel) => {
-            let entry_addr = load_external_kernel(&guest_mem, external_kernel)?;
-            Ok((guest_mem, entry_addr))
+            let (entry_addr, initrd_config, cmdline) =
+                load_external_kernel(&guest_mem, _arch_mem_info, external_kernel)?;
+            Ok((guest_mem, entry_addr, initrd_config, cmdline))
         }
         #[cfg(test)]
-        Payload::Empty => Ok((guest_mem, GuestAddress(0))),
+        Payload::Empty => Ok((guest_mem, GuestAddress(0), None, None)),
         #[cfg(feature = "tee")]
         Payload::Tee => {
             let (kernel_host_addr, kernel_guest_addr, kernel_size) =
@@ -1086,17 +1097,25 @@ fn load_payload(
             let initrd_data =
                 unsafe { std::slice::from_raw_parts(initrd_host_addr as *mut u8, initrd_size) };
             guest_mem
-                .write(
-                    initrd_data,
-                    GuestAddress(arch::x86_64::layout::INITRD_SEV_START),
-                )
+                .write(initrd_data, GuestAddress(_arch_mem_info.initrd_addr))
                 .unwrap();
-            Ok((guest_mem, GuestAddress(arch::RESET_VECTOR)))
+
+            let initrd_config = InitrdConfig {
+                address: GuestAddress(_arch_mem_info.initrd_addr),
+                size: initrd_data.len(),
+            };
+
+            Ok((
+                guest_mem,
+                GuestAddress(arch::RESET_VECTOR),
+                Some(initrd_config),
+                None,
+            ))
         }
         #[cfg(feature = "efi")]
         Payload::Efi => {
             guest_mem.write(EDK2_BINARY, GuestAddress(0u64)).unwrap();
-            Ok((guest_mem, GuestAddress(0)))
+            Ok((guest_mem, GuestAddress(0), None, None))
         }
         #[cfg(not(feature = "efi"))]
         Payload::Efi => {
@@ -1105,12 +1124,18 @@ fn load_payload(
     }
 }
 
+struct PayloadConfig {
+    entry_addr: GuestAddress,
+    initrd_config: Option<InitrdConfig>,
+    kernel_cmdline: Option<String>,
+}
+
 fn create_guest_memory(
     mem_size: usize,
     vm_resources: &VmResources,
     payload: &Payload,
 ) -> std::result::Result<
-    (GuestMemoryMmap, GuestAddress, ArchMemoryInfo, ShmManager),
+    (GuestMemoryMmap, ArchMemoryInfo, ShmManager, PayloadConfig),
     StartMicrovmError,
 > {
     let mem_size = mem_size << 20;
@@ -1125,10 +1150,11 @@ fn create_guest_memory(
                 } else {
                     return Err(StartMicrovmError::MissingKernelConfig);
                 };
-            arch::arch_memory_regions(mem_size, Some(kernel_guest_addr), kernel_size)
+            arch::arch_memory_regions(mem_size, Some(kernel_guest_addr), kernel_size, 0)
         }
-        #[cfg(not(feature = "efi"))]
-        Payload::ExternalKernel(_kernel_path) => arch::arch_memory_regions(mem_size, None, 0),
+        Payload::ExternalKernel(external_kernel) => {
+            arch::arch_memory_regions(mem_size, None, 0, external_kernel.initramfs_size)
+        }
         #[cfg(feature = "tee")]
         Payload::Tee => {
             let (kernel_guest_addr, kernel_size) =
@@ -1137,13 +1163,19 @@ fn create_guest_memory(
                 } else {
                     return Err(StartMicrovmError::MissingKernelConfig);
                 };
-            arch::arch_memory_regions(mem_size, Some(kernel_guest_addr), kernel_size)
+            arch::arch_memory_regions(mem_size, Some(kernel_guest_addr), kernel_size, 0)
         }
         #[cfg(test)]
-        Payload::Empty => arch::arch_memory_regions(mem_size, None, 0),
+        Payload::Empty => arch::arch_memory_regions(mem_size, None, 0, 0),
+        Payload::Efi => unreachable!(),
     };
     #[cfg(target_arch = "aarch64")]
-    let (arch_mem_info, mut arch_mem_regions) = arch::arch_memory_regions(mem_size);
+    let (arch_mem_info, mut arch_mem_regions) = match payload {
+        Payload::ExternalKernel(external_kernel) => {
+            arch::arch_memory_regions(mem_size, external_kernel.initramfs_size)
+        }
+        _ => arch::arch_memory_regions(mem_size, 0),
+    };
 
     let mut shm_manager = ShmManager::new(&arch_mem_info);
 
@@ -1167,9 +1199,16 @@ fn create_guest_memory(
     let guest_mem = GuestMemoryMmap::from_ranges(&arch_mem_regions)
         .map_err(StartMicrovmError::GuestMemoryMmap)?;
 
-    let (guest_mem, entry_addr) = load_payload(vm_resources, guest_mem, payload)?;
+    let (guest_mem, entry_addr, initrd_config, cmdline) =
+        load_payload(vm_resources, guest_mem, &arch_mem_info, payload)?;
 
-    Ok((guest_mem, entry_addr, arch_mem_info, shm_manager))
+    let payload_config = PayloadConfig {
+        entry_addr,
+        initrd_config,
+        kernel_cmdline: cmdline.clone(),
+    };
+
+    Ok((guest_mem, arch_mem_info, shm_manager, payload_config))
 }
 
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
@@ -1847,23 +1886,23 @@ fn attach_snd_device(
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::vmm_config::kernel_bundle::KernelBundle;
 
     fn default_guest_memory(
         mem_size_mib: usize,
-    ) -> std::result::Result<(GuestMemoryMmap, ArchMemoryInfo, ShmManager), StartMicrovmError> {
-        let kernel_guest_addr: u64 = 0x1000;
-        let kernel_size: usize = 0x1000;
-        let kernel_host_addr: u64 = 0x1000;
+    ) -> std::result::Result<
+        (GuestMemoryMmap, ArchMemoryInfo, ShmManager, PayloadConfig),
+        StartMicrovmError,
+    > {
+        let mut vm_resources = VmResources::default();
+        vm_resources.kernel_bundle = Some(KernelBundle {
+            host_addr: 0x1000,
+            guest_addr: 0x1000,
+            entry_addr: 0x1000,
+            size: 0x1000,
+        });
 
-        let kernel_region = unsafe {
-            MmapRegion::build_raw(kernel_host_addr as *mut _, kernel_size, 0, 0).unwrap()
-        };
-
-        create_guest_memory(
-            mem_size_mib,
-            None,
-            Payload::KernelMmap(kernel_region, kernel_guest_addr, kernel_size),
-        )
+        create_guest_memory(mem_size_mib, &vm_resources, &Payload::KernelMmap)
     }
 
     #[test]
@@ -1871,7 +1910,8 @@ pub mod tests {
     fn test_create_vcpus_x86_64() {
         let vcpu_count = 2;
 
-        let (guest_memory, _arch_memory_info, _shm_manager) = default_guest_memory(128).unwrap();
+        let (guest_memory, _arch_memory_info, _shm_manager, _payload_config) =
+            default_guest_memory(128).unwrap();
         let mut vm = setup_vm(&guest_memory).unwrap();
         setup_interrupt_controller(&mut vm).unwrap();
         let vcpu_config = VcpuConfig {

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -18,6 +18,7 @@ use kbs_types::Tee;
 #[cfg(feature = "blk")]
 use crate::vmm_config::block::{BlockBuilder, BlockConfigError, BlockDeviceConfig};
 use crate::vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
+use crate::vmm_config::external_kernel::ExternalKernel;
 #[cfg(not(feature = "tee"))]
 use crate::vmm_config::fs::*;
 #[cfg(feature = "tee")]
@@ -85,6 +86,8 @@ pub struct VmResources {
     pub boot_config: BootSourceConfig,
     /// The parameters for the kernel bundle to be loaded in this microVM.
     pub kernel_bundle: Option<KernelBundle>,
+    /// The path to an external kernel, as an alternative to KernelBundle.
+    pub external_kernel: Option<ExternalKernel>,
     /// The parameters for the qboot bundle to be loaded in this microVM.
     #[cfg(feature = "tee")]
     pub qboot_bundle: Option<QbootBundle>,
@@ -201,6 +204,14 @@ impl VmResources {
 
         self.kernel_bundle = Some(kernel_bundle);
         Ok(())
+    }
+
+    pub fn external_kernel(&self) -> Option<&ExternalKernel> {
+        self.external_kernel.as_ref()
+    }
+
+    pub fn set_external_kernel(&mut self, external_kernel: ExternalKernel) {
+        self.external_kernel = Some(external_kernel);
     }
 
     #[cfg(feature = "tee")]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -330,6 +330,7 @@ mod tests {
             vm_config: VmConfig::default(),
             boot_config: default_boot_cfg(),
             kernel_bundle: Default::default(),
+            external_kernel: None,
             fs: Default::default(),
             vsock: Default::default(),
             #[cfg(feature = "net")]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -199,10 +199,6 @@ impl VmResources {
             return Err(KernelBundleError::InvalidGuestAddress);
         }
 
-        if kernel_bundle.size & (page_size - 1) != 0 {
-            return Err(KernelBundleError::InvalidSize);
-        }
-
         self.kernel_bundle = Some(kernel_bundle);
         Ok(())
     }

--- a/src/vmm/src/vmm_config/external_kernel.rs
+++ b/src/vmm/src/vmm_config/external_kernel.rs
@@ -1,0 +1,33 @@
+// Copyright 2024, Red Hat Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub enum KernelFormat {
+    // Raw image, ready to be loaded into the VM.
+    Raw,
+    // ELF image, need to locale sections be loaded.
+    Elf,
+    // Raw image compressed with GZIP, embedded into a PE file.
+    PeGz,
+    // ELF image compressed with BZIP2, embedded into an Image file.
+    ImageBz2,
+    // ELF image compressed with GZIP, embedded into an Image file.
+    ImageGz,
+    // ELF image compressed with ZSTD, embedded into an Image file.
+    ImageZstd,
+}
+
+impl Default for KernelFormat {
+    fn default() -> Self {
+        Self::Raw
+    }
+}
+
+/// Data structure holding the attributes read from the `libkrunfw` kernel config.
+#[derive(Clone, Debug, Default)]
+pub struct ExternalKernel {
+    pub path: PathBuf,
+    pub format: KernelFormat,
+}

--- a/src/vmm/src/vmm_config/external_kernel.rs
+++ b/src/vmm/src/vmm_config/external_kernel.rs
@@ -30,4 +30,7 @@ impl Default for KernelFormat {
 pub struct ExternalKernel {
     pub path: PathBuf,
     pub format: KernelFormat,
+    pub initramfs_path: Option<PathBuf>,
+    pub initramfs_size: u64,
+    pub cmdline: Option<String>,
 }

--- a/src/vmm/src/vmm_config/mod.rs
+++ b/src/vmm/src/vmm_config/mod.rs
@@ -8,6 +8,9 @@ pub mod block;
 /// Wrapper for configuring the microVM boot source.
 pub mod boot_source;
 
+/// Wrapper for configuring an external kernel to be loaded in the microVM.
+pub mod external_kernel;
+
 /// Wrapper for configuring the Fs devices attached to the microVM.
 #[cfg(not(feature = "tee"))]
 pub mod fs;


### PR DESCRIPTION
This PR makes libkrunfw optional (by dynamically loading it) and adds
support for loading external kernels from multiple image formats. The
ones currently implemented are:

 - ELF: A kernel binary in ELF format (vmlinux).
 - PeGz: A PE binary embedding a kernel image compressed with GZIP.
 - ImageBz2: An Image file embedding a kernel compressed with BZIP2.
 - ImageGz: An Image file embedding a kernel compressed with GZIP.
 - ImageZstd: An Image file embedding a kernel compressed with ZSTD.

Adding new kernel formats should be quite straightforward.

Please note this change doesn't implement support for loading an
external initramfs. The main reason is that we can't guarantee to
maintain the control of the VM boot when using an arbitrary
initramfs.

This means that the external kernel must be built with, at least,
the following driver built-in:

- virtio-mmio
- virtio-console
- virtio-fs

Depending on the use case, more drivers might be required.