### PR TITLE
Consolidate worker threads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,6 +1717,7 @@ name = "utils"
 version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
+ "crossbeam-channel",
  "env_logger",
  "kvm-bindings",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1718,6 +1718,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
  "env_logger",
+ "kvm-bindings",
  "libc",
  "log",
  "vmm-sys-util",

--- a/src/devices/src/legacy/mod.rs
+++ b/src/devices/src/legacy/mod.rs
@@ -42,7 +42,7 @@ pub use self::hvfgicv3::HvfGicV3;
 pub use self::i8042::Error as I8042DeviceError;
 pub use self::i8042::I8042Device;
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-pub use self::ioapic::{IoApic, IrqWorkerMessage};
+pub use self::ioapic::IoApic;
 pub use self::irqchip::{IrqChip, IrqChipDevice, IrqChipT};
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 pub use self::kvmgicv3::KvmGicV3;

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -6,9 +6,9 @@ use std::sync::atomic::{AtomicI32, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
-#[cfg(target_os = "macos")]
-use hvf::MemoryMapping;
 use utils::eventfd::{EventFd, EFD_NONBLOCK};
+#[cfg(target_os = "macos")]
+use utils::worker_message::WorkerMessage;
 use virtio_bindings::{virtio_config::VIRTIO_F_VERSION_1, virtio_ring::VIRTIO_RING_F_EVENT_IDX};
 use vm_memory::{ByteValued, GuestMemoryMmap};
 
@@ -56,7 +56,7 @@ pub struct Fs {
     worker_stopfd: EventFd,
     exit_code: Arc<AtomicI32>,
     #[cfg(target_os = "macos")]
-    map_sender: Option<Sender<MemoryMapping>>,
+    map_sender: Option<Sender<WorkerMessage>>,
 }
 
 impl Fs {
@@ -135,7 +135,7 @@ impl Fs {
     }
 
     #[cfg(target_os = "macos")]
-    pub fn set_map_sender(&mut self, map_sender: Sender<MemoryMapping>) {
+    pub fn set_map_sender(&mut self, map_sender: Sender<WorkerMessage>) {
         self.map_sender = Some(map_sender);
     }
 }

--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -5,7 +5,7 @@
 #[cfg(target_os = "macos")]
 use crossbeam_channel::Sender;
 #[cfg(target_os = "macos")]
-use hvf::MemoryMapping;
+use utils::worker_message::WorkerMessage;
 
 use std::collections::BTreeMap;
 use std::convert::TryInto;
@@ -1134,7 +1134,7 @@ pub trait FileSystem {
         moffset: u64,
         host_shm_base: u64,
         shm_size: u64,
-        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
     ) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }
@@ -1145,7 +1145,7 @@ pub trait FileSystem {
         requests: Vec<RemovemappingOne>,
         host_shm_base: u64,
         shm_size: u64,
-        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
     ) -> io::Result<()> {
         Err(io::Error::from_raw_os_error(libc::ENOSYS))
     }

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -19,7 +19,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
 use crossbeam_channel::{unbounded, Sender};
-use hvf::MemoryMapping;
+use utils::worker_message::WorkerMessage;
 
 use crate::virtio::fs::filesystem::SecContext;
 
@@ -1994,7 +1994,7 @@ impl FileSystem for PassthroughFs {
         moffset: u64,
         guest_shm_base: u64,
         shm_size: u64,
-        map_sender: &Option<Sender<MemoryMapping>>,
+        map_sender: &Option<Sender<WorkerMessage>>,
     ) -> io::Result<()> {
         if map_sender.is_none() {
             return Err(linux_error(io::Error::from_raw_os_error(libc::ENOSYS)));
@@ -2043,7 +2043,7 @@ impl FileSystem for PassthroughFs {
         let sender = map_sender.as_ref().unwrap();
         let (reply_sender, reply_receiver) = unbounded();
         sender
-            .send(MemoryMapping::AddMapping(
+            .send(WorkerMessage::GpuAddMapping(
                 reply_sender,
                 host_addr as u64,
                 guest_addr,
@@ -2070,7 +2070,7 @@ impl FileSystem for PassthroughFs {
         requests: Vec<fuse::RemovemappingOne>,
         guest_shm_base: u64,
         shm_size: u64,
-        map_sender: &Option<Sender<MemoryMapping>>,
+        map_sender: &Option<Sender<WorkerMessage>>,
     ) -> io::Result<()> {
         if map_sender.is_none() {
             return Err(linux_error(io::Error::from_raw_os_error(libc::ENOSYS)));
@@ -2093,7 +2093,7 @@ impl FileSystem for PassthroughFs {
             let sender = map_sender.as_ref().unwrap();
             let (reply_sender, reply_receiver) = unbounded();
             sender
-                .send(MemoryMapping::RemoveMapping(
+                .send(WorkerMessage::GpuRemoveMapping(
                     reply_sender,
                     guest_addr,
                     req.len,

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -5,7 +5,7 @@
 #[cfg(target_os = "macos")]
 use crossbeam_channel::Sender;
 #[cfg(target_os = "macos")]
-use hvf::MemoryMapping;
+use utils::worker_message::WorkerMessage;
 
 use std::convert::TryInto;
 use std::ffi::{CStr, CString};
@@ -85,7 +85,7 @@ impl<F: FileSystem + Sync> Server<F> {
         w: Writer,
         shm_region: &Option<VirtioShmRegion>,
         exit_code: &Arc<AtomicI32>,
-        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
     ) -> Result<usize> {
         let in_header: InHeader = r.read_obj().map_err(Error::DecodeMessage)?;
 
@@ -1341,7 +1341,7 @@ impl<F: FileSystem + Sync> Server<F> {
         w: Writer,
         host_shm_base: u64,
         shm_size: u64,
-        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
     ) -> Result<usize> {
         let SetupmappingIn {
             fh,
@@ -1376,7 +1376,7 @@ impl<F: FileSystem + Sync> Server<F> {
         w: Writer,
         host_shm_base: u64,
         shm_size: u64,
-        #[cfg(target_os = "macos")] map_sender: &Option<Sender<MemoryMapping>>,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
     ) -> Result<usize> {
         let RemovemappingIn { count } = r.read_obj().map_err(Error::DecodeMessage)?;
 

--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -1,7 +1,7 @@
 #[cfg(target_os = "macos")]
 use crossbeam_channel::Sender;
 #[cfg(target_os = "macos")]
-use hvf::MemoryMapping;
+use utils::worker_message::WorkerMessage;
 
 use std::os::fd::AsRawFd;
 use std::sync::atomic::{AtomicI32, AtomicUsize, Ordering};
@@ -34,7 +34,7 @@ pub struct FsWorker {
     stop_fd: EventFd,
     exit_code: Arc<AtomicI32>,
     #[cfg(target_os = "macos")]
-    map_sender: Option<Sender<MemoryMapping>>,
+    map_sender: Option<Sender<WorkerMessage>>,
 }
 
 impl FsWorker {
@@ -51,7 +51,7 @@ impl FsWorker {
         passthrough_cfg: passthrough::Config,
         stop_fd: EventFd,
         exit_code: Arc<AtomicI32>,
-        #[cfg(target_os = "macos")] map_sender: Option<Sender<MemoryMapping>>,
+        #[cfg(target_os = "macos")] map_sender: Option<Sender<WorkerMessage>>,
     ) -> Self {
         Self {
             queues,

--- a/src/devices/src/virtio/gpu/device.rs
+++ b/src/devices/src/virtio/gpu/device.rs
@@ -18,7 +18,7 @@ use super::worker::Worker;
 use crate::legacy::IrqChip;
 use crate::Error as DeviceError;
 #[cfg(target_os = "macos")]
-use hvf::MemoryMapping;
+use utils::worker_message::WorkerMessage;
 
 // Control queue.
 pub(crate) const CTL_INDEX: usize = 0;
@@ -49,7 +49,7 @@ pub struct Gpu {
     pub(crate) sender: Option<Sender<u64>>,
     virgl_flags: u32,
     #[cfg(target_os = "macos")]
-    map_sender: Sender<MemoryMapping>,
+    map_sender: Sender<WorkerMessage>,
     export_table: Option<ExportTable>,
 }
 
@@ -57,7 +57,7 @@ impl Gpu {
     pub(crate) fn with_queues(
         queues: Vec<VirtQueue>,
         virgl_flags: u32,
-        #[cfg(target_os = "macos")] map_sender: Sender<MemoryMapping>,
+        #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
     ) -> super::Result<Gpu> {
         let mut queue_events = Vec::new();
         for _ in 0..queues.len() {
@@ -92,7 +92,7 @@ impl Gpu {
 
     pub fn new(
         virgl_flags: u32,
-        #[cfg(target_os = "macos")] map_sender: Sender<MemoryMapping>,
+        #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
     ) -> super::Result<Gpu> {
         let queues: Vec<VirtQueue> = defs::QUEUE_SIZES
             .iter()

--- a/src/devices/src/virtio/gpu/worker.rs
+++ b/src/devices/src/virtio/gpu/worker.rs
@@ -6,13 +6,13 @@ use std::{result, thread};
 use crossbeam_channel::Receiver;
 #[cfg(target_os = "macos")]
 use crossbeam_channel::Sender;
-#[cfg(target_os = "macos")]
-use hvf::MemoryMapping;
 use rutabaga_gfx::{
     ResourceCreate3D, ResourceCreateBlob, RutabagaFence, Transfer3D,
     RUTABAGA_PIPE_BIND_RENDER_TARGET, RUTABAGA_PIPE_TEXTURE_2D,
 };
 use utils::eventfd::EventFd;
+#[cfg(target_os = "macos")]
+use utils::worker_message::WorkerMessage;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
 
 use super::super::descriptor_utils::{Reader, Writer};
@@ -39,7 +39,7 @@ pub struct Worker {
     shm_region: VirtioShmRegion,
     virgl_flags: u32,
     #[cfg(target_os = "macos")]
-    map_sender: Sender<MemoryMapping>,
+    map_sender: Sender<WorkerMessage>,
     export_table: Option<ExportTable>,
 }
 
@@ -55,7 +55,7 @@ impl Worker {
         irq_line: Option<u32>,
         shm_region: VirtioShmRegion,
         virgl_flags: u32,
-        #[cfg(target_os = "macos")] map_sender: Sender<MemoryMapping>,
+        #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
         export_table: Option<ExportTable>,
     ) -> Self {
         Self {

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -24,7 +24,6 @@ use std::time::Duration;
 
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 use arch::aarch64::sysreg::{sys_reg_name, SYSREG_MASK};
-use crossbeam_channel::Sender;
 use log::debug;
 
 extern "C" {
@@ -147,12 +146,6 @@ impl Display for Error {
             VmCreate => write!(f, "Error creating HVF VM instance"),
         }
     }
-}
-
-/// Messages for requesting memory maps/unmaps.
-pub enum MemoryMapping {
-    AddMapping(Sender<bool>, u64, u64, u64),
-    RemoveMapping(Sender<bool>, u64, u64),
 }
 
 pub enum InterruptType {

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -10,3 +10,6 @@ env_logger = "0.9.0"
 libc = ">=0.2.85"
 log = "0.4.0"
 vmm-sys-util = "0.12.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+kvm-bindings = { version = ">=0.10", features = ["fam-wrappers"] }

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -10,6 +10,7 @@ env_logger = "0.9.0"
 libc = ">=0.2.85"
 log = "0.4.0"
 vmm-sys-util = "0.12.1"
+crossbeam-channel = "0.5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.10", features = ["fam-wrappers"] }

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -23,3 +23,4 @@ pub mod sized_vec;
 pub mod sm;
 pub mod syscall;
 pub mod time;
+pub mod worker_message;

--- a/src/utils/src/worker_message.rs
+++ b/src/utils/src/worker_message.rs
@@ -1,9 +1,12 @@
 #[derive(Debug)]
 pub enum WorkerMessage {
     #[cfg(target_arch = "x86_64")]
-    GsiRoute(Vec<kvm_bindings::kvm_irq_routing_entry>),
+    GsiRoute(
+        crossbeam_channel::Sender<bool>,
+        Vec<kvm_bindings::kvm_irq_routing_entry>,
+    ),
     #[cfg(target_arch = "x86_64")]
-    IrqLine(u32, bool),
+    IrqLine(crossbeam_channel::Sender<bool>, u32, bool),
     #[cfg(target_os = "macos")]
     GpuAddMapping(crossbeam_channel::Sender<bool>, u64, u64, u64),
     #[cfg(target_os = "macos")]

--- a/src/utils/src/worker_message.rs
+++ b/src/utils/src/worker_message.rs
@@ -1,0 +1,7 @@
+#[derive(Debug)]
+pub enum WorkerMessage {
+    #[cfg(target_arch = "x86_64")]
+    GsiRoute(Vec<kvm_bindings::kvm_irq_routing_entry>),
+    #[cfg(target_arch = "x86_64")]
+    IrqLine(u32, bool),
+}

--- a/src/utils/src/worker_message.rs
+++ b/src/utils/src/worker_message.rs
@@ -1,4 +1,11 @@
 #[derive(Debug)]
+pub struct MemoryProperties {
+    pub gpa: u64,
+    pub size: u64,
+    pub private: bool,
+}
+
+#[derive(Debug)]
 pub enum WorkerMessage {
     #[cfg(target_arch = "x86_64")]
     GsiRoute(
@@ -11,4 +18,5 @@ pub enum WorkerMessage {
     GpuAddMapping(crossbeam_channel::Sender<bool>, u64, u64, u64),
     #[cfg(target_os = "macos")]
     GpuRemoveMapping(crossbeam_channel::Sender<bool>, u64, u64),
+    ConvertMemory(crossbeam_channel::Sender<bool>, MemoryProperties),
 }

--- a/src/utils/src/worker_message.rs
+++ b/src/utils/src/worker_message.rs
@@ -4,4 +4,8 @@ pub enum WorkerMessage {
     GsiRoute(Vec<kvm_bindings::kvm_irq_routing_entry>),
     #[cfg(target_arch = "x86_64")]
     IrqLine(u32, bool),
+    #[cfg(target_os = "macos")]
+    GpuAddMapping(crossbeam_channel::Sender<bool>, u64, u64, u64),
+    #[cfg(target_os = "macos")]
+    GpuRemoveMapping(crossbeam_channel::Sender<bool>, u64, u64),
 }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -512,8 +512,7 @@ pub fn build_microvm(
     event_manager: &mut EventManager,
     _shutdown_efd: Option<EventFd>,
     #[cfg(feature = "tee")] pm_sender: (Sender<MemoryProperties>, EventFd),
-    #[cfg(target_os = "macos")] _sender: Sender<WorkerMessage>,
-    #[cfg(target_arch = "x86_64")] _sender: Sender<(WorkerMessage, EventFd)>,
+    _sender: Sender<WorkerMessage>,
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     let payload = choose_payload(vm_resources)?;
 

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -34,8 +34,6 @@ mod terminal;
 pub mod worker;
 
 #[cfg(target_os = "macos")]
-pub use hvf::MemoryMapping;
-#[cfg(target_os = "macos")]
 use macos::vstate;
 
 use std::fmt::{Display, Formatter};

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -31,6 +31,7 @@ use crate::linux::vstate;
 #[cfg(target_os = "macos")]
 mod macos;
 mod terminal;
+pub mod worker;
 
 #[cfg(target_os = "macos")]
 pub use hvf::MemoryMapping;

--- a/src/vmm/src/worker.rs
+++ b/src/vmm/src/worker.rs
@@ -1,9 +1,21 @@
 use std::io;
 use std::sync::{Arc, Mutex};
 
+#[cfg(feature = "tee")]
+use utils::worker_message::MemoryProperties;
 use utils::worker_message::WorkerMessage;
 
 use crossbeam_channel::Receiver;
+#[cfg(feature = "tee")]
+use crossbeam_channel::Sender;
+#[cfg(feature = "tee")]
+use kvm_bindings::{kvm_memory_attributes, KVM_MEMORY_ATTRIBUTE_PRIVATE};
+#[cfg(feature = "tee")]
+use libc::{fallocate, madvise, FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, MADV_DONTNEED};
+#[cfg(feature = "tee")]
+use std::ffi::c_void;
+#[cfg(feature = "tee")]
+use vm_memory::{guest_memory::GuestMemory, GuestAddress, GuestMemoryRegion, MemoryRegionAddress};
 
 pub fn start_worker_thread(
     vmm: Arc<Mutex<super::Vmm>>,
@@ -55,6 +67,94 @@ impl super::Vmm {
                     .send(self.vm.fd().set_irq_line(irq, active).is_ok())
                     .unwrap();
             }
+            WorkerMessage::ConvertMemory(_sender, _properties) =>
+            {
+                #[cfg(feature = "tee")]
+                self.convert_memory(_sender, _properties)
+            }
         }
+    }
+
+    #[cfg(feature = "tee")]
+    fn convert_memory(&self, sender: Sender<bool>, properties: MemoryProperties) {
+        let (guest_memfd, region_start) = self
+            .kvm_vm()
+            .guest_memfd_get(properties.gpa)
+            .unwrap_or_else(|| {
+                panic!(
+                    "unable to find KVM guest_memfd for memory region corresponding to GPA 0x{:x}",
+                    properties.gpa
+                )
+            });
+
+        let attributes: u64 = if properties.private {
+            KVM_MEMORY_ATTRIBUTE_PRIVATE as u64
+        } else {
+            0
+        };
+
+        let attr = kvm_memory_attributes {
+            address: properties.gpa,
+            size: properties.size,
+            attributes,
+            flags: 0,
+        };
+
+        self.kvm_vm()
+            .fd()
+            .set_memory_attributes(attr)
+            .unwrap_or_else(|_| panic!("unable to set memory attributes for memory region corresponding to guest address 0x{:x}", properties.gpa));
+
+        let region = self
+            .guest_memory()
+            .find_region(GuestAddress(properties.gpa));
+        if region.is_none() {
+            error!(
+                "guest memory region corresponding to GPA 0x{:x} not found",
+                properties.gpa
+            );
+            sender.send(false).unwrap();
+            return;
+        }
+
+        let offset = properties.gpa - region_start;
+
+        if properties.private {
+            let region_addr = MemoryRegionAddress(offset);
+
+            let host_startaddr = region
+                .unwrap()
+                .get_host_address(region_addr)
+                .expect("host address corresponding to memory region address 0x{:x} not found");
+
+            let ret = unsafe {
+                madvise(
+                    host_startaddr as *mut c_void,
+                    properties.size.try_into().unwrap(),
+                    MADV_DONTNEED,
+                )
+            };
+
+            if ret < 0 {
+                error!("unable to advise kernel that memory region corresponding to GPA 0x{:x} will likely not be needed (madvise)", properties.gpa);
+                sender.send(false).unwrap();
+            }
+        } else {
+            let ret = unsafe {
+                fallocate(
+                    guest_memfd,
+                    FALLOC_FL_PUNCH_HOLE | FALLOC_FL_KEEP_SIZE,
+                    offset as i64,
+                    properties.size as i64,
+                )
+            };
+
+            if ret < 0 {
+                error!("unable to allocate space in guest_memfd for shared memory (fallocate)");
+                sender.send(false).unwrap();
+            }
+        }
+
+        sender.send(true).unwrap();
     }
 }

--- a/src/vmm/src/worker.rs
+++ b/src/vmm/src/worker.rs
@@ -1,0 +1,58 @@
+use std::io;
+use std::sync::{Arc, Mutex};
+
+use utils::eventfd::EventFd;
+use utils::worker_message::WorkerMessage;
+
+use crossbeam_channel::Receiver;
+
+pub fn start_worker_thread(
+    vmm: Arc<Mutex<super::Vmm>>,
+    #[cfg(not(target_os = "macos"))] receiver: Receiver<(WorkerMessage, EventFd)>,
+) -> io::Result<()> {
+    std::thread::Builder::new()
+        .name("vmm worker".into())
+        .spawn(move || loop {
+            match receiver.recv() {
+                Err(e) => error!("error receiving message from vmm worker thread: {:?}", e),
+                #[cfg(target_os = "linux")]
+                Ok((message, evt_fd)) => vmm.lock().unwrap().match_worker_message(message, evt_fd),
+            }
+        })?;
+    Ok(())
+}
+
+impl super::Vmm {
+    fn match_worker_message(
+        &self,
+        msg: WorkerMessage,
+        #[cfg(target_os = "linux")] evt_fd: EventFd,
+    ) {
+        match msg {
+            #[cfg(target_arch = "x86_64")]
+            WorkerMessage::GsiRoute(entries) => {
+                let mut irq_routing = utils::sized_vec::vec_with_array_field::<
+                    kvm_bindings::kvm_irq_routing,
+                    kvm_bindings::kvm_irq_routing_entry,
+                >(entries.len());
+                irq_routing[0].nr = entries.len() as u32;
+                irq_routing[0].flags = 0;
+
+                unsafe {
+                    let entries_slice: &mut [kvm_bindings::kvm_irq_routing_entry] =
+                        irq_routing[0].entries.as_mut_slice(entries.len());
+                    entries_slice.copy_from_slice(&entries);
+                }
+
+                self.vm.fd().set_gsi_routing(&irq_routing[0]).unwrap();
+
+                evt_fd.write(1).unwrap();
+            }
+            #[cfg(target_arch = "x86_64")]
+            WorkerMessage::IrqLine(irq, active) => {
+                self.vm.fd().set_irq_line(irq, active).unwrap();
+                evt_fd.write(1).unwrap();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Whenever the vCPU needs to access resources the Vm or Vmm has control over, we end up spawning a worker thread to complete the task. Rather than spawning a new worker thread for each task, use a single thread, but make the message that's passed generic to allow for multiple use cases.  