### PR TITLE
arch_gen: add Cargo edition

### DIFF
--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -2,5 +2,6 @@
 name = "arch_gen"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
+edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Adding the Cargo edition for the `arch_gen` crate will get rid of the warning every time the project is built saying the Cargo edition is defaulting to 2015.