### PR TITLE
Introduce a display subsystem for GPU output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-rs"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae50b5510d86cf96ac2370e66d8dc960882f3df179d6a5a1e52bd94a1416c0f7"
+dependencies = [
+ "bitflags 2.9.0",
+ "cairo-sys-rs",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "cairo-sys-rs"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f18b6bb8e43c7eb0f2aac7976afe0c61b6f5fc2ab7bc4c139537ea56c92290df"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps 7.0.3",
+]
+
+[[package]]
 name = "caps"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -269,6 +292,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfg-expr"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d4ba6e40bd1184518716a6e1a781bf9160e286d219ccdb8ab2612e74cfe4789"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,9 +315,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -407,6 +440,7 @@ dependencies = [
  "caps",
  "crossbeam-channel",
  "env_logger",
+ "gtk4",
  "hvf",
  "imago",
  "kvm-bindings",
@@ -474,6 +508,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "field-offset"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
+dependencies = [
+ "memoffset 0.9.1",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -596,10 +640,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.15"
+name = "gdk-pixbuf"
+version = "0.20.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "7563afd6ff0a221edfbb70a78add5075b8d9cb48e637a40a24c3ece3fea414d0"
+dependencies = [
+ "gdk-pixbuf-sys",
+ "gio",
+ "glib",
+ "libc",
+]
+
+[[package]]
+name = "gdk-pixbuf-sys"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67f2587c9202bf997476bbba6aaed4f78a11538a2567df002a5f57f5331d0b5c"
+dependencies = [
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 7.0.3",
+]
+
+[[package]]
+name = "gdk4"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850c9d9c1aecd1a3eb14fadc1cdb0ac0a2298037e116264c7473e1740a32d60"
+dependencies = [
+ "cairo-rs",
+ "gdk-pixbuf",
+ "gdk4-sys",
+ "gio",
+ "glib",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gdk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f6eb95798e2b46f279cf59005daf297d5b69555428f185650d71974a910473a"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "pango-sys",
+ "pkg-config",
+ "system-deps 7.0.3",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -625,10 +726,201 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "gio"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f00c70f8029d84ea7572dd0e1aaa79e5329667b4c17f329d79ffb1e6277487"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "gio-sys",
+ "glib",
+ "libc",
+ "pin-project-lite",
+ "smallvec",
+]
+
+[[package]]
+name = "gio-sys"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "160eb5250a26998c3e1b54e6a3d4ea15c6c7762a6062a19a7b63eff6e2b33f9e"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 7.0.3",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "glib"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707b819af8059ee5395a2de9f2317d87a53dbad8846a2f089f0bb44703f37686"
+dependencies = [
+ "bitflags 2.9.0",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-task",
+ "futures-util",
+ "gio-sys",
+ "glib-macros",
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "memchr",
+ "smallvec",
+]
+
+[[package]]
+name = "glib-macros"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715601f8f02e71baef9c1f94a657a9a77c192aea6097cf9ae7e5e177cd8cde68"
+dependencies = [
+ "heck",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "glib-sys"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928869a44cfdd1fccb17d6746e4ff82c8f82e41ce705aa026a52ca8dc3aefb"
+dependencies = [
+ "libc",
+ "system-deps 7.0.3",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gobject-sys"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c773a3cb38a419ad9c26c81d177d96b4b08980e8bdbbf32dace883e96e96e7e3"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "system-deps 7.0.3",
+]
+
+[[package]]
+name = "graphene-rs"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cbc5911bfb32d68dcfa92c9510c462696c2f715548fcd7f3f1be424c739de19"
+dependencies = [
+ "glib",
+ "graphene-sys",
+ "libc",
+]
+
+[[package]]
+name = "graphene-sys"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a68d39515bf340e879b72cecd4a25c1332557757ada6e8aba8654b4b81d23a"
+dependencies = [
+ "glib-sys",
+ "libc",
+ "pkg-config",
+ "system-deps 7.0.3",
+]
+
+[[package]]
+name = "gsk4"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f5e72f931c8c9f65fbfc89fe0ddc7746f147f822f127a53a9854666ac1f855"
+dependencies = [
+ "cairo-rs",
+ "gdk4",
+ "glib",
+ "graphene-rs",
+ "gsk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gsk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "755059de55fa6f85a46bde8caf03e2184c96bfda1f6206163c72fb0ea12436dc"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk4-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "libc",
+ "pango-sys",
+ "system-deps 7.0.3",
+]
+
+[[package]]
+name = "gtk4"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af1c491051f030994fd0cde6f3c44f3f5640210308cff1298c7673c47408091d"
+dependencies = [
+ "cairo-rs",
+ "field-offset",
+ "futures-channel",
+ "gdk-pixbuf",
+ "gdk4",
+ "gio",
+ "glib",
+ "graphene-rs",
+ "gsk4",
+ "gtk4-macros",
+ "gtk4-sys",
+ "libc",
+ "pango",
+]
+
+[[package]]
+name = "gtk4-macros"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1786c4703dd196baf7e103525ce0cf579b3a63a0570fe653b7ee6bac33999"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "gtk4-sys"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41e03b01e54d77c310e1d98647d73f996d04b2f29b9121fe493ea525a7ec03d6"
+dependencies = [
+ "cairo-sys-rs",
+ "gdk-pixbuf-sys",
+ "gdk4-sys",
+ "gio-sys",
+ "glib-sys",
+ "gobject-sys",
+ "graphene-sys",
+ "gsk4-sys",
+ "libc",
+ "pango-sys",
+ "system-deps 7.0.3",
+]
 
 [[package]]
 name = "hashbrown"
@@ -896,7 +1188,7 @@ dependencies = [
  "libspa-sys",
  "nix 0.27.1",
  "nom",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -907,7 +1199,7 @@ checksum = "bf0d9716420364790e85cbb9d3ac2c950bde16a7dd36f3209b7dfdfc4a24d01f"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -966,6 +1258,15 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
 ]
@@ -1128,6 +1429,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pango"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1f5dc1b8cf9bc08bfc0843a04ee0fa2e78f1e1fa4b126844a383af4f25f0ec"
+dependencies = [
+ "gio",
+ "glib",
+ "libc",
+ "pango-sys",
+]
+
+[[package]]
+name = "pango-sys"
+version = "0.20.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dbb9b751673bd8fe49eb78620547973a1e719ed431372122b20abd12445bab5"
+dependencies = [
+ "glib-sys",
+ "gobject-sys",
+ "libc",
+ "system-deps 7.0.3",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,7 +1489,7 @@ checksum = "849e188f90b1dda88fe2bfe1ad31fe5f158af2c98f80fb5d13726c44f3f01112"
 dependencies = [
  "bindgen 0.69.5",
  "libspa-sys",
- "system-deps",
+ "system-deps 6.2.2",
 ]
 
 [[package]]
@@ -1187,7 +1512,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -1198,6 +1523,15 @@ checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
+dependencies = [
+ "toml_edit",
 ]
 
 [[package]]
@@ -1266,7 +1600,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1284,7 +1618,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror",
 ]
@@ -1556,9 +1890,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1571,7 +1905,20 @@ version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
 dependencies = [
- "cfg-expr",
+ "cfg-expr 0.15.8",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "system-deps"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d23aaf9f331227789a99e8de4c91bf46703add012bdfd45fdecdfb2975a005"
+dependencies = [
+ "cfg-expr 0.17.2",
  "heck",
  "pkg-config",
  "toml",
@@ -1625,9 +1972,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1637,18 +1984,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "serde",
@@ -2123,9 +2470,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -2160,11 +2507,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -2180,9 +2527,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,9 @@ endif
 ifeq ($(GPU),1)
     FEATURE_FLAGS += --features gpu
 endif
+ifeq ($(GTK_DISPLAY),1)
+    FEATURE_FLAGS += --features gtk_display
+endif
 ifeq ($(VIRGL_RESOURCE_MAP2),1)
 	FEATURE_FLAGS += --features virgl_resource_map2
 endif

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -362,6 +362,18 @@ int32_t krun_set_gpu_options2(uint32_t ctx_id,
 int32_t krun_set_display(uint32_t ctx_id, uint32_t display_id, uint32_t width, uint32_t height);
 
 /**
+ * Enable the Gtk display backend. This allows you to attach virtual displays to the GPU
+ * for graphical output.
+ *
+ * Arguments:
+ *  "ctx_id"      - the configuration context ID
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_display_backend_gtk(uint32_t ctx_id);
+
+/**
  * Enables or disables a virtio-snd device.
  *
  * Arguments:

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -341,6 +341,26 @@ int32_t krun_set_gpu_options2(uint32_t ctx_id,
                               uint32_t virgl_flags,
                               uint64_t shm_size);
 
+/* Maximum number of displays. Same as VIRTIO_GPU_MAX_SCANOUTS defined in the virtio-gpu spec */
+#define KRUN_MAX_DISPLAYS 16
+
+/**
+ * Configure and enable a display output for the VM.
+ *
+ * Some display backend must be set using krun_set_display_backend_*, and the GPU
+ * device must be enabled.
+ *
+ * Arguments:
+ *  "ctx_id"      - the configuration context ID.
+ *  "display_id"  - the ID of the display (range: 0 to KRUN_MAX_DISPLAYS - 1)
+ *  "width"       - the width of the window/display
+ *  "height"      - the height of the window/display
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_display(uint32_t ctx_id, uint32_t display_id, uint32_t width, uint32_t height);
+
 /**
  * Enables or disables a virtio-snd device.
  *

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -12,6 +12,7 @@ blk = []
 efi = ["blk", "net"]
 gpu = ["rutabaga_gfx", "thiserror", "zerocopy", "zerocopy-derive"]
 snd = ["pw", "thiserror"]
+gtk_display = ["gpu", "gtk4"]
 virgl_resource_map2 = []
 
 [dependencies]
@@ -29,6 +30,7 @@ virtio-bindings = "0.2.0"
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
 zerocopy = { version = "0.6.3", optional = true }
 zerocopy-derive = { version = "0.6.3", optional = true }
+gtk4 = { version = "0.9.6", features = ["v4_14"], optional = true }
 
 arch = { path = "../arch" }
 utils = { path = "../utils" }

--- a/src/devices/src/display/gtk/mod.rs
+++ b/src/devices/src/display/gtk/mod.rs
@@ -1,0 +1,116 @@
+mod worker;
+
+use crate::display::gtk::worker::gtk_display_main_loop;
+use crate::display::{check_scanout_id, DisplayBackend, DisplayBackendError, DisplayInfoList};
+use crate::virtio::GpuResourceFormat;
+use gtk4::gdk;
+use std::thread;
+use utils::pollable_channel::{pollable_channel, PollableChannelSender};
+
+enum DisplayEvent {
+    ConfigureScanout {
+        scanout_id: u32,
+        width: i32,
+        height: i32,
+        format: gdk::MemoryFormat,
+    },
+    DisableScanout {
+        scanout_id: u32,
+    },
+    UpdateScanout {
+        scanout_id: u32,
+        data: Vec<u8>,
+        /// stride/pitch of row specified in bytes
+        stride: u32,
+    },
+}
+
+pub struct DisplayBackendGtk {
+    tx: PollableChannelSender<DisplayEvent>,
+    displays: DisplayInfoList,
+}
+
+fn resource_format_into_gdk(format: GpuResourceFormat) -> gdk::MemoryFormat {
+    match format {
+        GpuResourceFormat::BGRA => gdk::MemoryFormat::B8g8r8a8,
+        GpuResourceFormat::BGRX => gdk::MemoryFormat::B8g8r8x8,
+        GpuResourceFormat::ARGB => gdk::MemoryFormat::A8r8g8b8,
+        GpuResourceFormat::XRGB => gdk::MemoryFormat::X8r8g8b8,
+        GpuResourceFormat::RGBA => gdk::MemoryFormat::R8g8b8a8,
+        GpuResourceFormat::XBGR => gdk::MemoryFormat::X8b8g8r8,
+        GpuResourceFormat::ABGR => gdk::MemoryFormat::A8b8g8r8,
+        GpuResourceFormat::RGBX => gdk::MemoryFormat::R8g8b8x8,
+    }
+}
+
+impl DisplayBackendGtk {
+    pub fn new(displays: DisplayInfoList) -> DisplayBackendGtk {
+        let (tx, rx) = pollable_channel().unwrap();
+        let displays_clone = displays.clone();
+        thread::Builder::new()
+            .name("gtk display".to_string())
+            .spawn(move || {
+                gtk_display_main_loop(rx, displays_clone);
+            })
+            .unwrap();
+
+        Self { displays, tx }
+    }
+}
+
+impl DisplayBackend for DisplayBackendGtk {
+    fn displays(&self) -> &DisplayInfoList {
+        &self.displays
+    }
+
+    fn configure_scanout(
+        &self,
+        scanout_id: u32,
+        width: u32,
+        height: u32,
+        format: GpuResourceFormat,
+    ) -> Result<(), DisplayBackendError> {
+        check_scanout_id(self, scanout_id)?;
+        let Ok(width) = width.try_into() else {
+            warn!("Display width out of range");
+            return Err(DisplayBackendError::InvalidParameter);
+        };
+
+        let Ok(height) = height.try_into() else {
+            warn!("Display width out of range");
+            return Err(DisplayBackendError::InvalidParameter);
+        };
+
+        let format = resource_format_into_gdk(format);
+
+        self.tx.send(DisplayEvent::ConfigureScanout {
+            scanout_id,
+            width,
+            height,
+            format,
+        })?;
+        Ok(())
+    }
+
+    fn disable_scanout(&self, scanout_id: u32) -> Result<(), DisplayBackendError> {
+        check_scanout_id(self, scanout_id)?;
+        self.tx.send(DisplayEvent::DisableScanout { scanout_id })?;
+        Ok(())
+    }
+
+    fn update_scanout(
+        &self,
+        scanout_id: u32,
+        data: Vec<u8>,
+        stride: u32,
+    ) -> Result<(), DisplayBackendError> {
+        check_scanout_id(self, scanout_id)?;
+
+        self.tx.send(DisplayEvent::UpdateScanout {
+            scanout_id,
+            data,
+            stride,
+        })?;
+        Ok(())
+    }
+}

--- a/src/devices/src/display/gtk/worker.rs
+++ b/src/devices/src/display/gtk/worker.rs
@@ -1,0 +1,276 @@
+use std::os::fd::AsRawFd;
+
+use crate::display::gtk::DisplayEvent;
+use crate::display::{DisplayInfo, DisplayInfoList, MAX_DISPLAYS};
+use utils::pollable_channel::PollableChannelReciever;
+
+use gtk4::{
+    gdk,
+    gio::{ActionEntry, Cancellable, SimpleActionGroup},
+    glib::{self, source, Bytes, ControlFlow, IOCondition},
+    prelude::*,
+    AlertDialog, Align, Button, EventControllerMotion, HeaderBar, Overlay, Picture,
+    Revealer, RevealerTransitionType, Window,
+};
+
+struct Scanout {
+    window: Window,
+    width: i32,
+    height: i32,
+    format: gdk::MemoryFormat,
+    picture: Picture,
+}
+
+impl Scanout {
+    fn new(
+        title: String,
+        display_info: DisplayInfo,
+        width: i32,
+        height: i32,
+        format: gdk::MemoryFormat,
+    ) -> Self {
+        let header_bar = HeaderBar::new();
+        let window = Window::builder()
+            .title(title)
+            // remove the close button, since it is unclear what it should do
+            .deletable(false)
+            // Enforce a minimum window size:
+            .height_request(64)
+            .titlebar(&header_bar)
+            .build();
+
+        let actions = SimpleActionGroup::new();
+        actions.add_action_entries([
+            ActionEntry::builder("kill")
+                .activate(glib::clone!(
+                    #[weak]
+                    window,
+                    move |_, _, _| {
+                        let dialog = AlertDialog::builder()
+                            .buttons(["Kill VM", "Cancel"].as_ref())
+                            .default_button(0)
+                            .cancel_button(1)
+                            .modal(true)
+                            .message("Do you want to kill the VM?")
+                            .detail("WARNING: This may lead to loss of data or corruption of the VM image.")
+                            .build();
+                        dialog.choose(Some(&window), None::<&Cancellable>, |b| {
+                            if b.is_ok_and(|b| b == 0) {
+                                // SAFETY: Safe because we are terminating the process anyway.
+                                // We also use _exit during normal VM exit, so we don't clean up
+                                // ever anyway.
+                                unsafe { libc::_exit(125) };
+                            }
+                        });
+                    }
+                ))
+                .build(),
+            ActionEntry::builder("fullscreen")
+                .activate(glib::clone!(
+                    #[weak]
+                    window,
+                    move |_, _, _| {
+                        window.fullscreen();
+                    }
+                ))
+                .build(),
+            ActionEntry::builder("unfullscreen")
+                .activate(glib::clone!(
+                    #[weak]
+                    window,
+                    move |_, _, _| {
+                        window.unfullscreen();
+                    }
+                ))
+                .build(),
+        ]);
+        window.insert_action_group("scanout", Some(&actions));
+
+        let fullscreen_btn = Button::builder()
+            .icon_name("view-fullscreen")
+            .tooltip_text("Enter fullscreen mode")
+            .action_name("scanout.fullscreen")
+            .build();
+
+        let picture = Picture::builder()
+            // Set picture dimension to the requested display size,
+            // this will make the created window have the appropriate size
+            .width_request(display_info.width as i32)
+            .height_request(display_info.height as i32)
+            .build();
+
+        window.set_titlebar(Some(&header_bar));
+        header_bar.pack_start(&build_kill_vm_btn());
+        header_bar.pack_end(&fullscreen_btn);
+
+        let overlay = build_overlay(&window);
+        overlay.set_child(Some(&picture));
+        window.set_child(Some(&overlay));
+        window.set_visible(true);
+
+        // Unset the width/height after the window is created to allow resizing the window to
+        // be smaller
+        picture.set_size_request(-1, -1);
+
+        Self {
+            window,
+            width,
+            height,
+            format,
+            picture,
+        }
+    }
+
+    fn update_params(&mut self, width: i32, height: i32, format: gdk::MemoryFormat) {
+        self.width = width;
+        self.height = height;
+        self.format = format;
+    }
+
+    fn update(&mut self, data: Vec<u8>, stride: u32) {
+        let texture = gdk::MemoryTexture::new(
+            self.width,
+            self.height,
+            self.format,
+            &Bytes::from_owned(data),
+            stride as usize,
+        );
+        self.picture.set_paintable(Some(&texture));
+    }
+}
+
+impl Drop for Scanout {
+    fn drop(&mut self) {
+        self.window.destroy();
+    }
+}
+
+fn build_kill_vm_btn() -> Button {
+    let kill_vm_btn = Button::builder()
+        .label("Kill VM")
+        .action_name("scanout.kill")
+        .build();
+    kill_vm_btn.add_css_class("destructive-action");
+    kill_vm_btn
+}
+
+fn build_overlay(window: &Window) -> Overlay {
+    let overlay_bar = HeaderBar::builder()
+        .valign(Align::Start)
+        .hexpand_set(false)
+        .hexpand(false)
+        .opacity(0.8)
+        .build();
+
+    let overlay = Overlay::new();
+    let revealer = Revealer::builder()
+        .transition_type(RevealerTransitionType::SwingDown)
+        .transition_duration(300)
+        .reveal_child(false)
+        .build();
+    revealer.set_child(Some(&overlay_bar));
+    overlay.add_overlay(&revealer);
+
+    let overlay_unfullscreen_btn = Button::builder()
+        .tooltip_text("Exit fullscreen mode")
+        .icon_name("view-restore")
+        .action_name("window.unfullscreen")
+        .build();
+
+    let bar_controller = EventControllerMotion::new();
+    bar_controller.connect_leave(glib::clone!(
+        #[weak]
+        revealer,
+        move |_| {
+            revealer.set_reveal_child(false);
+        }
+    ));
+    overlay_bar.add_controller(bar_controller);
+
+    let overlay_controller = EventControllerMotion::new();
+    overlay_controller.connect_motion(glib::clone!(
+        #[weak]
+        revealer,
+        #[weak]
+        window,
+        move |_motion, _x, y| {
+            if window.is_fullscreen() && y < 1.0 {
+                revealer.set_reveal_child(true);
+            }
+        }
+    ));
+    overlay.add_controller(overlay_controller);
+
+    overlay_bar.pack_start(&build_kill_vm_btn());
+    overlay_bar.pack_end(&overlay_unfullscreen_btn);
+    overlay_bar.set_show_title_buttons(false);
+
+    overlay
+}
+
+pub fn gtk_display_main_loop(rx: PollableChannelReciever<DisplayEvent>, displays: DisplayInfoList) {
+    gtk4::init().expect("Failed to initialize GTK");
+    let main_loop = glib::MainLoop::new(None, false);
+
+    let mut scanouts: [Option<Scanout>; MAX_DISPLAYS] = [const { None }; MAX_DISPLAYS];
+    let program_name = {
+        let args = std::env::args();
+        args.into_iter()
+            .next()
+            .map(|name| format!("{name} (libkrun)"))
+            .unwrap_or_else(|| "libkrun".to_string())
+    };
+
+    source::unix_fd_add_local(rx.as_raw_fd(), IOCondition::IN, move |_, _| {
+        let Some(msg) = rx.try_recv().unwrap() else {
+            return ControlFlow::Continue;
+        };
+
+        // The scanout_id validity is checked by DisplayBackendGtk, so we just assume it is valid
+        // here
+        match msg {
+            DisplayEvent::ConfigureScanout {
+                scanout_id,
+                width,
+                height,
+                format,
+            } => {
+                let display_info = displays[scanout_id as usize]
+                    .as_ref()
+                    .expect("Invalid scanout_id");
+                if let Some(ref mut scanout) = scanouts[scanout_id as usize] {
+                    trace!("Update params of scanout {scanout_id}: width={width} height={height} format={format:?}");
+                    scanout.update_params(width, height, format);
+                } else {
+                    debug!("Enable scanout {scanout_id} width={width} height={height} format={format:?}");
+                    scanouts[scanout_id as usize] = Some(Scanout::new(
+                        format!("{program_name} - display {scanout_id} ({width}x{height})"),
+                        display_info.clone(),
+                        width,
+                        height,
+                        format,
+                    ));
+                }
+            }
+            DisplayEvent::DisableScanout { scanout_id } => {
+                debug!("Disable scanout {scanout_id}");
+                scanouts[scanout_id as usize] = None;
+            }
+            DisplayEvent::UpdateScanout {
+                scanout_id,
+                data,
+                stride,
+            } => {
+                if let Some(scanout) = &mut scanouts[scanout_id as usize] {
+                    scanout.update(data, stride);
+                } else {
+                    warn!("Attempted to update non-existent scanout: {scanout_id}");
+                }
+            }
+        };
+
+        ControlFlow::Continue
+    });
+
+    main_loop.run();
+}

--- a/src/devices/src/display/mod.rs
+++ b/src/devices/src/display/mod.rs
@@ -1,0 +1,58 @@
+mod noop;
+
+pub use noop::DisplayBackendNoop;
+use std::io;
+
+use crate::virtio::GpuResourceFormat;
+use thiserror::Error;
+use virtio_bindings::virtio_gpu::VIRTIO_GPU_MAX_SCANOUTS;
+
+#[derive(Clone, Debug)]
+pub struct DisplayInfo {
+    pub width: u32,
+    pub height: u32,
+}
+
+pub const MAX_DISPLAYS: usize = VIRTIO_GPU_MAX_SCANOUTS as usize;
+pub type DisplayInfoList = [Option<DisplayInfo>; MAX_DISPLAYS];
+
+impl DisplayInfo {
+    pub fn new(width: u32, height: u32) -> Self {
+        DisplayInfo { width, height }
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum DisplayBackendError {
+    #[error("Invalid scanout id")]
+    InvalidScanoutId,
+    #[error("Invalid parameter")]
+    InvalidParameter,
+    #[error("Internal IO error: {0}")]
+    InternalIOError(#[from] io::Error),
+}
+
+pub trait DisplayBackend: Send {
+    fn displays(&self) -> &DisplayInfoList;
+
+    fn num_displays(&self) -> u32 {
+        self.displays().len() as u32
+    }
+
+    fn configure_scanout(
+        &self,
+        scanout_id: u32,
+        width: u32,
+        height: u32,
+        format: GpuResourceFormat,
+    ) -> Result<(), DisplayBackendError>;
+
+    fn disable_scanout(&self, scanout_id: u32) -> Result<(), DisplayBackendError>;
+
+    fn update_scanout(
+        &self,
+        scanout_id: u32,
+        data: Vec<u8>,
+        stride: u32,
+    ) -> Result<(), DisplayBackendError>;
+}

--- a/src/devices/src/display/mod.rs
+++ b/src/devices/src/display/mod.rs
@@ -3,6 +3,11 @@ mod noop;
 pub use noop::DisplayBackendNoop;
 use std::io;
 
+#[cfg(feature = "gtk_display")]
+mod gtk;
+#[cfg(feature = "gtk_display")]
+pub use gtk::DisplayBackendGtk;
+
 use crate::virtio::GpuResourceFormat;
 use thiserror::Error;
 use virtio_bindings::virtio_gpu::VIRTIO_GPU_MAX_SCANOUTS;
@@ -55,4 +60,20 @@ pub trait DisplayBackend: Send {
         data: Vec<u8>,
         stride: u32,
     ) -> Result<(), DisplayBackendError>;
+}
+
+pub fn check_scanout_id(
+    backend: &impl DisplayBackend,
+    scanout_id: u32,
+) -> Result<(), DisplayBackendError> {
+    let displays = backend.displays();
+
+    if displays
+        .get(scanout_id as usize)
+        .is_some_and(|d| d.is_some())
+    {
+        Ok(())
+    } else {
+        Err(DisplayBackendError::InvalidScanoutId)
+    }
 }

--- a/src/devices/src/display/noop.rs
+++ b/src/devices/src/display/noop.rs
@@ -1,0 +1,34 @@
+use crate::display::{DisplayBackend, DisplayBackendError, DisplayInfoList, MAX_DISPLAYS};
+use crate::virtio::GpuResourceFormat;
+
+pub struct DisplayBackendNoop;
+
+impl DisplayBackend for DisplayBackendNoop {
+    fn displays(&self) -> &DisplayInfoList {
+        static NO_DISPLAYS: DisplayInfoList = [const { None }; MAX_DISPLAYS];
+        &NO_DISPLAYS
+    }
+
+    fn configure_scanout(
+        &self,
+        _scanout_id: u32,
+        _width: u32,
+        _height: u32,
+        _format: GpuResourceFormat,
+    ) -> Result<(), DisplayBackendError> {
+        Err(DisplayBackendError::InvalidScanoutId)
+    }
+
+    fn disable_scanout(&self, _scanout_id: u32) -> Result<(), DisplayBackendError> {
+        Err(DisplayBackendError::InvalidScanoutId)
+    }
+
+    fn update_scanout(
+        &self,
+        _scanout_id: u32,
+        _data: Vec<u8>,
+        _stride: u32,
+    ) -> Result<(), DisplayBackendError> {
+        Err(DisplayBackendError::InvalidScanoutId)
+    }
+}

--- a/src/devices/src/lib.rs
+++ b/src/devices/src/lib.rs
@@ -14,6 +14,8 @@ use std::fmt;
 use std::io;
 
 mod bus;
+#[cfg(feature = "gpu")]
+pub mod display;
 #[cfg(target_arch = "aarch64")]
 pub mod fdt;
 pub mod legacy;

--- a/src/devices/src/virtio/gpu/mod.rs
+++ b/src/devices/src/virtio/gpu/mod.rs
@@ -8,6 +8,12 @@ use super::descriptor_utils::Error as DescriptorError;
 
 pub use self::defs::uapi::VIRTIO_ID_GPU as TYPE_GPU;
 pub use self::device::Gpu;
+use crate::virtio::gpu::protocol::{
+    VIRTIO_GPU_FORMAT_A8B8G8R8_UNORM, VIRTIO_GPU_FORMAT_A8R8G8B8_UNORM,
+    VIRTIO_GPU_FORMAT_B8G8R8A8_UNORM, VIRTIO_GPU_FORMAT_B8G8R8X8_UNORM,
+    VIRTIO_GPU_FORMAT_R8G8B8A8_UNORM, VIRTIO_GPU_FORMAT_R8G8B8X8_UNORM,
+    VIRTIO_GPU_FORMAT_X8B8G8R8_UNORM, VIRTIO_GPU_FORMAT_X8R8G8B8_UNORM,
+};
 
 mod defs {
     pub const GPU_DEV_ID: &str = "virtio_gpu";
@@ -39,6 +45,42 @@ mod defs {
             pub num_capsets: u32,
         }
         unsafe impl ByteValued for virtio_gpu_config {}
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u32)]
+pub enum GpuResourceFormat {
+    BGRA = VIRTIO_GPU_FORMAT_B8G8R8A8_UNORM,
+    BGRX = VIRTIO_GPU_FORMAT_B8G8R8X8_UNORM,
+    ARGB = VIRTIO_GPU_FORMAT_A8R8G8B8_UNORM,
+    XRGB = VIRTIO_GPU_FORMAT_X8R8G8B8_UNORM,
+    RGBA = VIRTIO_GPU_FORMAT_R8G8B8A8_UNORM,
+    XBGR = VIRTIO_GPU_FORMAT_X8B8G8R8_UNORM,
+    ABGR = VIRTIO_GPU_FORMAT_A8B8G8R8_UNORM,
+    RGBX = VIRTIO_GPU_FORMAT_R8G8B8X8_UNORM,
+}
+
+impl GpuResourceFormat {
+    // This is true for all exiting formats, hence we can hardcode it here
+    const BYTES_PER_PIXEL: u32 = 4;
+}
+
+impl TryFrom<u32> for GpuResourceFormat {
+    type Error = ();
+
+    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+        match value {
+            VIRTIO_GPU_FORMAT_B8G8R8A8_UNORM => Ok(Self::BGRA),
+            VIRTIO_GPU_FORMAT_B8G8R8X8_UNORM => Ok(Self::BGRX),
+            VIRTIO_GPU_FORMAT_A8R8G8B8_UNORM => Ok(Self::ARGB),
+            VIRTIO_GPU_FORMAT_X8R8G8B8_UNORM => Ok(Self::XRGB),
+            VIRTIO_GPU_FORMAT_R8G8B8A8_UNORM => Ok(Self::RGBA),
+            VIRTIO_GPU_FORMAT_X8B8G8R8_UNORM => Ok(Self::XBGR),
+            VIRTIO_GPU_FORMAT_A8B8G8R8_UNORM => Ok(Self::ABGR),
+            VIRTIO_GPU_FORMAT_R8G8B8X8_UNORM => Ok(Self::RGBX),
+            _ => Err(()),
+        }
     }
 }
 

--- a/src/devices/src/virtio/gpu/protocol.rs
+++ b/src/devices/src/virtio/gpu/protocol.rs
@@ -542,7 +542,7 @@ pub const VIRTIO_GPU_FORMAT_R8G8B8X8_UNORM: u32 = 134;
 /// A virtio gpu command and associated metadata specific to each command.
 #[derive(Copy, Clone)]
 pub enum GpuCommand {
-    GetDisplayInfo(virtio_gpu_ctrl_hdr),
+    GetDisplayInfo,
     ResourceCreate2d(virtio_gpu_resource_create_2d),
     ResourceUnref(virtio_gpu_resource_unref),
     SetScanout(virtio_gpu_set_scanout),
@@ -591,7 +591,7 @@ impl fmt::Debug for GpuCommand {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::GpuCommand::*;
         match self {
-            GetDisplayInfo(_info) => f.debug_struct("GetDisplayInfo").finish(),
+            GetDisplayInfo => f.debug_struct("GetDisplayInfo").finish(),
             ResourceCreate2d(_info) => f.debug_struct("ResourceCreate2d").finish(),
             ResourceUnref(_info) => f.debug_struct("ResourceUnref").finish(),
             SetScanout(_info) => f.debug_struct("SetScanout").finish(),
@@ -628,7 +628,7 @@ impl GpuCommand {
         use self::GpuCommand::*;
         let hdr = cmd.read_obj::<virtio_gpu_ctrl_hdr>()?;
         let cmd = match hdr.type_ {
-            VIRTIO_GPU_CMD_GET_DISPLAY_INFO => GetDisplayInfo(cmd.read_obj()?),
+            VIRTIO_GPU_CMD_GET_DISPLAY_INFO => GetDisplayInfo,
             VIRTIO_GPU_CMD_RESOURCE_CREATE_2D => ResourceCreate2d(cmd.read_obj()?),
             VIRTIO_GPU_CMD_RESOURCE_UNREF => ResourceUnref(cmd.read_obj()?),
             VIRTIO_GPU_CMD_SET_SCANOUT => SetScanout(cmd.read_obj()?),

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -1,10 +1,11 @@
 use std::collections::BTreeMap;
-use std::env;
+use std::io::IoSliceMut;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
+use std::{env, result};
 
 #[cfg(target_os = "macos")]
 use crossbeam_channel::{unbounded, Sender};
@@ -38,10 +39,11 @@ use super::protocol::{
 };
 
 use super::{GpuError, Result};
+use crate::display::DisplayBackend;
 use crate::legacy::IrqChip;
 use crate::virtio::fs::ExportTable;
-use crate::virtio::gpu::protocol::VIRTIO_GPU_FLAG_INFO_RING_IDX;
-use crate::virtio::{VirtioShmRegion, VIRTIO_MMIO_INT_VRING};
+use crate::virtio::gpu::protocol::{VIRTIO_GPU_FLAG_INFO_RING_IDX, VIRTIO_GPU_MAX_SCANOUTS};
+use crate::virtio::{GpuResourceFormat, VirtioShmRegion, VIRTIO_MMIO_INT_VRING};
 
 fn sglist_to_rutabaga_iovecs(
     vecs: &[(GuestAddress, usize)],
@@ -84,8 +86,35 @@ pub struct FenceState {
     completed_fences: BTreeMap<VirtioGpuRing, u64>,
 }
 
+#[derive(Copy, Clone, Debug, Default)]
+struct AssociatedScanouts(u32);
+
+impl AssociatedScanouts {
+    fn enable(&mut self, scanout_id: u32) {
+        self.0 |= 1 << scanout_id;
+    }
+
+    fn disable(&mut self, scanout_id: u32) {
+        self.0 ^= 1 << scanout_id;
+    }
+
+    const fn has_any_enabled(self) -> bool {
+        self.0 != 0
+    }
+
+    fn iter_enabled(self) -> impl Iterator<Item = u32> {
+        (0..VIRTIO_GPU_MAX_SCANOUTS).filter(move |i| ((self.0 >> i) & 1) == 1)
+    }
+}
+
+#[derive(Copy, Clone)]
 struct VirtioGpuResource {
-    size: u64,
+    id: u32,
+    width: u32,
+    height: u32,
+    scanouts: AssociatedScanouts,
+    format: Option<GpuResourceFormat>,
+    size: u64, // only for blob resources
     shmem_offset: Option<u64>,
     rutabaga_external_mapping: bool,
 }
@@ -93,13 +122,40 @@ struct VirtioGpuResource {
 impl VirtioGpuResource {
     /// Creates a new VirtioGpuResource with the given metadata.  Width and height are used by the
     /// display, while size is useful for hypervisor mapping.
-    pub fn new(_resource_id: u32, _width: u32, _height: u32, size: u64) -> VirtioGpuResource {
+    pub fn new(
+        resource_id: u32,
+        width: u32,
+        height: u32,
+        format: Option<GpuResourceFormat>,
+        size: u64,
+    ) -> VirtioGpuResource {
         VirtioGpuResource {
+            id: resource_id,
+            width,
+            height,
+            scanouts: Default::default(),
             size,
+            format,
             shmem_offset: None,
             rutabaga_external_mapping: false,
         }
     }
+
+    fn calculate_size(&self) -> result::Result<usize, &str> {
+        let width = self.width as usize;
+        let height = self.height as usize;
+        let size = width
+            .checked_mul(height)
+            .ok_or("Multiplication of width and height overflowed")?
+            .checked_mul(GpuResourceFormat::BYTES_PER_PIXEL as usize)
+            .ok_or("Multiplication of result and bytes_per_pixel overflowed")?;
+
+        Ok(size)
+    }
+}
+
+pub struct VirtioGpuScanout {
+    resource_id: u32,
 }
 
 pub struct VirtioGpu {
@@ -108,6 +164,8 @@ pub struct VirtioGpu {
     fence_state: Arc<Mutex<FenceState>>,
     #[cfg(target_os = "macos")]
     map_sender: Sender<WorkerMessage>,
+    scanouts: [Option<VirtioGpuScanout>; VIRTIO_GPU_MAX_SCANOUTS as usize],
+    display_backend: Box<dyn DisplayBackend>,
 }
 
 impl VirtioGpu {
@@ -184,6 +242,7 @@ impl VirtioGpu {
         virgl_flags: u32,
         #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
         export_table: Option<ExportTable>,
+        display_backend: Box<dyn DisplayBackend>,
     ) -> Self {
         let xdg_runtime_dir = match env::var("XDG_RUNTIME_DIR") {
             Ok(dir) => dir,
@@ -232,7 +291,6 @@ impl VirtioGpu {
             0,
         )
         .set_rutabaga_channels(rutabaga_channels_opt);
-
         let builder = if let Some(export_table) = export_table {
             builder.set_export_table(export_table)
         } else {
@@ -257,6 +315,8 @@ impl VirtioGpu {
             rutabaga,
             resources: Default::default(),
             fence_state,
+            scanouts: Default::default(),
+            display_backend,
             #[cfg(target_os = "macos")]
             map_sender,
         }
@@ -296,10 +356,19 @@ impl VirtioGpu {
         self.rutabaga
             .resource_create_3d(resource_id, resource_create_3d)?;
 
+        let format = GpuResourceFormat::try_from(resource_create_3d.format).ok();
+        if format.is_none() {
+            debug!(
+                "Unknown format {} for resource {}",
+                resource_create_3d.format, resource_id
+            );
+        }
+
         let resource = VirtioGpuResource::new(
             resource_id,
             resource_create_3d.width,
             resource_create_3d.height,
+            format,
             0,
         );
 
@@ -315,6 +384,14 @@ impl VirtioGpu {
             .remove(&resource_id)
             .ok_or(ErrInvalidResourceId)?;
 
+        if resource.scanouts.has_any_enabled() {
+            warn!(
+                "The driver requested unref_resource, but resource {resource_id} has \
+                     associated scanouts, refusing to delete the resource."
+            );
+            return Err(ErrUnspec);
+        }
+
         if resource.rutabaga_external_mapping {
             self.rutabaga.unmap(resource_id)?;
         }
@@ -323,10 +400,114 @@ impl VirtioGpu {
         Ok(OkNoData)
     }
 
+    pub fn set_scanout(
+        &mut self,
+        scanout_id: u32,
+        resource_id: u32,
+        width: u32,
+        height: u32,
+    ) -> VirtioGpuResult {
+        let scanout = self
+            .scanouts
+            .get_mut(scanout_id as usize)
+            .ok_or(ErrInvalidScanoutId)?;
+
+        // If a resource is already associated with this scanout, make sure to disable
+        // this scanout for that resource
+        if let Some(resource_id) = scanout.as_ref().map(|scanout| scanout.resource_id) {
+            let resource = self
+                .resources
+                .get_mut(&resource_id)
+                .ok_or(ErrInvalidResourceId)?;
+
+            resource.scanouts.disable(scanout_id);
+        }
+
+        // Virtio spec: "The driver can use resource_id = 0 to disable a scanout."
+        if resource_id == 0 {
+            debug!("Disabling scanout {scanout_id:?}");
+            *scanout = None;
+            self.display_backend.disable_scanout(scanout_id)?;
+            return Ok(OkNoData);
+        }
+
+        // Enable the scanout
+        let resource = self
+            .resources
+            .get_mut(&resource_id)
+            .ok_or(ErrInvalidResourceId)?;
+        resource.scanouts.enable(scanout_id);
+
+        let Some(format) = resource.format else {
+            warn!(
+                "Cannot use resource {} ith unknown format for scanout",
+                resource_id
+            );
+            return Err(ErrUnspec);
+        };
+
+        self.display_backend
+            .configure_scanout(scanout_id, width, height, format)?;
+
+        *scanout = Some(VirtioGpuScanout { resource_id });
+        Ok(OkNoData)
+    }
+
+    fn read_2d_resource(
+        &mut self,
+        resource: VirtioGpuResource,
+        output: &mut [u8],
+    ) -> VirtioGpuResult {
+        let transfer = Transfer3D {
+            x: 0,
+            y: 0,
+            z: 0,
+            w: resource.width,
+            h: resource.height,
+            d: 1,
+            level: 0,
+            stride: resource.width * GpuResourceFormat::BYTES_PER_PIXEL,
+            layer_stride: 0,
+            offset: 0,
+        };
+
+        self.rutabaga
+            .transfer_read(0, resource.id, transfer, Some(IoSliceMut::new(output)))
+            .map_err(|e| format!("{e}"))
+            .unwrap();
+
+        Ok(OkNoData)
+    }
+
     /// If the resource is the scanout resource, flush it to the display.
     pub fn flush_resource(&mut self, resource_id: u32) -> VirtioGpuResult {
         if resource_id == 0 {
             return Ok(OkNoData);
+        }
+
+        let resource = *self
+            .resources
+            .get(&resource_id)
+            .ok_or(ErrInvalidResourceId)?;
+
+        let resource_size = resource.calculate_size().map_err(|e| {
+            error!(
+                "Resource {id} size calculation failed: {e}",
+                id = resource.id
+            );
+            ErrUnspec
+        })?;
+
+        for scanout_id in resource.scanouts.iter_enabled() {
+            let mut data = vec![0; resource_size];
+            if let Err(e) = self.read_2d_resource(resource, &mut data) {
+                log::error!("Failed to read resource {resource_id} for scanout {scanout_id}: {e}");
+            }
+            self.display_backend.update_scanout(
+                scanout_id,
+                data,
+                resource.width * GpuResourceFormat::BYTES_PER_PIXEL,
+            )?;
         }
 
         #[cfg(windows)]
@@ -337,6 +518,21 @@ impl VirtioGpu {
         }
 
         Ok(OkNoData)
+    }
+
+    pub fn display_info(&self) -> VirtioGpuResult {
+        let display_info = self
+            .display_backend
+            .displays()
+            .iter()
+            .map(|d| {
+                d.as_ref()
+                    .map(|d| (d.width, d.height, true))
+                    .unwrap_or((0, 0, false))
+            })
+            .collect();
+
+        Ok(OkDisplayInfo(display_info))
     }
 
     /// Copies data to host resource from the attached iovecs. Can also be used to flush caches.
@@ -516,7 +712,7 @@ impl VirtioGpu {
             None,
         )?;
 
-        let resource = VirtioGpuResource::new(resource_id, 0, 0, resource_create_blob.size);
+        let resource = VirtioGpuResource::new(resource_id, 0, 0, None, resource_create_blob.size);
 
         // Rely on rutabaga to check for duplicate resource ids.
         self.resources.insert(resource_id, resource);
@@ -769,5 +965,46 @@ impl VirtioGpu {
         resource.shmem_offset = None;
 
         Ok(OkNoData)
+    }
+}
+#[cfg(test)]
+mod test {
+    use crate::virtio::gpu::protocol::VIRTIO_GPU_MAX_SCANOUTS;
+
+    #[test]
+    fn test_virtio_gpu_associated_scanouts() {
+        use super::AssociatedScanouts;
+
+        let mut scanouts = AssociatedScanouts::default();
+
+        assert!(!scanouts.has_any_enabled());
+        assert_eq!(scanouts.iter_enabled().next(), None);
+
+        scanouts.enable(1);
+        assert!(scanouts.has_any_enabled());
+        scanouts.disable(1);
+        assert!(!scanouts.has_any_enabled());
+
+        (0..VIRTIO_GPU_MAX_SCANOUTS).for_each(|scanout| scanouts.enable(scanout));
+        assert!(scanouts.has_any_enabled());
+        assert_eq!(
+            scanouts.iter_enabled().collect::<Vec<u32>>(),
+            (0..VIRTIO_GPU_MAX_SCANOUTS).collect::<Vec<u32>>()
+        );
+
+        (0..VIRTIO_GPU_MAX_SCANOUTS)
+            .filter(|&i| i % 2 == 0)
+            .for_each(|scanout| scanouts.disable(scanout));
+        assert_eq!(
+            scanouts.iter_enabled().collect::<Vec<u32>>(),
+            (1..VIRTIO_GPU_MAX_SCANOUTS)
+                .step_by(2)
+                .collect::<Vec<u32>>()
+        );
+
+        (0..VIRTIO_GPU_MAX_SCANOUTS)
+            .filter(|&i| i % 2 != 0)
+            .for_each(|scanout| scanouts.disable(scanout));
+        assert!(!scanouts.has_any_enabled());
     }
 }

--- a/src/devices/src/virtio/gpu/worker.rs
+++ b/src/devices/src/virtio/gpu/worker.rs
@@ -128,7 +128,7 @@ impl Worker {
         virtio_gpu.force_ctx_0();
 
         match cmd {
-            GpuCommand::GetDisplayInfo(_) => {
+            GpuCommand::GetDisplayInfo => {
                 panic!("virtio_gpu: GpuCommand::GetDisplayInfo unimplemented");
             }
             GpuCommand::ResourceCreate2d(info) => {

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -14,6 +14,7 @@ efi = [ "blk", "net" ]
 gpu = []
 snd = []
 virgl_resource_map2 = []
+gtk_display = ["gpu"]
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -991,6 +991,29 @@ pub unsafe extern "C" fn krun_set_gpu_options2(
     KRUN_SUCCESS
 }
 
+#[cfg(not(feature = "gtk_display"))]
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_set_display_backend_gtk(_ctx_id: u32) -> i32 {
+    -libc::ENOTSUP
+}
+
+#[cfg(feature = "gtk_display")]
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+pub unsafe extern "C" fn krun_set_display_backend_gtk(ctx_id: u32) -> i32 {
+    #[cfg(feature = "gpu")]
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+            cfg.vmr.display_backend = DisplayBackendConfig::Gtk;
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
 #[cfg(feature = "gpu")]
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]

--- a/src/utils/src/lib.rs
+++ b/src/utils/src/lib.rs
@@ -16,6 +16,7 @@ pub mod macos;
 pub use macos::epoll;
 #[cfg(target_os = "macos")]
 pub use macos::eventfd;
+pub mod pollable_channel;
 pub mod rand;
 #[cfg(target_os = "linux")]
 pub mod signal;

--- a/src/utils/src/pollable_channel.rs
+++ b/src/utils/src/pollable_channel.rs
@@ -1,0 +1,64 @@
+use crate::eventfd::{EventFd, EFD_NONBLOCK};
+use std::collections::VecDeque;
+use std::io;
+use std::io::ErrorKind;
+use std::os::fd::{AsRawFd, RawFd};
+use std::sync::{Arc, Mutex};
+
+/// A multiple producer single consumer channel that can be listened to by a file descriptor
+pub fn pollable_channel<T: Send>(
+) -> io::Result<(PollableChannelSender<T>, PollableChannelReciever<T>)> {
+    let eventfd = EventFd::new(EFD_NONBLOCK)?;
+
+    let inner = Arc::new(Inner {
+        eventfd,
+        queue: Mutex::new(VecDeque::new()),
+    });
+    let tx = PollableChannelSender {
+        inner: inner.clone(),
+    };
+    let rx = PollableChannelReciever { inner };
+    Ok((tx, rx))
+}
+
+struct Inner<T: Send> {
+    eventfd: EventFd,
+    queue: Mutex<VecDeque<T>>,
+}
+
+#[derive(Clone)]
+pub struct PollableChannelSender<T: Send> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T: Send> PollableChannelSender<T> {
+    pub fn send(&self, msg: T) -> io::Result<()> {
+        let mut data_lock = self.inner.queue.lock().expect("Poisoned mutex");
+        data_lock.push_back(msg);
+        self.inner.eventfd.write(1)?;
+        Ok(())
+    }
+}
+
+pub struct PollableChannelReciever<T: Send> {
+    inner: Arc<Inner<T>>,
+}
+
+impl<T: Send> PollableChannelReciever<T> {
+    pub fn try_recv(&self) -> io::Result<Option<T>> {
+        let mut data_lock = self.inner.queue.lock().expect("Poisoned mutex");
+        match self.inner.eventfd.read() {
+            Ok(_) => (),
+            Err(e) if e.kind() == ErrorKind::WouldBlock => (),
+            Err(e) => return Err(e),
+        }
+
+        Ok(data_lock.pop_back())
+    }
+}
+
+impl<T: Send> AsRawFd for PollableChannelReciever<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.eventfd.as_raw_fd()
+    }
+}

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -12,6 +12,7 @@ blk = []
 efi = [ "blk", "net" ]
 gpu = []
 snd = []
+gtk_display = ["gpu"]
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -23,8 +23,10 @@ use super::{Error, Vmm};
 #[cfg(target_arch = "x86_64")]
 use crate::device_manager::legacy::PortIODeviceManager;
 use crate::device_manager::mmio::MMIODeviceManager;
-use crate::resources::VmResources;
+use crate::resources::{DisplayBackendConfig, VmResources};
 use crate::vmm_config::external_kernel::{ExternalKernel, KernelFormat};
+#[cfg(feature = "gtk_display")]
+use devices::display::DisplayBackendGtk;
 #[cfg(feature = "gpu")]
 use devices::display::{DisplayBackend, DisplayBackendNoop};
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
@@ -1868,6 +1870,10 @@ fn attach_rng_device(
 fn create_display_backend(vm_resources: &VmResources) -> Box<dyn DisplayBackend> {
     match vm_resources.display_backend {
         DisplayBackendConfig::Noop => Box::new(DisplayBackendNoop),
+        #[cfg(feature = "gtk_display")]
+        DisplayBackendConfig::Gtk => {
+            Box::new(DisplayBackendGtk::new(vm_resources.displays.clone()))
+        }
     }
 }
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -82,6 +82,8 @@ impl Default for TeeConfig {
 pub enum DisplayBackendConfig {
     #[default]
     Noop,
+    #[cfg(feature = "gtk_display")]
+    Gtk,
 }
 
 /// A data structure that encapsulates the device configurations

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -12,9 +12,6 @@ use std::path::PathBuf;
 #[cfg(feature = "tee")]
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "tee")]
-use kbs_types::Tee;
-
 #[cfg(feature = "blk")]
 use crate::vmm_config::block::{BlockBuilder, BlockConfigError, BlockDeviceConfig};
 use crate::vmm_config::boot_source::{BootSourceConfig, BootSourceConfigError};
@@ -29,6 +26,11 @@ use crate::vmm_config::machine_config::{VmConfig, VmConfigError};
 use crate::vmm_config::net::{NetBuilder, NetworkInterfaceConfig, NetworkInterfaceError};
 use crate::vmm_config::vsock::*;
 use crate::vstate::VcpuConfig;
+#[cfg(feature = "gpu")]
+use devices::display::DisplayInfoList;
+
+#[cfg(feature = "tee")]
+use kbs_types::Tee;
 
 type Result<E> = std::result::Result<(), E>;
 
@@ -76,6 +78,12 @@ impl Default for TeeConfig {
     }
 }
 
+#[derive(Debug, Default, PartialEq, Eq)]
+pub enum DisplayBackendConfig {
+    #[default]
+    Noop,
+}
+
 /// A data structure that encapsulates the device configurations
 /// held in the Vmm.
 #[derive(Default)]
@@ -111,6 +119,10 @@ pub struct VmResources {
     /// Flags for the virtio-gpu device.
     pub gpu_virgl_flags: Option<u32>,
     pub gpu_shm_size: Option<usize>,
+    #[cfg(feature = "gpu")]
+    pub display_backend: DisplayBackendConfig,
+    #[cfg(feature = "gpu")]
+    pub displays: DisplayInfoList,
     #[cfg(feature = "snd")]
     /// Enable the virtio-snd device.
     pub snd_device: bool,
@@ -315,11 +327,15 @@ impl VmResources {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "gpu")]
+    use crate::resources::DisplayBackendConfig;
     use crate::resources::VmResources;
     use crate::vmm_config::boot_source::BootSourceConfig;
     use crate::vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
     use crate::vmm_config::vsock::tests::{default_config, TempSockFile};
     use crate::vstate::VcpuConfig;
+    #[cfg(feature = "gpu")]
+    use devices::display::DisplayInfoList;
     use utils::tempfile::TempFile;
 
     fn default_boot_cfg() -> BootSourceConfig {
@@ -341,6 +357,10 @@ mod tests {
             net_builder: Default::default(),
             gpu_virgl_flags: None,
             gpu_shm_size: None,
+            #[cfg(feature = "gpu")]
+            display_backend: DisplayBackendConfig::Noop,
+            #[cfg(feature = "gpu")]
+            displays: DisplayInfoList::default(),
             #[cfg(feature = "snd")]
             enable_snd: False,
             console_output: None,


### PR DESCRIPTION
This PR adds initial support for the more traditional display output from the VM by basically having virtual displays (until now we only had cross-domain/wayland).

This implementes 2 display backends:
- `DisplayBackendNoop` - used by default, pretty much returns an error for every operation
- `DisplayBackendGtk` - implementation using GTK (works on Linux, to be tested on macOS)

This introduces 2 new public API function: 
- `int32_t krun_set_display_backend_gtk(uint32_t ctx_id)`
- `int32_t krun_set_display(uint32_t ctx_id, uint32_t display_id, uint32_t width, uint32_t height)`

Current limitations to be addressed by future PRs:
- add a virtio-input device and forward the events from the window to the guest
- improve the performance by using dmabufs instead copying it to the CPU
- send display resize events to the guest

You can test this using the newly added `--display` option in `chroot_vm` and running something graphical in the guest - the simplest option is probably `kmscube`:
`$ ./chroot_vm --display=0:1920:1080 rootfs_fedora kmscube`
