### PR TITLE
libkrun: stop using patchelf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,28 +91,20 @@ $(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY)
 ifeq ($(SEV),1)
 	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
 endif
-ifeq ($(OS),Linux)
-	patchelf --set-soname $(KRUN_SONAME_$(OS)) --output $(LIBRARY_RELEASE_$(OS)) target/release/$(KRUN_BASE_$(OS))
-else
-ifeq ($(EFI),1)
 ifeq ($(OS),Darwin)
+ifeq ($(EFI),1)
 	install_name_tool -id libkrun-efi.dylib target/release/libkrun.dylib
 endif
 	mv target/release/libkrun.dylib target/release/$(KRUN_BASE_$(OS))
 endif
 	cp target/release/$(KRUN_BASE_$(OS)) $(LIBRARY_RELEASE_$(OS))
-endif
 
 $(LIBRARY_DEBUG_$(OS)): $(INIT_BINARY)
 	cargo build $(FEATURE_FLAGS)
 ifeq ($(SEV),1)
 	mv target/debug/libkrun.so target/debug/$(KRUN_BASE_$(OS))
 endif
-ifeq ($(OS),Linux)
-	patchelf --set-soname $(KRUN_SONAME_$(OS)) --output $(LIBRARY_DEBUG_$(OS)) target/debug/$(KRUN_BASE_$(OS))
-else
 	cp target/debug/$(KRUN_BASE_$(OS)) $(LIBRARY_DEBUG_$(OS))
-endif
 
 libkrun.pc: libkrun.pc.in Makefile
 	rm -f $@ $@-t

--- a/src/libkrun/build.rs
+++ b/src/libkrun/build.rs
@@ -1,4 +1,9 @@
 fn main() {
+    #[cfg(target_os = "linux")]
+    println!(
+        "cargo:rustc-cdylib-link-arg=-Wl,-soname,libkrun.so.{}",
+        std::env::var("CARGO_PKG_VERSION_MAJOR").unwrap()
+    );
     #[cfg(target_os = "macos")]
     println!("cargo:rustc-link-lib=framework=Hypervisor");
 }


### PR DESCRIPTION
Using patchelf to set soname in the library has always been kind of a hack. Let's get rid of it.