### PR TITLE
libkrun.pc.in: add libs and cflags directories

### DIFF
--- a/libkrun.pc.in
+++ b/libkrun.pc.in
@@ -20,5 +20,5 @@ Name: @PACKAGE_NAME@
 Version: @PACKAGE_VERSION@
 Description: Library providing Virtualization-based process isolation
 Requires:
-Cflags:
-Libs: -lkrun
+Cflags: -I${includedir}
+Libs: -L${libdir} -lkrun


### PR DESCRIPTION
Add variables for the headers and libraries to Cflags and Libs. This fixes non-system-wide installations of libkrun referenced by using PKG_CONFIG_PATH.