### PR TITLE
vsock: TCP test + fix a bug leading to an error in TCP connect call in guest 

### DIFF
--- a/src/devices/src/virtio/vsock/proxy.rs
+++ b/src/devices/src/virtio/vsock/proxy.rs
@@ -25,6 +25,7 @@ pub enum ProxyError {
 pub enum ProxyStatus {
     Idle,
     Connecting,
+    ConnectedUnconfirmed,
     Connected,
     Listening,
     Closed,

--- a/src/devices/src/virtio/vsock/tcp.rs
+++ b/src/devices/src/virtio/vsock/tcp.rs
@@ -340,8 +340,7 @@ impl TcpProxy {
         push_packet(self.cid, rx, &self.rxq, &self.queue, &self.mem);
     }
 
-    fn switch_to_connected(&mut self) {
-        self.status = ProxyStatus::Connected;
+    fn switch_to_blocking(&mut self) {
         match fcntl(self.fd, FcntlArg::F_GETFL) {
             Ok(flags) => match OFlag::from_bits(flags) {
                 Some(flags) => {
@@ -374,7 +373,8 @@ impl Proxy for TcpProxy {
         ) {
             Ok(()) => {
                 debug!("vsock: connect: Connected");
-                self.switch_to_connected();
+                self.switch_to_blocking();
+                self.status = ProxyStatus::ConnectedUnconfirmed;
                 0
             }
             Err(nix::errno::Errno::EINPROGRESS) => {
@@ -395,7 +395,7 @@ impl Proxy for TcpProxy {
         if self.status == ProxyStatus::Connecting {
             update.polling = Some((self.id, self.fd, EventSet::IN | EventSet::OUT));
         } else {
-            if self.status == ProxyStatus::Connected {
+            if self.status == ProxyStatus::ConnectedUnconfirmed {
                 update.polling = Some((self.id, self.fd, EventSet::IN));
             }
             self.push_connect_rsp(result);
@@ -412,6 +412,15 @@ impl Proxy for TcpProxy {
             self.local_port,
             self.peer_port,
         );
+
+        if self.status != ProxyStatus::ConnectedUnconfirmed {
+            warn!(
+                "tcp: confirm_connect: Expected state to be {:?}, but it is {:?}",
+                ProxyStatus::ConnectedUnconfirmed,
+                self.status
+            );
+        }
+        self.status = ProxyStatus::Connected;
 
         self.peer_buf_alloc = pkt.buf_alloc();
         self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
@@ -574,8 +583,6 @@ impl Proxy for TcpProxy {
         self.peer_buf_alloc = pkt.buf_alloc();
         self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
 
-        self.status = ProxyStatus::Connected;
-
         ProxyUpdate {
             polling: Some((self.id, self.fd, EventSet::IN)),
             ..Default::default()
@@ -607,7 +614,8 @@ impl Proxy for TcpProxy {
         self.peer_buf_alloc = pkt.buf_alloc();
         self.peer_fwd_cnt = Wrapping(pkt.fwd_cnt());
 
-        self.switch_to_connected();
+        self.switch_to_blocking();
+        self.status = ProxyStatus::Connected;
 
         ProxyUpdate {
             polling: Some((self.id, self.fd, EventSet::IN)),
@@ -748,7 +756,8 @@ impl Proxy for TcpProxy {
         if evset.contains(EventSet::OUT) {
             debug!("process_event: OUT");
             if self.status == ProxyStatus::Connecting {
-                self.switch_to_connected();
+                self.switch_to_blocking();
+                self.status = ProxyStatus::ConnectedUnconfirmed;
                 self.push_connect_rsp(0);
                 update.signal_queue = true;
                 update.polling = Some((self.id(), self.fd, EventSet::IN));

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -12,4 +12,15 @@ cargo test -p test_cases --features guest
 GUEST_TARGET_ARCH="$(uname -m)-unknown-linux-musl"
 
 cargo build --target=$GUEST_TARGET_ARCH -p guest-agent
-KRUN_TEST_GUEST_AGENT_PATH="target/$GUEST_TARGET_ARCH/debug/guest-agent" cargo run -p runner "$@"
+cargo build -p runner
+
+export KRUN_TEST_GUEST_AGENT_PATH="target/$GUEST_TARGET_ARCH/debug/guest-agent"
+
+if which unshare 2>&1 >/dev/null; then
+	unshare --user --map-root-user --net -- /bin/sh -c "ifconfig lo 127.0.0.1 && exec target/debug/runner $@"
+else
+	echo "WARNING: Running tests without a network namespace."
+	echo "Tests may fail if the required network ports are already in use."
+	echo
+	target/debug/runner $@
+fi

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -7,6 +7,9 @@ use test_vsock_guest_connect::TestVsockGuestConnect;
 mod test_tsi_tcp_guest_connect;
 use test_tsi_tcp_guest_connect::TestTsiTcpGuestConnect;
 
+mod test_tsi_tcp_guest_listen;
+use test_tsi_tcp_guest_listen::TestTsiTcpGuestListen;
+
 pub fn test_cases() -> Vec<TestCase> {
     // Register your test here:
     vec![
@@ -26,6 +29,10 @@ pub fn test_cases() -> Vec<TestCase> {
         ),
         TestCase::new("vsock-guest-connect", Box::new(TestVsockGuestConnect)),
         TestCase::new("tsi-tcp-guest-connect", Box::new(TestTsiTcpGuestConnect::new())),
+        TestCase::new(
+            "tsi-tcp-guest-listen",
+            Box::new(TestTsiTcpGuestListen::new()),
+        ),
     ]
 }
 

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -4,6 +4,9 @@ use test_vm_config::TestVmConfig;
 mod test_vsock_guest_connect;
 use test_vsock_guest_connect::TestVsockGuestConnect;
 
+mod test_tsi_tcp_guest_connect;
+use test_tsi_tcp_guest_connect::TestTsiTcpGuestConnect;
+
 pub fn test_cases() -> Vec<TestCase> {
     // Register your test here:
     vec![
@@ -22,6 +25,7 @@ pub fn test_cases() -> Vec<TestCase> {
             }),
         ),
         TestCase::new("vsock-guest-connect", Box::new(TestVsockGuestConnect)),
+        TestCase::new("tsi-tcp-guest-connect", Box::new(TestTsiTcpGuestConnect::new())),
     ]
 }
 
@@ -42,6 +46,7 @@ mod common;
 
 #[cfg(feature = "host")]
 mod krun;
+mod tcp_tester;
 
 #[host]
 #[derive(Clone, Debug)]

--- a/tests/test_cases/src/tcp_tester.rs
+++ b/tests/test_cases/src/tcp_tester.rs
@@ -1,0 +1,62 @@
+use std::io::{ErrorKind, Read, Write};
+use std::mem;
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, SocketAddrV4, TcpListener, TcpStream};
+use std::time::Duration;
+
+fn expect_msg(stream: &mut TcpStream, expected: &[u8]) {
+    let mut buf = vec![0; expected.len()];
+    stream.read_exact(&mut buf[..]).unwrap();
+    assert_eq!(&buf[..], expected);
+}
+
+fn expect_wouldblock(stream: &mut TcpStream) {
+    stream.set_nonblocking(true).unwrap();
+    let err = stream.read(&mut [0u8; 1]).unwrap_err();
+    stream.set_nonblocking(false).unwrap();
+    assert_eq!(err.kind(), ErrorKind::WouldBlock);
+}
+
+fn set_timeouts(stream: &mut TcpStream) {
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+    stream
+        .set_write_timeout(Some(Duration::from_millis(500)))
+        .unwrap();
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct TcpTester {
+    port: u16,
+}
+
+impl TcpTester {
+    pub const fn new(port: u16) -> Self {
+        Self { port }
+    }
+
+    pub fn create_server_socket(&self) -> TcpListener {
+        TcpListener::bind(SocketAddrV4::new(Ipv4Addr::new(0, 0, 0, 0), self.port)).unwrap()
+    }
+
+    pub fn run_server(&self, listener: TcpListener) {
+        let (mut stream, _addr) = listener.accept().unwrap();
+        set_timeouts(&mut stream);
+        stream.write_all(b"ping!").unwrap();
+        expect_msg(&mut stream, b"pong!");
+        expect_wouldblock(&mut stream);
+        stream.write_all(b"bye!").unwrap();
+        // We leak the file descriptor for now, since there is no easy way to close it on libkrun exit
+        mem::forget(listener);
+    }
+
+    pub fn run_client(&self) {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), self.port);
+        let mut stream = TcpStream::connect(&addr).unwrap();
+        set_timeouts(&mut stream);
+        expect_msg(&mut stream, b"ping!");
+        expect_wouldblock(&mut stream);
+        stream.write_all(b"pong!").unwrap();
+        expect_msg(&mut stream, b"bye!");
+    }
+}

--- a/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
@@ -1,0 +1,53 @@
+use crate::tcp_tester::TcpTester;
+use macros::{guest, host};
+
+const PORT: u16 = 8000;
+
+pub struct TestTsiTcpGuestConnect {
+    tcp_tester: TcpTester,
+}
+
+impl TestTsiTcpGuestConnect {
+    pub fn new() -> TestTsiTcpGuestConnect {
+        Self {
+            tcp_tester: TcpTester::new(PORT),
+        }
+    }
+}
+
+#[host]
+mod host {
+    use super::*;
+
+    use crate::common::setup_fs_and_enter;
+    use crate::{krun_call, krun_call_u32};
+    use crate::{Test, TestSetup};
+    use krun_sys::*;
+    use std::thread;
+
+    impl Test for TestTsiTcpGuestConnect {
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let listener = self.tcp_tester.create_server_socket();
+            thread::spawn(move || self.tcp_tester.run_server(listener));
+            unsafe {
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                setup_fs_and_enter(ctx, test_setup)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+
+    impl Test for TestTsiTcpGuestConnect {
+        fn in_guest(self: Box<Self>) {
+            self.tcp_tester.run_client();
+            println!("OK");
+        }
+    }
+}

--- a/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
@@ -1,0 +1,64 @@
+use crate::tcp_tester::TcpTester;
+use macros::{guest, host};
+
+const PORT: u16 = 8001;
+
+pub struct TestTsiTcpGuestListen {
+    tcp_tester: TcpTester,
+}
+
+impl TestTsiTcpGuestListen {
+    pub fn new() -> Self {
+        Self {
+            tcp_tester: TcpTester::new(PORT),
+        }
+    }
+}
+
+#[host]
+mod host {
+    use super::*;
+    use crate::common::setup_fs_and_enter;
+    use crate::{krun_call, krun_call_u32, Test, TestSetup};
+    use krun_sys::*;
+    use std::ffi::CString;
+    use std::ptr::null;
+    use std::thread;
+    use std::time::Duration;
+
+    impl Test for TestTsiTcpGuestListen {
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            unsafe {
+                thread::spawn(move || {
+                    thread::sleep(Duration::from_secs(1));
+                    self.tcp_tester.run_client();
+                });
+
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                let port_mapping = format!("{PORT}:{PORT}");
+                let port_mapping = CString::new(port_mapping).unwrap();
+                let port_map = [port_mapping.as_ptr(), null()];
+
+                krun_call!(krun_set_port_map(ctx, port_map.as_ptr()))?;
+                krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                setup_fs_and_enter(ctx, test_setup)?;
+                println!("OK");
+            }
+            Ok(())
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+
+    impl Test for TestTsiTcpGuestListen {
+        fn in_guest(self: Box<Self>) {
+            let listener = self.tcp_tester.create_server_socket();
+            self.tcp_tester.run_server(listener);
+            println!("OK");
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a simple tests that attempts to connect to a TCP socket on host from the guest. However this would often fail, due to a race condition:

As far as I understand, this is what happens:
`libkrun` connects to the TCP socket on the host (this action is done upon the TSI_CONNECT request), but the guest is not connected to stream vsock socket corresponding to the actual transport for that connection. (We have not called `confirm_connect`).  The problem is that since we assume the guest is already connected we attempt to recv here:
https://github.com/containers/libkrun/blob/a84dc1ac44c20713deff11343647ee51f5fc7931/src/devices/src/virtio/vsock/tcp.rs#L700-L714
This returns `wait_credit = true`, which causes us to send `VSOCK_OP_CREDIT_REQUEST` before sending the `VSOCK_OP_RESPONSE` to the `VSOCK_OP_REQUEST` which the guest kernel sends.
The kernel is not expecting this and returns EPROTO from `connect` call in the guest userspace. (specifically EPROTO is returned from the `virtio_transport_recv_connecting` in `net/vmw_vsock/virtio_transport_common.c`)

The fix here introduces a new state ConnectedUnconfirmed which it uses for TCP Proxy code in vsock. This state is used as a transitional state between the host socket being connected to libkrun and the `confirm_connect` being called, meaning the connection is actually established to the guest and we can actually send/recv.

A similar issue cannot happen with UDP sockets, because `VSOCK_OP_REQUEST`/`VSOCK_OP_RESPONSE` is only used for stream sockets. This also cannot **currently** happen with UNIX stream sockets, because currently these are only ever connected on the host and `confirm_connect`-ed at the same time here:
https://github.com/containers/libkrun/blob/a84dc1ac44c20713deff11343647ee51f5fc7931/src/devices/src/virtio/vsock/muxer.rs#L533-L534
Though, should the unix stream sockets also use the `ConnectedUnconfirmed` state too? For consistency of the semantics of the `Proxy` trait methods it would make sense...  

Depends on: https://github.com/containers/libkrun/pull/258