### PR TITLE
Fix virtio-fs escape outside of root directy (on Linux)

### DIFF
--- a/src/devices/src/virtio/fs/mod.rs
+++ b/src/devices/src/virtio/fs/mod.rs
@@ -61,6 +61,8 @@ pub enum FsError {
     /// A C string parameter is invalid.
     InvalidCString(FromBytesWithNulError),
     InvalidCString2(FromVecWithNulError),
+    /// Given string is not a valid filename
+    InvalidFilename,
     /// The `len` field of the header is too small.
     InvalidHeaderLength,
     /// The `size` field of the `SetxattrIn` message does not match the length


### PR DESCRIPTION
This is attempt at fixing #329 
Like mentioned in the issue I am not sure if we should completely disallow resolving ".." or just for root directory.