### PR TITLE
Fix incremental builds using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ ifeq ($(PREFIX),)
     PREFIX := /usr/local
 endif
 
-.PHONY: install clean
+.PHONY: install clean $(LIBRARY_RELEASE_$(OS)) $(LIBRARY_DEBUG_$(OS))
 
 all: $(LIBRARY_RELEASE_$(OS)) libkrun.pc
 


### PR DESCRIPTION
Add .PHONY to to the release and debug library targets so running make does the right thing after changing the source.

It is possible to use cargo directly, but this means a developer need to also run the more commands manually for each build which is error prone.