### PR TITLE
virtio/block: allow using host OS block devices in addition to regular files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,6 +653,7 @@ dependencies = [
  "bincode",
  "libc",
  "miniz_oxide",
+ "nix 0.29.0",
  "rustc_version",
  "serde",
  "tokio",
@@ -915,6 +922,18 @@ checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
  "bitflags 2.6.0",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 

--- a/src/imago/Cargo.toml
+++ b/src/imago/Cargo.toml
@@ -36,6 +36,9 @@ vm-memory = ["dep:vm-memory"]
 name = "imago"
 path = "src/lib.rs"
 
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.29.0", features = ["ioctl"] }
+
 [dependencies.async-trait]
 version = "0.1"
 


### PR DESCRIPTION
This PR fixes file size detection of virtio block devices in case the backing file is also a block device on the host OS.
See #275.