### PR TITLE
vmm: drop use of rangemap crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,12 +1270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rangemap"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
-
-[[package]]
 name = "rdrand"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1796,7 +1790,6 @@ dependencies = [
  "nix 0.24.3",
  "polly",
  "procfs",
- "rangemap",
  "rdrand",
  "serde",
  "serde_json",

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -21,7 +21,6 @@ libc = ">=0.2.39"
 linux-loader = { version = "0.13.0", features = ["bzimage", "elf", "pe"] }
 log = "0.4.0"
 vm-memory = { version = ">=0.13", features = ["backend-mmap"] }
-rangemap = "1.5.1"
 
 arch = { path = "../arch" }
 devices = { path = "../devices" }


### PR DESCRIPTION
It's not packaged in Fedora and I don't think it adds enough value to justify its addition.