### PR TITLE
Implement the ability to record the exit code from the entrypoint in userspace

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -980,6 +980,7 @@ int main(int argc, char **argv)
     struct ifreq ifr;
     int sockfd;
     int status;
+    int saved_errno;
     char localhost[] = "localhost\0";
     char *hostname;
     char *krun_home;
@@ -1067,16 +1068,23 @@ int main(int argc, char **argv)
     int child = fork();
     if (child < 0) {
         perror("fork");
-        exit(-3);
+        set_exit_code(125);
+        exit(125);
     }
     if (child == 0) { // child
         if (setup_redirects() < 0) {
-            exit(-4);
+            exit(125);
         }
         if (execvp(exec_argv[0], exec_argv) < 0) {
+            saved_errno = errno;
             printf("Couldn't execute '%s' inside the vm: %s\n", exec_argv[0],
                    strerror(errno));
-            exit(-3);
+            // Use the same exit code as chroot and podman do.
+            if (saved_errno == ENOENT) {
+                exit(127);
+            } else {
+                exit(126);
+            }
         }
     } else { // parent
         // Wait until our first child has exited, ignoring any other children.

--- a/init/init.c
+++ b/init/init.c
@@ -28,6 +28,8 @@
 #include "tee/snp_attest.h"
 #endif
 
+#define KRUN_EXIT_CODE_IOCTL 0x7602
+
 #define KRUN_MAGIC "KRUN"
 #define KRUN_FOOTER_LEN 12
 #define CMDLINE_SECRET_PATH "/sfs/secrets/coco/cmdline"
@@ -954,10 +956,30 @@ int setup_redirects()
     return 0;
 }
 
