### PR TITLE
Require crossbeam-channel 0.5.15 or higher

### DIFF
--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -16,7 +16,7 @@ virgl_resource_map2 = []
 
 [dependencies]
 bitflags = "1.2.0"
-crossbeam-channel = "0.5"
+crossbeam-channel = ">=0.5.15"
 env_logger = "0.9.0"
 libc = ">=0.2.39"
 libloading = "0.8"

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Sergio Lopez <slp@sinrega.org>"]
 edition = "2021"
 
 [dependencies]
-crossbeam-channel = "0.5"
+crossbeam-channel = ">=0.5.15"
 libloading = "0.8"
 log = "0.4.0"
 env_logger = "0.9.0"

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -16,7 +16,7 @@ snd = []
 virgl_resource_map2 = []
 
 [dependencies]
-crossbeam-channel = "0.5"
+crossbeam-channel = ">=0.5.15"
 env_logger = "0.9.0"
 libc = ">=0.2.39"
 libloading = "0.8"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -10,7 +10,7 @@ env_logger = "0.9.0"
 libc = ">=0.2.85"
 log = "0.4.0"
 vmm-sys-util = "0.12.1"
-crossbeam-channel = "0.5"
+crossbeam-channel = ">=0.5.15"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.10", features = ["fam-wrappers"] }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -14,7 +14,7 @@ gpu = []
 snd = []
 
 [dependencies]
-crossbeam-channel = "0.5"
+crossbeam-channel = ">=0.5.15"
 env_logger = "0.9.0"
 flate2 = "1.0.35"
 libc = ">=0.2.39"


### PR DESCRIPTION
crosbeam-channel from version 0.5.12 to 0.5.14 are affected by CVE-2025-4574 (https://bugzilla.redhat.com/show_bug.cgi?id=2358890)