### PR TITLE
hvf: Add API to verify Nested Virt is supported

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -561,6 +561,19 @@ int32_t krun_setgid(uint32_t ctx_id, gid_t gid);
 int32_t krun_set_nested_virt(uint32_t ctx_id, bool enabled);
 
 /**
+ * Check the system if Nested Virtualization is supported
+ *
+ * Notes:
+ *  This feature is only supported on macOS.
+ *
+ * Returns:
+ *  - 1 : Success and Nested Virtualization is supported
+ *  - 0 : Success and Nested Virtualization is not supported
+ *  - <0: Failure
+ */
+int32_t krun_check_nested_virt(void);
+
+/**
  * Specify whether to split IRQCHIP responsibilities between the host and the guest.
  *
  * Arguments:

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1077,6 +1077,19 @@ pub unsafe extern "C" fn krun_set_nested_virt(ctx_id: u32, enabled: bool) -> i32
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
+pub unsafe extern "C" fn krun_check_nested_virt() -> i32 {
+    #[cfg(target_os = "macos")]
+    match hvf::check_nested_virt() {
+        Ok(supp) => supp as i32,
+        Err(_) => -libc::EINVAL,
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    -libc::EOPNOTSUPP
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
 pub extern "C" fn krun_split_irqchip(ctx_id: u32, enable: bool) -> i32 {
     if enable && !cfg!(target_arch = "x86_64") {
         return -libc::EINVAL;


### PR DESCRIPTION
Add an API to check if the current system supports Nested Virt on macOS.