### PR TITLE
init: use parsed_entrypoint in if condition

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -766,8 +766,8 @@ static int config_parse_file(char ***argv, char **workdir)
     entrypoint = NULL;
     parsed_env = parsed_workdir = parsed_args = parsed_entrypoint = 0;
 
-    for (i = 1;
-         i < num_tokens && (!parsed_env || !parsed_args || !parsed_workdir);
+    for (i = 1; i < num_tokens && (!parsed_env || !parsed_args ||
+                                   !parsed_workdir || !parsed_entrypoint);
          i++) {
         if (!parsed_env && jsoneq(data, &tokens[i], "Env") == 0 &&
             (i + 1) < num_tokens && tokens[i + 1].type == JSMN_ARRAY) {


### PR DESCRIPTION
Allow `Entrypoint` to be passed after the other tokens.

Drive-by PR.
I hope the PR makes sense.


