### PR TITLE
Add support for userspace IOAPIC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,8 @@ dependencies = [
  "devices",
  "env_logger",
  "hvf",
+ "kvm-bindings",
+ "kvm-ioctls",
  "libc",
  "libloading",
  "log",

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -301,6 +301,12 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    if (err = krun_split_irqchip(ctx_id, false)) {
+        errno = -err;
+        perror("Error setting split IRQCHIP property");
+        return -1;
+    }
+
     // Start and enter the microVM. Unless there is some error while creating the microVM
     // this function never returns.
     if (err = krun_start_enter(ctx_id)) {

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -554,6 +554,18 @@ int32_t krun_setgid(uint32_t ctx_id, gid_t gid);
 int32_t krun_set_nested_virt(uint32_t ctx_id, bool enabled);
 
 /**
+ * Specify whether to split IRQCHIP responsibilities between the host and the guest.
+ *
+ * Arguments:
+ *  "ctx_id" - the configuration context ID.
+ *  "enable" - whether to enable the split IRQCHIP
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+*/
+int32_t krun_split_irqchip(uint32_t ctx_id, bool enable);
+
+/**
  * Starts and enters the microVM with the configured parameters. The VMM will attempt to take over
  * stdin/stdout to manage them on behalf of the process running inside the isolated environment,
  * simulating that the latter has direct control of the terminal.

--- a/src/devices/src/legacy/ioapic.rs
+++ b/src/devices/src/legacy/ioapic.rs
@@ -30,6 +30,8 @@ const IOAPIC_VECTOR_MASK: u64 = 0xff;
 
 const IOAPIC_DM_EXTINT: u64 = 0x7;
 
+const IOAPIC_TRIGGER_EDGE: u64 = 0;
+
 /// 63:56 Destination Field (RW)
 /// 55:17 Reserved
 /// 16 Interrupt Mask (RW)
@@ -42,11 +44,10 @@ const IOAPIC_DM_EXTINT: u64 = 0x7;
 /// 7:0 Interrupt Vector (INTVEC) (RW)
 type RedirectionTableEntry = u64;
 
-const IOAPIC_TRIGGER_EDGE: u64 = 0;
-
 #[derive(Debug)]
 pub enum IrqWorkerMessage {
     GsiRoute(Vec<kvm_irq_routing_entry>),
+    IrqLine(u32, bool),
 }
 
 #[derive(Debug, Default)]
@@ -231,5 +232,37 @@ impl IoApic {
         }
 
         self.send_irq_worker_message(IrqWorkerMessage::GsiRoute(self.irq_routes.clone()));
+    }
+
+    fn service(&mut self) {
+        for i in 0..IOAPIC_NUM_PINS {
+            let mask = 1 << i;
+
+            if self.irr & mask > 0 {
+                let mut coalesce = 0;
+
+                let entry = self.ioredtbl[i];
+                let info = self.parse_entry(&entry);
+                if info.masked == 0 {
+                    if info.trig_mode as u64 == IOAPIC_TRIGGER_EDGE {
+                        self.irr &= !mask;
+                    } else {
+                        coalesce = self.ioredtbl[i] & IOAPIC_LVT_REMOTE_IRR;
+                        self.ioredtbl[i] |= IOAPIC_LVT_REMOTE_IRR;
+                    }
+
+                    if coalesce > 0 {
+                        continue;
+                    }
+
+                    if info.trig_mode as u64 == IOAPIC_TRIGGER_EDGE {
+                        self.send_irq_worker_message(IrqWorkerMessage::IrqLine(i as u32, true));
+                        self.send_irq_worker_message(IrqWorkerMessage::IrqLine(i as u32, false));
+                    } else {
+                        self.send_irq_worker_message(IrqWorkerMessage::IrqLine(i as u32, true));
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/devices/src/legacy/ioapic.rs
+++ b/src/devices/src/legacy/ioapic.rs
@@ -114,4 +114,12 @@ impl IoApic {
             self.ioredtbl[index] &= !IOAPIC_LVT_REMOTE_IRR;
         }
     }
+
+    fn send_irq_worker_message(&self, msg: IrqWorkerMessage) {
+        self.irq_sender
+            .send((msg, self.event_fd.try_clone().unwrap()))
+            .unwrap();
+
+        self.event_fd.read().unwrap();
+    }
 }

--- a/src/devices/src/legacy/ioapic.rs
+++ b/src/devices/src/legacy/ioapic.rs
@@ -10,6 +10,14 @@ const IOAPIC_NUM_PINS: usize = 24;
 
 const IOAPIC_LVT_MASKED_SHIFT: u64 = 16;
 
+const IOAPIC_LVT_TRIGGER_MODE_SHIFT: u64 = 15;
+const IOAPIC_LVT_TRIGGER_MODE: u64 = 1 << IOAPIC_LVT_TRIGGER_MODE_SHIFT;
+
+const IOAPIC_LVT_REMOTE_IRR_SHIFT: u64 = 14;
+const IOAPIC_LVT_REMOTE_IRR: u64 = 1 << IOAPIC_LVT_REMOTE_IRR_SHIFT;
+
+const IOAPIC_TRIGGER_EDGE: u64 = 0;
+
 #[derive(Debug)]
 pub enum IrqWorkerMessage {}
 
@@ -98,6 +106,12 @@ impl IoApic {
             self.irq_routes.push(kroute);
         } else {
             error!("ioapic: not enough space for irq");
+        }
+    }
+
+    fn fix_edge_remote_irr(&mut self, index: usize) {
+        if self.ioredtbl[index] & IOAPIC_LVT_TRIGGER_MODE == IOAPIC_TRIGGER_EDGE {
+            self.ioredtbl[index] &= !IOAPIC_LVT_REMOTE_IRR;
         }
     }
 }

--- a/src/devices/src/legacy/ioapic.rs
+++ b/src/devices/src/legacy/ioapic.rs
@@ -1,0 +1,103 @@
+use kvm_bindings::{
+    kvm_enable_cap, kvm_irq_routing, kvm_irq_routing_entry, kvm_irq_routing_entry__bindgen_ty_1,
+    kvm_irq_routing_msi, KVM_CAP_SPLIT_IRQCHIP, KVM_IRQ_ROUTING_MSI,
+};
+use kvm_ioctls::{Error, VmFd};
+
+use utils::eventfd::EventFd;
+
+const IOAPIC_NUM_PINS: usize = 24;
+
+const IOAPIC_LVT_MASKED_SHIFT: u64 = 16;
+
+#[derive(Debug)]
+pub enum IrqWorkerMessage {}
+
+#[derive(Default)]
+struct MsiMessage {
+    address: u64,
+    data: u64,
+}
+
+#[derive(Debug)]
+pub struct IoApic {
+    id: u8,
+    ioregsel: u8,
+    irr: u32,
+    ioredtbl: [u64; IOAPIC_NUM_PINS],
+    version: u8,
+    irq_eoi: [i32; IOAPIC_NUM_PINS],
+    irq_routes: Vec<kvm_irq_routing_entry>,
+    irq_sender: crossbeam_channel::Sender<(IrqWorkerMessage, EventFd)>,
+    event_fd: EventFd,
+}
+
+impl IoApic {
+    pub fn new(
+        vm: &VmFd,
+        _irq_sender: crossbeam_channel::Sender<(IrqWorkerMessage, EventFd)>,
+    ) -> Result<Self, Error> {
+        let mut cap = kvm_enable_cap {
+            cap: KVM_CAP_SPLIT_IRQCHIP,
+            ..Default::default()
+        };
+        cap.args[0] = 24;
+        vm.enable_cap(&cap)?;
+
+        let mut ioapic = Self {
+            id: 0,
+            ioregsel: 0,
+            irr: 0,
+            ioredtbl: [1 << IOAPIC_LVT_MASKED_SHIFT; IOAPIC_NUM_PINS],
+            version: 0x20,
+            irq_eoi: [0; IOAPIC_NUM_PINS],
+            irq_routes: Vec::with_capacity(IOAPIC_NUM_PINS),
+            irq_sender: _irq_sender,
+            event_fd: EventFd::new(libc::EFD_SEMAPHORE).unwrap(),
+        };
+
+        (0..IOAPIC_NUM_PINS).for_each(|i| ioapic.add_msi_route(i));
+
+        let mut irq_routing = utils::sized_vec::vec_with_array_field::<
+            kvm_irq_routing,
+            kvm_irq_routing_entry,
+        >(ioapic.irq_routes.len());
+        irq_routing[0].nr = ioapic.irq_routes.len() as u32;
+        irq_routing[0].flags = 0;
+
+        unsafe {
+            let entries_slice: &mut [kvm_irq_routing_entry] =
+                irq_routing[0].entries.as_mut_slice(ioapic.irq_routes.len());
+            entries_slice.copy_from_slice(ioapic.irq_routes.as_slice());
+        }
+
+        vm.set_gsi_routing(&irq_routing[0])?;
+
+        Ok(ioapic)
+    }
+
+    fn add_msi_route(&mut self, virq: usize) {
+        let msg = MsiMessage::default();
+        let kroute = kvm_irq_routing_entry {
+            gsi: virq as u32,
+            type_: KVM_IRQ_ROUTING_MSI,
+            flags: 0,
+            u: kvm_irq_routing_entry__bindgen_ty_1 {
+                msi: kvm_irq_routing_msi {
+                    address_lo: msg.address as u32,
+                    address_hi: (msg.address >> 32) as u32,
+                    data: msg.data as u32,
+                    ..Default::default()
+                },
+            },
+            ..Default::default()
+        };
+
+        // 4095 is the max irq number for kvm (MAX_IRQ_ROUTES - 1)
+        if self.irq_routes.len() < 4095 {
+            self.irq_routes.push(kroute);
+        } else {
+            error!("ioapic: not enough space for irq");
+        }
+    }
+}

--- a/src/devices/src/legacy/ioapic.rs
+++ b/src/devices/src/legacy/ioapic.rs
@@ -7,7 +7,10 @@ use kvm_ioctls::{Error, VmFd};
 use utils::eventfd::EventFd;
 
 use crate::bus::BusDevice;
+use crate::legacy::irqchip::IrqChipT;
+use crate::Error as DeviceError;
 
+const IOAPIC_BASE: u32 = 0xfec0_0000;
 const APIC_DEFAULT_ADDRESS: u32 = 0xfee0_0000;
 const IOAPIC_NUM_PINS: usize = 24;
 
@@ -284,6 +287,36 @@ impl IoApic {
                 }
             }
         }
+    }
+}
+
+impl IrqChipT for IoApic {
+    fn get_mmio_addr(&self) -> u64 {
+        IOAPIC_BASE as u64
+    }
+
+    fn get_mmio_size(&self) -> u64 {
+        0x1000
+    }
+
+    fn set_irq(
+        &self,
+        _irq_line: Option<u32>,
+        interrupt_evt: Option<&EventFd>,
+    ) -> Result<(), DeviceError> {
+        if let Some(interrupt_evt) = interrupt_evt {
+            if let Err(e) = interrupt_evt.write(1) {
+                error!("Failed to signal used queue: {:?}", e);
+                return Err(DeviceError::FailedSignalingUsedQueue(e));
+            }
+        } else {
+            error!("EventFd not set up for irq line");
+            return Err(DeviceError::FailedSignalingUsedQueue(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "EventFd not set up for irq line",
+            )));
+        }
+        Ok(())
     }
 }
 

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -11,6 +11,8 @@ mod gicv3;
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 mod hvfgicv3;
 mod i8042;
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+mod ioapic;
 mod irqchip;
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 mod kvmgicv3;
@@ -39,6 +41,8 @@ pub use self::gpio::Gpio;
 pub use self::hvfgicv3::HvfGicV3;
 pub use self::i8042::Error as I8042DeviceError;
 pub use self::i8042::I8042Device;
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+pub use self::ioapic::IoApic;
 pub use self::irqchip::{IrqChip, IrqChipDevice, IrqChipT};
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 pub use self::kvmgicv3::KvmGicV3;

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -42,7 +42,7 @@ pub use self::hvfgicv3::HvfGicV3;
 pub use self::i8042::Error as I8042DeviceError;
 pub use self::i8042::I8042Device;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-pub use self::ioapic::IoApic;
+pub use self::ioapic::{IoApic, IrqWorkerMessage};
 pub use self::irqchip::{IrqChip, IrqChipDevice, IrqChipT};
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 pub use self::kvmgicv3::KvmGicV3;

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -31,6 +31,10 @@ vmm = { path = "../vmm" }
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { path = "../hvf" }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+kvm-bindings = { version = ">=0.10", features = ["fam-wrappers"] }
+kvm-ioctls = ">=0.17"
+
 [lib]
 name = "krun"
 crate-type = ["cdylib"]

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1484,12 +1484,17 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     #[cfg(target_os = "macos")]
     let (sender, receiver) = unbounded();
 
+    #[cfg(target_arch = "x86_64")]
+    let (irq_sender, irq_receiver) = crossbeam_channel::unbounded();
+
     let _vmm = match vmm::builder::build_microvm(
         &ctx_cfg.vmr,
         &mut event_manager,
         ctx_cfg.shutdown_efd,
         #[cfg(target_os = "macos")]
         sender,
+        #[cfg(target_arch = "x86_64")]
+        irq_sender,
     ) {
         Ok(vmm) => vmm,
         Err(e) => {
@@ -1500,6 +1505,9 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
 
     #[cfg(target_os = "macos")]
     let mapper_vmm = _vmm.clone();
+
+    #[cfg(target_arch = "x86_64")]
+    let irq_vmm = _vmm.clone();
 
     #[cfg(target_os = "macos")]
     if ctx_cfg.gpu_virgl_flags.is_some() {
@@ -1514,6 +1522,54 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
                         }
                         MemoryMapping::RemoveMapping(s, g, l) => {
                             mapper_vmm.lock().unwrap().remove_mapping(s, g, l)
+                        }
+                    },
+                }
+            })
+            .unwrap();
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    if ctx_cfg.vmr.split_irqchip {
+        std::thread::Builder::new()
+            .name("irq worker".into())
+            .spawn(move || loop {
+                match irq_receiver.recv() {
+                    Err(e) => error!("Error in receiver: {:?}", e),
+                    Ok((message, evt_fd)) => match message {
+                        devices::legacy::IrqWorkerMessage::GsiRoute(entries) => {
+                            let mut irq_routing = utils::sized_vec::vec_with_array_field::<
+                                kvm_bindings::kvm_irq_routing,
+                                kvm_bindings::kvm_irq_routing_entry,
+                            >(entries.len());
+                            irq_routing[0].nr = entries.len() as u32;
+                            irq_routing[0].flags = 0;
+
+                            unsafe {
+                                let entries_slice: &mut [kvm_bindings::kvm_irq_routing_entry] =
+                                    irq_routing[0].entries.as_mut_slice(entries.len());
+                                entries_slice.copy_from_slice(&entries);
+                            }
+
+                            irq_vmm
+                                .lock()
+                                .unwrap()
+                                .kvm_vm()
+                                .fd()
+                                .set_gsi_routing(&irq_routing[0])
+                                .unwrap();
+
+                            evt_fd.write(1).unwrap();
+                        }
+                        devices::legacy::IrqWorkerMessage::IrqLine(irq, active) => {
+                            irq_vmm
+                                .lock()
+                                .unwrap()
+                                .kvm_vm()
+                                .fd()
+                                .set_irq_line(irq, active)
+                                .unwrap();
+                            evt_fd.write(1).unwrap();
                         }
                     },
                 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1064,6 +1064,22 @@ pub unsafe extern "C" fn krun_set_nested_virt(ctx_id: u32, enabled: bool) -> i32
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
+pub extern "C" fn krun_split_irqchip(ctx_id: u32, enable: bool) -> i32 {
+    if enable && !cfg!(target_arch = "x86_64") {
+        return -libc::EINVAL;
+    }
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+            cfg.vmr.split_irqchip = enable;
+            KRUN_SUCCESS
+        }
+        Entry::Vacant(_) => -libc::ENOENT,
+    }
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
 pub unsafe extern "C" fn krun_set_smbios_oem_strings(
     ctx_id: u32,
     oem_strings: *const *const c_char,

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -19,6 +19,7 @@ pub use macos::eventfd;
 pub mod rand;
 #[cfg(target_os = "linux")]
 pub mod signal;
+pub mod sized_vec;
 pub mod sm;
 pub mod syscall;
 pub mod time;

--- a/src/utils/src/sized_vec.rs
+++ b/src/utils/src/sized_vec.rs
@@ -1,0 +1,41 @@
+// Copyright © 2024 Institute of Software, CAS. All rights reserved.
+//
+// Copyright © 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+//
+// Copyright © 2020, Microsoft Corporation
+//
+// Copyright 2018-2019 CrowdStrike, Inc.
+//
+//
+
+// Returns a `Vec<T>` with a size in bytes at least as large as `size_in_bytes`.
+fn vec_with_size_in_bytes<T: Default>(size_in_bytes: usize) -> Vec<T> {
+    let rounded_size = size_in_bytes.div_ceil(size_of::<T>());
+    let mut v = Vec::with_capacity(rounded_size);
+    v.resize_with(rounded_size, T::default);
+    v
+}
+
+// The kvm API has many structs that resemble the following `Foo` structure:
+//
+// ```
+// #[repr(C)]
+// struct Foo {
+//    some_data: u32
+//    entries: __IncompleteArrayField<__u32>,
+// }
+// ```
+//
+// In order to allocate such a structure, `size_of::<Foo>()` would be too small because it would not
+// include any space for `entries`. To make the allocation large enough while still being aligned
+// for `Foo`, a `Vec<Foo>` is created. Only the first element of `Vec<Foo>` would actually be used
+// as a `Foo`. The remaining memory in the `Vec<Foo>` is for `entries`, which must be contiguous
+// with `Foo`. This function is used to make the `Vec<Foo>` with enough space for `count` entries.
+use std::mem::size_of;
+pub fn vec_with_array_field<T: Default, F>(count: usize) -> Vec<T> {
+    let element_space = count * size_of::<F>();
+    let vec_size_bytes = size_of::<T>() + element_space;
+    vec_with_size_in_bytes(vec_size_bytes)
+}

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -507,6 +507,10 @@ pub fn build_microvm(
     event_manager: &mut EventManager,
     _shutdown_efd: Option<EventFd>,
     #[cfg(target_os = "macos")] _map_sender: Sender<MemoryMapping>,
+    #[cfg(target_arch = "x86_64")] irq_sender: crossbeam_channel::Sender<(
+        devices::legacy::IrqWorkerMessage,
+        EventFd,
+    )>,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     let payload = choose_payload(vm_resources)?;
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -120,6 +120,8 @@ pub struct VmResources {
     pub smbios_oem_strings: Option<Vec<String>>,
     /// Whether to enable nested virtualization.
     pub nested_enabled: bool,
+    /// Whether to enable split irqchip
+    pub split_irqchip: bool,
 }
 
 impl VmResources {
@@ -344,6 +346,7 @@ mod tests {
             console_output: None,
             smbios_oem_strings: None,
             nested_enabled: false,
+            split_irqchip: false,
         }
     }
 


### PR DESCRIPTION
Allow the user to specify if they want to split the IRQCHIP such that the LAPIC is still inside the guest, but the IOAPIC is in userspace and managed by the VMM.

Intel Trust Domain Extensions, for example, require this functionality to work.

The Intel specification for the device can be found here: https://pdos.csail.mit.edu/6.828/2016/readings/ia32/ioapic.pdf