### PR TITLE
libkrun: fix shutdown_efd for efi flavor

### DIFF
--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -314,7 +314,7 @@ pub extern "C" fn krun_set_log_level(level: u32) -> i32 {
 #[no_mangle]
 pub extern "C" fn krun_create_ctx() -> i32 {
     let ctx_cfg = {
-        let shutdown_efd = if cfg!(feature = "tee") {
+        let shutdown_efd = if cfg!(feature = "efi") {
             Some(EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap())
         } else {
             None


### PR DESCRIPTION
In e789b3f4da2479bf64645eac76d6ee6179def456 I broke the logic, which only created the shutdown_efd on the efi flavor, to only create it on the tee flavor, which doesn't make sense. Fix it here.