### PR TITLE
Introduce a new krun_init_log() API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,6 @@ dependencies = [
  "bitflags 1.3.2",
  "caps",
  "crossbeam-channel",
- "env_logger",
  "hvf",
  "imago",
  "kvm-bindings",
@@ -674,7 +673,6 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "crossbeam-channel",
- "env_logger",
  "libloading",
  "log",
 ]
@@ -1712,7 +1710,6 @@ version = "0.1.0"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
- "env_logger",
  "kvm-bindings",
  "libc",
  "log",
@@ -1777,7 +1774,6 @@ dependencies = [
  "crossbeam-channel",
  "curl",
  "devices",
- "env_logger",
  "flate2",
  "hvf",
  "kbs-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,17 +139,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -312,6 +351,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
 name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,16 +501,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "env_logger"
-version = "0.9.3"
+name = "env_filter"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
- "atty",
- "humantime",
  "log",
  "regex",
- "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -647,25 +702,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hvf"
@@ -739,6 +779,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +807,30 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1066,6 +1136,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
 name = "openssl"
 version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1177,6 +1253,21 @@ version = "0.0.1"
 dependencies = [
  "libc",
  "utils",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
 ]
 
 [[package]]
@@ -1583,15 +1674,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1785,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utils"
@@ -1894,15 +1982,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -217,8 +217,8 @@ int main(int argc, char *const argv[])
         return 0;
     }
 
-    // Set the log level to "off".
-    err = krun_set_log_level(0);
+    // Set the log level to "warn".
+    err = krun_set_log_level(2);
     if (err) {
         errno = -err;
         perror("Error configuring log level");

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -26,6 +26,44 @@ extern "C" {
  */
 int32_t krun_set_log_level(uint32_t level);
 
+
+#define KRUN_LOG_TARGET_DEFAULT -1
+
+#define KRUN_LOG_LEVEL_OFF 0
+#define KRUN_LOG_LEVEL_ERROR 1
+#define KRUN_LOG_LEVEL_WARN 2
+#define KRUN_LOG_LEVEL_INFO 3
+#define KRUN_LOG_LEVEL_DEBUG 4
+#define KRUN_LOG_LEVEL_TRACE 5
+
+#define KRUN_LOG_STYLE_AUTO 0
+#define KRUN_LOG_STYLE_ALWAYS 1
+#define KRUN_LOG_STYLE_NEVER 2
+
+#define KRUN_LOG_OPTION_NO_ENV 1
+
+/**
+ * Initializes logging for the library.
+ *
+ * Arguments:
+ *  "target_fd" - File descriptor to write log to. Note that using a file descriptor pointing to a regular file on
+ *                filesystem might slow down the VM.
+ *                Use KRUN_LOG_TARGET_DEFAULT to use the default target for log output (stderr).
+ *
+ *  "level"     - Level is an integer specifying the level of verbosity, higher number means more verbose log.
+ *                The log levels are described by the constants: KRUN_LOG_LEVEL_{OFF, ERROR, WARN, INFO, DEBUG, TRACE}
+ *
+ *  "style"     - Enable/disable usage of terminal escape sequences (to display colors)
+ *                One of: KRUN_LOG_STYLE_{AUTO, ALWAYS, NEVER}.
+ *
+ *  "options"   - Bitmask of logging options, use 0 for default options.
+ *                KRUN_LOG_OPTION_NO_ENV to disallow environment variables to override these settings.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_init_log(int target_fd, uint32_t level, uint32_t style, uint32_t options);
+
 /**
  * Creates a configuration context.
  *

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -17,7 +17,6 @@ virgl_resource_map2 = []
 [dependencies]
 bitflags = "1.2.0"
 crossbeam-channel = ">=0.5.15"
-env_logger = "0.9.0"
 libc = ">=0.2.39"
 libloading = "0.8"
 log = "0.4.0"

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -8,6 +8,5 @@ edition = "2021"
 crossbeam-channel = ">=0.5.15"
 libloading = "0.8"
 log = "0.4.0"
-env_logger = "0.9.0"
 
 arch = { path = "../arch" }

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -17,7 +17,7 @@ virgl_resource_map2 = []
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"
-env_logger = "0.9.0"
+env_logger = "0.11"
 libc = ">=0.2.39"
 libloading = "0.8"
 log = "0.4.0"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 
 [dependencies]
 bitflags = "1.2.0"
-env_logger = "0.9.0"
 libc = ">=0.2.85"
 log = "0.4.0"
 vmm-sys-util = "0.12.1"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -15,7 +15,6 @@ snd = []
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"
-env_logger = "0.9.0"
 flate2 = "1.0.35"
 libc = ">=0.2.39"
 linux-loader = { version = "0.13.0", features = ["bzimage", "elf", "pe"] }

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 [dependencies]
 test_cases = { path = "../test_cases", features = ["host"] }
 anyhow = "1.0.95"
-nix = { version = "0.29.0", features = ["resource"] }
+nix = { version = "0.29.0", features = ["resource", "fs"] }
 macros = { path = "../macros" }
 clap = { version = "4.5.27", features = ["derive"] }
 tempdir = "0.3.7"


### PR DESCRIPTION
Introduce a new krun_init_log public API function to allow for much detailed configuration of logging by the application. The main improvment is the ability to specify a file descriptor to write the log to.

This can be tested using the added `chroot_vm` flags: `--log=/path/to/a/pipe` or  `--color-log=/path/to/a/pipe` (which will also display a formatting).
