### PR TITLE
hvf: mask SME in ID_AA64PFR1_EL1

### DIFF
--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -88,6 +88,8 @@ const CNTHCTL_EL0PCTEN: u64 = 1 << 0;
 // Trap accesses to both virtual and physical counter registers.
 const CNTHCTL_EL2_BITS: u64 = CNTHCTL_EL0VCTEN | CNTHCTL_EL0PCTEN;
 
+const AA64PFR1_EL1_SMEMASK: u64 = 3 << 24;
+
 const EC_WFX_TRAP: u64 = 0x1;
 const EC_AA64_HVC: u64 = 0x16;
 const EC_AA64_SMC: u64 = 0x17;
@@ -394,6 +396,30 @@ impl HvfVcpu<'_> {
                     self.vcpuid,
                     hv_sys_reg_t_HV_SYS_REG_CNTHCTL_EL2,
                     CNTHCTL_EL2_BITS,
+                )
+            };
+            if ret != HV_SUCCESS {
+                return Err(Error::VcpuInitialRegisters);
+            }
+
+            // If SME is enabled in ID_AA64PFR1_EL1 in the VM, the guest will
+            // break after enabling the MMU. Mask it out.
+            let val: u64 = 0;
+            let ret = unsafe {
+                hv_vcpu_get_sys_reg(
+                    self.vcpuid,
+                    hv_sys_reg_t_HV_SYS_REG_ID_AA64PFR1_EL1,
+                    &val as *const _ as *mut _,
+                )
+            };
+            if ret != HV_SUCCESS {
+                return Err(Error::VcpuInitialRegisters);
+            }
+            let ret = unsafe {
+                hv_vcpu_set_sys_reg(
+                    self.vcpuid,
+                    hv_sys_reg_t_HV_SYS_REG_ID_AA64PFR1_EL1,
+                    val & !AA64PFR1_EL1_SMEMASK,
                 )
             };
             if ret != HV_SUCCESS {


### PR DESCRIPTION
This fixes nested virt on M4 devices.