+void set_exit_code(int code)
+{
+    int fd;
+    int ret;
+
+    fd = open("/", O_RDONLY);
+    if (fd < 0) {
+        perror("Couldn't open root filesystem to report exit code");
+        return;
+    }
+
+    ret = ioctl(fd, KRUN_EXIT_CODE_IOCTL, code);
+    if (ret < 0) {
+        perror("Error using the ioctl to set the exit code");
+    }
+
+    close(fd);
+}
+
 int main(int argc, char **argv)
 {
     struct ifreq ifr;
     int sockfd;
+    int status;
     char localhost[] = "localhost\0";
     char *hostname;
     char *krun_home;
@@ -1042,12 +1064,12 @@ int main(int argc, char **argv)
 
     // We need to fork ourselves, because pid 1 cannot doesn't receive SIGINT
     // signal
-    int pid = fork();
-    if (pid < 0) {
+    int child = fork();
+    if (child < 0) {
         perror("fork");
         exit(-3);
     }
-    if (pid == 0) { // child
+    if (child == 0) { // child
         if (setup_redirects() < 0) {
             exit(-4);
         }
@@ -1057,11 +1079,17 @@ int main(int argc, char **argv)
             exit(-3);
         }
     } else { // parent
-        // tell the kernel we don't want to be notified on SIGCHLD so it'll reap
-        // our children for us
-        signal(SIGCHLD, SIG_IGN);
-        // wait for children since we can't exit init
-        waitpid(pid, NULL, 0);
+        // Wait until our first child has exited, ignoring any other children.
+        while (waitpid(-1, &status, 0) != child) {
+            // Not the first child, ignore it.
+        };
+
+        // Our first child has exited, record its exit code and exit ourselves.
+        if (WIFEXITED(status)) {
+            set_exit_code(WEXITSTATUS(status));
+        } else if (WIFSIGNALED(status)) {
+            set_exit_code(WTERMSIG(status) + 128);
+        }
     }
 
     return 0;

--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -13,6 +13,7 @@ use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
 use std::mem;
+use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -1160,6 +1161,7 @@ pub trait FileSystem {
         arg: u64,
         in_size: u32,
         out_size: u32,
+        exit_code: &Arc<AtomicI32>,
     ) -> io::Result<Vec<u8>> {
         Err(io::Error::from_raw_os_error(bindings::LINUX_ENOSYS))
     }

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -1238,7 +1238,15 @@ impl FileSystem for PassthroughFs {
         debug!("read: {:?}", inode);
         #[cfg(not(feature = "efi"))]
         if inode == self.init_inode {
-            return w.write(&INIT_BINARY[offset as usize..(offset + (size as u64)) as usize]);
+            let off: usize = offset
+                .try_into()
+                .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
+            let len = if off + (size as usize) < INIT_BINARY.len() {
+                size as usize
+            } else {
+                INIT_BINARY.len() - off
+            };
+            return w.write(&INIT_BINARY[off..(off + len)]);
         }
 
         let data = self

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -14,6 +14,7 @@ use std::io::{self, Read};
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
 
 use super::{Error, Vmm};
@@ -738,6 +739,9 @@ pub fn build_microvm(
         )?;
     }
 
+    // We use this atomic to record the exit code set by init/init.c in the VM.
+    let exit_code = Arc::new(AtomicI32::new(i32::MAX));
+
     let mut vmm = Vmm {
         guest_memory,
         arch_memory_info,
@@ -745,6 +749,7 @@ pub fn build_microvm(
         vcpus_handles: Vec::new(),
         exit_evt,
         exit_observers: Vec::new(),
+        exit_code: exit_code.clone(),
         vm,
         mmio_device_manager,
         #[cfg(target_arch = "x86_64")]
@@ -783,6 +788,7 @@ pub fn build_microvm(
             _map_sender.clone(),
         )?;
     }
+
     #[cfg(not(feature = "tee"))]
     attach_fs_devices(
         &mut vmm,
@@ -791,6 +797,7 @@ pub fn build_microvm(
         #[cfg(not(feature = "tee"))]
         export_table,
         intc.clone(),
+        exit_code,
         #[cfg(target_os = "macos")]
         _map_sender,
     )?;
@@ -1549,13 +1556,19 @@ fn attach_fs_devices(
     shm_manager: &mut ShmManager,
     #[cfg(not(feature = "tee"))] export_table: Option<ExportTable>,
     intc: IrqChip,
+    exit_code: Arc<AtomicI32>,
     #[cfg(target_os = "macos")] map_sender: Sender<MemoryMapping>,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
 
     for (i, config) in fs_devs.iter().enumerate() {
         let fs = Arc::new(Mutex::new(
-            devices::virtio::Fs::new(config.fs_id.clone(), config.shared_dir.clone()).unwrap(),
+            devices::virtio::Fs::new(
+                config.fs_id.clone(),
+                config.shared_dir.clone(),
+                exit_code.clone(),
+            )
+            .unwrap(),
         ));
 
         let id = format!("{}{}", String::from(fs.lock().unwrap().id()), i);

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -40,6 +40,7 @@ use macos::vstate;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::os::unix::io::AsRawFd;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::{Arc, Mutex};
 #[cfg(target_os = "linux")]
 use std::time::Duration;
@@ -202,6 +203,7 @@ pub struct Vmm {
     exit_evt: EventFd,
     vm: Vm,
     exit_observers: Vec<Arc<Mutex<dyn VmmExitObserver>>>,
+    exit_code: Arc<AtomicI32>,
 
     // Guest VM devices.
     mmio_device_manager: MMIODeviceManager,
@@ -394,7 +396,7 @@ impl Subscriber for Vmm {
             // If the exit_code can't be found on any vcpu, it means that the exit signal
             // has been issued by the i8042 controller in which case we exit with
             // FC_EXIT_CODE_OK.
-            let exit_code = self
+            let vcpu_exit_code = self
                 .vcpus_handles
                 .iter()
                 .find_map(|handle| match handle.response_receiver().try_recv() {
@@ -402,7 +404,15 @@ impl Subscriber for Vmm {
                     _ => None,
                 })
                 .unwrap_or(FC_EXIT_CODE_OK);
-            self.stop(i32::from(exit_code));
+            let vmm_exit_code = self.exit_code.load(Ordering::SeqCst);
+            let exit_code = if vmm_exit_code != i32::MAX {
+                debug!("using vmm exit code: {vmm_exit_code}");
+                vmm_exit_code
+            } else {
+                debug!("using vcpu exit code: {vcpu_exit_code}");
+                vcpu_exit_code as i32
+            };
+            self.stop(exit_code);
         } else {
             error!("Spurious EventManager event for handler: Vmm");
         }


### PR DESCRIPTION
    For the container use case, we need to relay the exit code from
    userspace in the microVM all the way to the process using libkrun to
    launch the VMM.

    Since ioctls are passed mostly unmodified from userspace in the guest
    to the virtio-fs device, we can use them as a mechanism for transporting
    this information without requiring any specific support in the guest's
    kernel.

    Here we create an AtomicI32 and wire it up between virtio-fs and Vmm,
    using it as exit code if userspace has set it to some value other than
    i32::MAX. Otherwise, we keep using the vCPU exit code, as we did before.