### PR TITLE
Preliminary support for AWS Nitro Enclaves

### DIFF
--- a/.github/workflows/code_quality-aarch64-darwin.yml
+++ b/.github/workflows/code_quality-aarch64-darwin.yml
@@ -29,4 +29,4 @@ jobs:
         run: cargo fmt -- --check
 
       - name: Formatting (rustfmt)
-        run: cargo clippy --features efi,gpu -- -D warnings
+        run: cargo clippy --workspace --exclude nitro --features efi,gpu -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "libloading",
  "log",
  "nitro",
+ "nitro-enclaves",
  "once_cell",
  "polly",
  "utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,7 @@ dependencies = [
  "nix 0.24.3",
  "pipewire",
  "polly",
- "rand",
+ "rand 0.8.5",
  "rutabaga_gfx",
  "thiserror 1.0.69",
  "utils",
@@ -1056,6 +1056,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1082,25 @@ dependencies = [
 [[package]]
 name = "nitro"
 version = "0.1.0"
+dependencies = [
+ "libc",
+ "nitro-enclaves",
+ "nix 0.26.4",
+ "vsock",
+]
+
+[[package]]
+name = "nitro-enclaves"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc4f6ad5cab7056766551e23ffe2e80c445406d4719944a36816873deec109d"
+dependencies = [
+ "bitflags 2.9.1",
+ "libc",
+ "nix 0.26.4",
+ "rand 0.9.1",
+ "vsock",
+]
 
 [[package]]
 name = "nix"
@@ -1120,6 +1148,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1366,8 +1395,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1377,7 +1416,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1390,12 +1439,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1919,6 +1977,16 @@ checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
+]
+
+[[package]]
+name = "vsock"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e8b4d00e672f147fc86a09738fadb1445bd1c0a40542378dfb82909deeee688"
+dependencies = [
+ "libc",
+ "nix 0.29.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,9 +59,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -74,33 +74,33 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
 dependencies = [
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.8"
+version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
@@ -149,9 +149,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -184,7 +184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -204,7 +204,7 @@ version = "0.71.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -220,9 +220,23 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.15.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c821a6e124197eb56d907ccc2188eab1038fb919c914f47976e64dd8dbc855d1"
+checksum = "db1bcd90f88eabbf0cadbfb87a45bceeaebcd3b4bc9e43da379cd2ef0162590d"
+dependencies = [
+ "bitfield-macros",
+]
+
+[[package]]
+name = "bitfield-macros"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "bitflags"
@@ -232,15 +246,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
 
 [[package]]
 name = "byteorder"
@@ -279,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -321,9 +335,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -352,9 +366,9 @@ checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "convert_case"
@@ -475,23 +489,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -651,9 +665,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -662,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -686,9 +700,9 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -838,7 +852,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "libc",
 ]
 
@@ -888,7 +902,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b702df98508cb63ad89dd9beb9f6409761b30edca10d48e57941d3f11513a006"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "kvm-bindings",
  "libc",
  "vmm-sys-util",
@@ -925,6 +939,7 @@ dependencies = [
  "libc",
  "libloading",
  "log",
+ "nitro",
  "once_cell",
  "polly",
  "utils",
@@ -934,12 +949,12 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -948,7 +963,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -958,7 +973,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f3a4b81b2a2d8c7f300643676202debd1b7c929dbf5c9bb89402ea11d19810"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cc",
  "convert_case",
  "cookie-factory",
@@ -1056,6 +1071,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "nitro"
+version = "0.1.0"
+
+[[package]]
 name = "nix"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,7 +1105,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "libc",
 ]
@@ -1097,7 +1116,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1145,11 +1164,11 @@ checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1176,13 +1195,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.107"
+name = "openssl-src"
+version = "300.5.0+3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1222,7 +1251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08e645ba5c45109106d56610b3ee60eb13a6f2beb8b74f8dc8186cf261788dda"
 dependencies = [
  "anyhow",
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
  "libspa",
  "libspa-sys",
@@ -1259,9 +1288,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "portable-atomic-util"
@@ -1278,14 +1307,14 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1357,7 +1386,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1371,13 +1400,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1449,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "rutabaga_gfx"
@@ -1542,23 +1571,23 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "sev"
-version = "6.0.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20ac277517d8fffdf3c41096323ed705b3a7c75e397129c072fb448339839d0f"
+checksum = "1750ba11a6a6bba3c220da714caa0226aa34e417dce3975d2953062240717dea"
 dependencies = [
  "base64",
  "bincode",
  "bitfield",
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "byteorder",
  "codicon",
  "dirs",
@@ -1605,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1621,9 +1650,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1691,9 +1720,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "pin-project-lite",
@@ -1701,9 +1730,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1713,18 +1742,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
@@ -1746,9 +1775,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1757,9 +1786,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -1802,11 +1831,13 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1838,9 +1869,9 @@ checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 
 [[package]]
 name = "vm-memory"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1720e7240cdc739f935456eb77f370d7e9b2a3909204da1e2b47bef1137a013"
+checksum = "1fd5e56d48353c5f54ef50bd158a0452fc82f5383da840f7b8efc31695dd3b9d"
 dependencies = [
  "libc",
  "thiserror 1.0.69",
@@ -1987,9 +2018,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.61.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
@@ -2028,29 +2059,20 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -2073,21 +2095,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -2095,7 +2102,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -2103,10 +2110,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+name = "windows-targets"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2115,10 +2132,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2127,10 +2144,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
+name = "windows_aarch64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2139,16 +2156,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
+name = "windows_i686_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2157,10 +2180,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
+name = "windows_i686_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2169,10 +2192,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+name = "windows_x86_64_gnu"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2181,10 +2204,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2193,10 +2216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.6"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -2207,7 +2236,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2231,11 +2260,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -2251,9 +2280,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,11 @@ endif
 ifeq ($(SND),1)
     FEATURE_FLAGS += --features snd
 endif
+ifeq ($(NITRO),1)
+	VARIANT = -nitro
+	FEATURE_FLAGS := --features nitro
+	BUILD_INIT = 0
+endif
 
 ifeq ($(TIMESYNC),1)
     INIT_DEFS += -D__TIMESYNC__
@@ -89,6 +94,9 @@ endif
 $(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY)
 	cargo build --release $(FEATURE_FLAGS)
 ifeq ($(SEV),1)
+	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
+endif
+ifeq ($(NITRO),1)
 	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
 endif
 ifeq ($(OS),Darwin)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -5,6 +5,7 @@ LDFLAGS_aarch64_Linux = -lkrun
 LDFLAGS_arm64_Darwin = -L/opt/homebrew/lib -lkrun
 LDFLAGS_sev = -lkrun-sev
 LDFLAGS_efi = -L/opt/homebrew/lib -lkrun-efi
+LDFLAGS_nitro = -lkrun-nitro
 CFLAGS = -O2 -g -I../include
 ROOTFS_DISTRO := fedora
 ROOTFS_DIR = rootfs_$(ROOTFS_DISTRO)
@@ -42,6 +43,9 @@ ifeq ($(OS),Darwin)
 	codesign --entitlements chroot_vm.entitlements --force -s - $@
 endif
 
+nitro: nitro.c
+	gcc -o $@ $< $(CFLAGS) $(LDFLAGS_nitro)
+
 # Build the rootfs to be used with chroot_vm.
 rootfs:
 	mkdir -p $(ROOTFS_DIR)
@@ -50,4 +54,4 @@ rootfs:
 	podman rm libkrun_chroot_vm
 
 clean:
-	rm -rf chroot_vm $(ROOTFS_DIR) launch-tee boot_efi external_kernel
+	rm -rf chroot_vm $(ROOTFS_DIR) launch-tee boot_efi external_kernel nitro

--- a/examples/nitro.c
+++ b/examples/nitro.c
@@ -1,0 +1,136 @@
+/*
+ * This is an example implementing running an example AWS nitro enclave with
+ * libkrun.
+ *
+ * Given a nitro enclave image, run the image in a nitro enclave with 1 vCPU and
+ * 256 MiB of memory allocated.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/socket.h>
+#include <libkrun.h>
+#include <getopt.h>
+#include <stdbool.h>
+#include <assert.h>
+
+#define MAX_ARGS_LEN 4096
+#ifndef MAX_PATH
+#define MAX_PATH 4096
+#endif
+
+static void print_help(char *const name)
+{
+    fprintf(stderr,
+        "Usage: %s EIF_FILE [COMMAND_ARGS...]\n"
+        "OPTIONS: \n"
+        "        -h    --help                Show help\n"
+        "\n"
+        "ENCLAVE_IMAGE:     The enclave image to run\n",
+        name
+    );
+}
+
+static const struct option long_options[] = {
+    { "help", no_argument, NULL, 'h' },
+    { NULL, 0, NULL, 0 }
+};
+
+struct cmdline {
+    bool show_help;
+    const char *eif_path;
+};
+
+bool parse_cmdline(int argc, char *const argv[], struct cmdline *cmdline)
+{
+    int c, option_index = 0;
+
+    assert(cmdline != NULL);
+
+    // set the defaults
+    *cmdline = (struct cmdline){
+        .show_help = false,
+        .eif_path = NULL,
+    };
+
+    // the '+' in optstring is a GNU extension that disables permutating argv
+    while ((c = getopt_long(argc, argv, "+h", long_options, &option_index)) != -1) {
+        switch (c) {
+        case 'h':
+            cmdline->show_help = true;
+            return true;
+        case '?':
+            return false;
+        default:
+            fprintf(stderr, "internal argument parsing error (returned character code 0x%x)\n", c);
+            return false;
+        }
+    }
+
+    if (optind < argc) {
+        cmdline->eif_path = argv[optind];
+        return true;
+    } else
+        fprintf(stderr, "Missing EIF_FILE argument");
+
+    return false;
+}
+
+int main(int argc, char *const argv[])
+{
+    int ctx_id, err, i;
+    struct cmdline cmdline;
+
+    if (!parse_cmdline(argc, argv, &cmdline)) {
+        putchar('\n');
+        print_help(argv[0]);
+        return -1;
+    }
+
+    if (cmdline.show_help){
+        print_help(argv[0]);
+        return 0;
+    }
+
+    // Set the log level to "off".
+    err = krun_set_log_level(0);
+    if (err) {
+        errno = -err;
+        perror("Error configuring log level");
+        return -1;
+    }
+
+    // Create the configuration context.
+    ctx_id = krun_create_ctx();
+    if (ctx_id < 0) {
+        errno = -ctx_id;
+        perror("Error creating configuration context");
+        return -1;
+    }
+
+    // Configure the number of vCPUs (1) and the amount of RAM (512 MiB).
+    if (err = krun_set_vm_config(ctx_id, 1, 512)) {
+        errno = -err;
+        perror("Error configuring the number of vCPUs and/or the amount of RAM");
+        return -1;
+    }
+
+    // Set the nitro enclave image specified on the command line.
+    if (err = krun_nitro_set_image(ctx_id, cmdline.eif_path,
+                                   KRUN_NITRO_IMG_TYPE_EIF)) {
+        errno = -err;
+        perror("Error configuring nitro enclave image");
+        return -1;
+
+    }
+
+    // Start and enter the microVM. Unless there is some error while creating the microVM
+    // this function never returns.
+    if (err = krun_start_enter(ctx_id)) {
+        errno = -err;
+        perror("Error creating the microVM");
+        return -1;
+    }
+
+    return 0;
+}

--- a/examples/nitro.c
+++ b/examples/nitro.c
@@ -154,6 +154,13 @@ int main(int argc, char *const argv[])
 
     }
 
+    // Configure the nitro enclave to run in debug mode.
+    if (err = krun_nitro_set_start_flags(ctx_id, KRUN_NITRO_START_FLAG_DEBUG)) {
+        errno = -err;
+        perror("Error configuring nitro enclave start flags");
+        return -1;
+    }
+
     // Create and initialize UNIX IPC socket for reading enclave output.
     sock_fd = socket(AF_UNIX, SOCK_STREAM, 0);
     if (sock_fd < 0) {

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -636,6 +636,16 @@ int32_t krun_split_irqchip(uint32_t ctx_id, bool enable);
 int32_t krun_nitro_set_image(uint32_t ctx_id, const char *image_path,
                              uint32_t image_type);
 
+#define KRUN_NITRO_START_FLAG_DEBUG (1 << 0)
+/**
+ * Configure a Nitro Enclave's start flags.
+ *
+ * Arguments:
+ *  "ctx_id" - the configuration context ID.
+ *  "start_flags" - Start flags.
+ */
+int32_t krun_nitro_set_start_flags(uint32_t ctx_id, uint64_t start_flags);
+
 /**
  * Starts and enters the microVM with the configured parameters. The VMM will attempt to take over
  * stdin/stdout to manage them on behalf of the process running inside the isolated environment,

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -623,6 +623,19 @@ int32_t krun_check_nested_virt(void);
 */
 int32_t krun_split_irqchip(uint32_t ctx_id, bool enable);
 
+#define KRUN_NITRO_IMG_TYPE_EIF 1
+/**
+ * Configure a Nitro Enclaves image.
+ *
+ * Arguments:
+ *  "ctx_id"     - the configuration context ID.
+ *  "image_path" - a null-terminated string representing the path of the image
+ *                 in the host.
+ *  "image_type" - the type of enclave image being provided.
+ */
+int32_t krun_nitro_set_image(uint32_t ctx_id, const char *image_path,
+                             uint32_t image_type);
+
 /**
  * Starts and enters the microVM with the configured parameters. The VMM will attempt to take over
  * stdin/stdout to manage them on behalf of the process running inside the isolated environment,

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -13,6 +13,7 @@ efi = ["blk", "net"]
 gpu = ["rutabaga_gfx", "thiserror", "zerocopy", "zerocopy-derive"]
 snd = ["pw", "thiserror"]
 virgl_resource_map2 = []
+nitro = []
 
 [dependencies]
 bitflags = "1.2.0"

--- a/src/devices/src/virtio/mod.rs
+++ b/src/devices/src/virtio/mod.rs
@@ -21,7 +21,7 @@ pub mod console;
 pub mod descriptor_utils;
 pub mod device;
 pub mod file_traits;
-#[cfg(not(feature = "tee"))]
+#[cfg(not(any(feature = "tee", feature = "nitro")))]
 pub mod fs;
 #[cfg(feature = "gpu")]
 pub mod gpu;
@@ -42,7 +42,7 @@ pub use self::balloon::*;
 pub use self::block::{Block, CacheType};
 pub use self::console::*;
 pub use self::device::*;
-#[cfg(not(feature = "tee"))]
+#[cfg(not(any(feature = "tee", feature = "nitro")))]
 pub use self::fs::*;
 #[cfg(feature = "gpu")]
 pub use self::gpu::*;

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -14,7 +14,7 @@ efi = [ "blk", "net" ]
 gpu = []
 snd = []
 virgl_resource_map2 = []
-nitro = [ "dep:nitro" ]
+nitro = [ "dep:nitro", "dep:nitro-enclaves" ]
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"
@@ -36,6 +36,7 @@ hvf = { path = "../hvf" }
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 nitro = { path = "../nitro", optional = true }
+nitro-enclaves = { version = "0.2.0", optional = true }
 vm-memory = ">=0.13"
 
 [lib]

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -14,6 +14,7 @@ efi = [ "blk", "net" ]
 gpu = []
 snd = []
 virgl_resource_map2 = []
+nitro = []
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -14,7 +14,7 @@ efi = [ "blk", "net" ]
 gpu = []
 snd = []
 virgl_resource_map2 = []
-nitro = []
+nitro = [ "dep:nitro" ]
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"
@@ -35,6 +35,7 @@ hvf = { path = "../hvf" }
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
+nitro = { path = "../nitro", optional = true }
 vm-memory = ">=0.13"
 
 [lib]

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -990,6 +990,11 @@ pub unsafe extern "C" fn krun_add_vsock_port2(
     c_filepath: *const c_char,
     listen: bool,
 ) -> i32 {
+    #[cfg(feature = "nitro")]
+    if listen {
+        return -libc::EINVAL;
+    }
+
     let filepath = match CStr::from_ptr(c_filepath).to_str() {
         Ok(f) => PathBuf::from(f.to_string()),
         Err(_) => return -libc::EINVAL,

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1665,9 +1665,14 @@ fn krun_start_enter_nitro(ctx_id: u32) -> i32 {
         None => return -libc::ENOENT,
     };
 
-    let Ok(_enclave) = NitroEnclave::try_from(ctx_cfg) else {
+    let Ok(mut enclave) = NitroEnclave::try_from(ctx_cfg) else {
         return -libc::EINVAL;
     };
+
+    if let Err(e) = enclave.run() {
+        error!("Error running nitro enclave: {e}");
+        return -libc::EINVAL;
+    }
 
     KRUN_SUCCESS
 }

--- a/src/nitro/Cargo.toml
+++ b/src/nitro/Cargo.toml
@@ -1,0 +1,6 @@
+[package]
+name = "nitro"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]

--- a/src/nitro/Cargo.toml
+++ b/src/nitro/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+libc = "0.2.171"
+nix = { version = "0.26.0", features = ["ioctl", "poll"] }
+vsock = "0.5.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+nitro-enclaves = "0.2.0"

--- a/src/nitro/src/error.rs
+++ b/src/nitro/src/error.rs
@@ -22,6 +22,7 @@ pub enum NitroError {
     VsockCreate,
     VsockSetTimeout,
     VsockConnect,
+    IpcWrite(io::Error),
 }
 
 impl fmt::Display for NitroError {
@@ -60,6 +61,9 @@ impl fmt::Display for NitroError {
                 "unable to set poll timeout for enclave vsock".to_string()
             }
             NitroError::VsockConnect => "unable to connect to enclave vsock".to_string(),
+            NitroError::IpcWrite(e) => {
+                format!("unable to write enclave vsock data to UNIX IPC socket: {e}")
+            }
         };
 
         write!(f, "{}", msg)

--- a/src/nitro/src/error.rs
+++ b/src/nitro/src/error.rs
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use nitro_enclaves::launch::LaunchError;
+use std::{fmt, io};
+
+#[derive(Debug)]
+pub enum NitroError {
+    DeviceOpen(io::Error),
+    VmCreate(LaunchError),
+    VmMemorySet(LaunchError),
+    VcpuAdd(LaunchError),
+    HeartbeatAccept(io::Error),
+    HeartbeatBind(io::Error),
+    HeartbeatRead(io::Error),
+    HeartbeatWrite(io::Error),
+    VmStart(LaunchError),
+    PollTimeoutCalculate(LaunchError),
+    PollNoSelectedEvents,
+    PollMoreThanOneSelectedEvent,
+    EnclaveHeartbeatNotDetected,
+    HeartbeatCidMismatch,
+    VsockCreate,
+    VsockSetTimeout,
+    VsockConnect,
+}
+
+impl fmt::Display for NitroError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let msg = match self {
+            NitroError::DeviceOpen(e) => format!("unable to open nitro enclaves device: {e}"),
+            NitroError::VmCreate(e) => format!("unable to create enclave VM: {e}"),
+            NitroError::VmMemorySet(e) => format!("unable to set enclave memory regions: {e}"),
+            NitroError::VcpuAdd(e) => format!("unable to add vCPU to enclave: {e}"),
+            NitroError::HeartbeatAccept(e) => {
+                format!("unable to accept enclave heartbeat vsock: {e}")
+            }
+            NitroError::HeartbeatBind(e) => {
+                format!("unable to bind to enclave hearbeat vsock: {e}")
+            }
+            NitroError::HeartbeatRead(e) => format!("unable to read enclave hearbeat vsock: {e}"),
+            NitroError::HeartbeatWrite(e) => {
+                format!("unable to write to enclave heartbeat vsock: {e}")
+            }
+            NitroError::VmStart(e) => format!("unable to start enclave: {e}"),
+            NitroError::PollTimeoutCalculate(e) => {
+                format!("unable to calculate vsock poll timeout: {e}")
+            }
+            NitroError::PollNoSelectedEvents => {
+                "no selected poll fds for heartbeat vsock found".to_string()
+            }
+            NitroError::PollMoreThanOneSelectedEvent => {
+                "more than one selected pollfd for heartbeat vsock found".to_string()
+            }
+            NitroError::EnclaveHeartbeatNotDetected => {
+                "enclave heartbeat message not detected".to_string()
+            }
+            NitroError::HeartbeatCidMismatch => "enclave heartbeat vsock CID mismatch".to_string(),
+            NitroError::VsockCreate => "unable to create enclave vsock".to_string(),
+            NitroError::VsockSetTimeout => {
+                "unable to set poll timeout for enclave vsock".to_string()
+            }
+            NitroError::VsockConnect => "unable to connect to enclave vsock".to_string(),
+        };
+
+        write!(f, "{}", msg)
+    }
+}

--- a/src/nitro/src/lib.rs
+++ b/src/nitro/src/lib.rs
@@ -38,7 +38,6 @@ const SO_VM_SOCKETS_CONNECT_TIMEOUT: i32 = 6;
 const HEART_BEAT: u8 = 0xb7;
 
 /// Nitro Enclave data.
-#[derive(Debug)]
 pub struct NitroEnclave {
     /// Enclave image.
     pub image: File,
@@ -48,6 +47,8 @@ pub struct NitroEnclave {
     pub vcpus: u8,
     /// Path of vsock for initial enclave communication.
     pub ipc_stream: UnixStream,
+    /// Enclave start flags.
+    pub start_flags: StartFlags,
 }
 
 impl NitroEnclave {
@@ -68,7 +69,7 @@ impl NitroEnclave {
         let listener = VsockListener::bind(&sockaddr).map_err(NitroError::HeartbeatBind)?;
 
         let cid = launcher
-            .start(StartFlags::DEBUG, None)
+            .start(self.start_flags, None)
             .map_err(NitroError::VmStart)?;
 
         // Safe to unwrap.

--- a/src/nitro/src/lib.rs
+++ b/src/nitro/src/lib.rs
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+
+/// Nitro Enclave data.
+#[derive(Debug)]
+pub struct NitroEnclave {
+    /// Enclave image.
+    pub image: File,
+    /// Amount of RAM (in MiB).
+    pub mem_size_mib: usize,
+    /// Number of vCPUs.
+    pub vcpus: u8,
+}

--- a/src/nitro/src/lib.rs
+++ b/src/nitro/src/lib.rs
@@ -1,6 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
-use std::fs::File;
+mod error;
+
+use error::NitroError;
+use nitro_enclaves::{
+    launch::{ImageType, Launcher, MemoryInfo, PollTimeout, StartFlags},
+    Device,
+};
+use nix::{
+    poll::{poll, PollFd, PollFlags},
+    sys::{
+        socket::{connect, socket, AddressFamily, SockFlag, SockType, VsockAddr as NixVsockAddr},
+        time::{TimeVal, TimeValLike},
+    },
+    unistd::read,
+};
+use std::{
+    fs::File,
+    io::{Read, Write},
+    os::fd::{AsRawFd, RawFd},
+};
+use vsock::{VsockAddr, VsockListener};
+
+type Result<T> = std::result::Result<T, NitroError>;
+
+const ENCLAVE_READY_VSOCK_PORT: u32 = 9000;
+const CID_TO_CONSOLE_PORT_OFFSET: u32 = 10000;
+
+const VMADDR_CID_PARENT: u32 = 3;
+const VMADDR_CID_HYPERVISOR: u32 = 0;
+
+const SO_VM_SOCKETS_CONNECT_TIMEOUT: i32 = 6;
+
+const HEART_BEAT: u8 = 0xb7;
 
 /// Nitro Enclave data.
 #[derive(Debug)]
@@ -11,4 +43,123 @@ pub struct NitroEnclave {
     pub mem_size_mib: usize,
     /// Number of vCPUs.
     pub vcpus: u8,
+}
+
+impl NitroEnclave {
+    /// Run the enclave.
+    pub fn run(&mut self) -> Result<()> {
+        let device = Device::open().map_err(NitroError::DeviceOpen)?;
+
+        let mut launcher = Launcher::new(&device).map_err(NitroError::VmCreate)?;
+
+        let mem = MemoryInfo::new(ImageType::Eif(&mut self.image), self.mem_size_mib);
+        launcher.set_memory(mem).map_err(NitroError::VmMemorySet)?;
+
+        for _ in 0..self.vcpus {
+            launcher.add_vcpu(None).map_err(NitroError::VcpuAdd)?;
+        }
+
+        let sockaddr = VsockAddr::new(VMADDR_CID_PARENT, ENCLAVE_READY_VSOCK_PORT);
+        let listener = VsockListener::bind(&sockaddr).map_err(NitroError::HeartbeatBind)?;
+
+        let cid = launcher
+            .start(StartFlags::DEBUG, None)
+            .map_err(NitroError::VmStart)?;
+
+        // Safe to unwrap.
+        let cid: u32 = cid.try_into().unwrap();
+
+        let poll_timeout = PollTimeout::try_from((&self.image, self.mem_size_mib << 20))
+            .map_err(NitroError::PollTimeoutCalculate)?;
+
+        enclave_check(listener, poll_timeout.into(), cid)?;
+
+        listen(VMADDR_CID_HYPERVISOR, cid + CID_TO_CONSOLE_PORT_OFFSET)?;
+
+        Ok(())
+    }
+}
+
+fn enclave_check(listener: VsockListener, poll_timeout_ms: libc::c_int, cid: u32) -> Result<()> {
+    let mut poll_fds = [PollFd::new(listener.as_raw_fd(), PollFlags::POLLIN)];
+    let result = poll(&mut poll_fds, poll_timeout_ms);
+    if result == Ok(0) {
+        return Err(NitroError::PollNoSelectedEvents);
+    } else if result != Ok(1) {
+        return Err(NitroError::PollMoreThanOneSelectedEvent);
+    }
+
+    let mut stream = listener.accept().map_err(NitroError::HeartbeatAccept)?;
+
+    let mut buf = [0u8];
+    let bytes = stream.0.read(&mut buf).map_err(NitroError::HeartbeatRead)?;
+
+    if bytes != 1 || buf[0] != HEART_BEAT {
+        return Err(NitroError::EnclaveHeartbeatNotDetected);
+    }
+
+    stream
+        .0
+        .write_all(&buf)
+        .map_err(NitroError::HeartbeatWrite)?;
+
+    if stream.1.cid() != cid {
+        return Err(NitroError::HeartbeatCidMismatch);
+    }
+
+    Ok(())
+}
+
+fn listen(cid: u32, port: u32) -> Result<()> {
+    let socket_fd = socket(
+        AddressFamily::Vsock,
+        SockType::Stream,
+        SockFlag::empty(),
+        None,
+    )
+    .map_err(|_| NitroError::VsockCreate)?;
+
+    let sockaddr = NixVsockAddr::new(cid, port);
+
+    vsock_timeout(socket_fd)?;
+
+    connect(socket_fd, &sockaddr).map_err(|_| NitroError::VsockConnect)?;
+
+    let mut buf = [0u8; 512];
+    loop {
+        // Read debug output from vsock.
+        let ret = read(socket_fd, &mut buf);
+        let Ok(sz) = ret else {
+            break;
+        };
+        if sz != 0 {
+            let msg = String::from_utf8(buf[..sz].to_vec()).unwrap();
+            print!("{}", msg);
+        } else {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn vsock_timeout(socket_fd: RawFd) -> Result<()> {
+    // Set the timeout to 20 seconds.
+    let timeval = TimeVal::milliseconds(20000);
+
+    let ret = unsafe {
+        libc::setsockopt(
+            socket_fd,
+            libc::AF_VSOCK,
+            SO_VM_SOCKETS_CONNECT_TIMEOUT,
+            &timeval as *const _ as *const libc::c_void,
+            size_of::<TimeVal>() as u32,
+        )
+    };
+
+    if ret != 0 {
+        return Err(NitroError::VsockSetTimeout);
+    }
+
+    Ok(())
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -12,6 +12,7 @@ blk = []
 efi = [ "blk", "net" ]
 gpu = []
 snd = []
+nitro = []
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -55,7 +55,7 @@ use crate::terminal::term_set_raw_mode;
 #[cfg(feature = "blk")]
 use crate::vmm_config::block::BlockBuilder;
 use crate::vmm_config::boot_source::DEFAULT_KERNEL_CMDLINE;
-#[cfg(not(feature = "tee"))]
+#[cfg(not(any(feature = "tee", feature = "nitro")))]
 use crate::vmm_config::fs::FsDeviceConfig;
 #[cfg(target_os = "linux")]
 use crate::vstate::KvmContext;
@@ -64,7 +64,7 @@ use crate::vstate::MeasuredRegion;
 use crate::vstate::{Error as VstateError, Vcpu, VcpuConfig, Vm};
 use arch::{ArchMemoryInfo, InitrdConfig};
 use device_manager::shm::ShmManager;
-#[cfg(not(feature = "tee"))]
+#[cfg(not(any(feature = "tee", feature = "nitro")))]
 use devices::virtio::{fs::ExportTable, VirtioShmRegion};
 use flate2::read::GzDecoder;
 #[cfg(feature = "tee")]
@@ -78,12 +78,14 @@ use utils::eventfd::EventFd;
 use utils::worker_message::WorkerMessage;
 #[cfg(all(target_arch = "x86_64", not(feature = "efi"), not(feature = "tee")))]
 use vm_memory::mmap::MmapRegion;
-#[cfg(not(feature = "tee"))]
+#[cfg(not(any(feature = "tee", feature = "nitro")))]
 use vm_memory::Address;
 use vm_memory::Bytes;
+#[cfg(not(feature = "nitro"))]
+use vm_memory::GuestMemory;
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
 use vm_memory::GuestRegionMmap;
-use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory::{GuestAddress, GuestMemoryMmap};
 
 #[cfg(feature = "efi")]
 static EDK2_BINARY: &[u8] = include_bytes!("../../../edk2/KRUN_EFI.silent.fd");
@@ -784,7 +786,7 @@ pub fn build_microvm(
         vm_resources.console_output.clone(),
     )?;
 
-    #[cfg(not(feature = "tee"))]
+    #[cfg(not(any(feature = "tee", feature = "nitro")))]
     let export_table: Option<ExportTable> = if cfg!(feature = "gpu") {
         Some(Default::default())
     } else {
@@ -805,8 +807,7 @@ pub fn build_microvm(
             _sender.clone(),
         )?;
     }
-
-    #[cfg(not(feature = "tee"))]
+    #[cfg(not(any(feature = "tee", feature = "nitro")))]
     attach_fs_devices(
         &mut vmm,
         &vm_resources.fs,
@@ -1579,7 +1580,7 @@ fn attach_mmio_device(
     Ok(())
 }
 
-#[cfg(not(feature = "tee"))]
+#[cfg(not(any(feature = "tee", feature = "nitro")))]
 fn attach_fs_devices(
     vmm: &mut Vmm,
     fs_devs: &[FsDeviceConfig],

--- a/src/vmm/src/device_manager/shm.rs
+++ b/src/vmm/src/device_manager/shm.rs
@@ -46,7 +46,7 @@ impl ShmManager {
         regions
     }
 
-    #[cfg(not(feature = "tee"))]
+    #[cfg(not(any(feature = "tee", feature = "nitro")))]
     pub fn fs_region(&self, index: usize) -> Option<&ShmRegion> {
         self.fs_regions.get(&index)
     }


### PR DESCRIPTION
This PR adds a new flavor, `libkrun-nitro`. The nitro flavor is expected to be run on AWS EC2 instances that support [AWS Nitro Enclaves](https://aws.amazon.com/ec2/nitro/nitro-enclaves/).

AWS Nitro Enclaves are fully isolated and highly constrained virtual machines that run on the Nitro hypervisor. CPUs and memory of an enclave are completely isolated from a parent instance and other users of a system, significantly reducing the attack surface and helping to prevent the stealing/tampering of data.

### Try for yourself
To demo on an AWS EC2 instance with Nitro Enclaves enabled:

- Clone repo, checkout the `nitro` branch
```
$ git clone https://github.com/tylerfanelli/libkrun.git
$ cd libkrun
$ git checkout nitro
```

- Build the `libkrun-nitro` flavor
```
$ make NITRO=1
$ make install NITRO=1
$ ln /usr/local/lib64/libkrun-nitro.so /usr/local/lib64/libkrun.so.1
```
- Build the `nitro` example
```
$ cd examples
$ make nitro
```
- Run the nitro example with an example EIF file found in `examples/test_data`
```
$ LD_LIBRARY_PATH=/usr/local/lib64 ./nitro test_data/hello.eif
```

This will run the enclave in debug mode, where you can examine debug output from the nitro enclave.

This will include Linux kernel logs:
```
[    0.000000] Booting Linux on physical CPU 0x0                                                                                                                                                                                                                                
.. snip ..
```

As well as a hello message from the enclave:
```
.. snip ..
[    0.062913] random: crng init done
[    0.063151] NSM RNG: returning rand bytes = 128
[    0.063450] NSM RNG: returning rand bytes = 128
Hello (from a nitro enclave!)
[    0.066406] reboot: Restarting system
```