### PR TITLE
vmm: bump kbs-types and drop tee-sev

### DIFF
--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -29,7 +29,7 @@ polly = { path = "../polly" }
 
 # Dependencies for amd-sev
 codicon = { version = "3.0.0", optional = true }
-kbs-types = { version = "0.8.0", features = ["tee-sev", "tee-snp"], optional = true }
+kbs-types = { version = "0.11.0", features = ["tee-snp"], optional = true }
 procfs = { version = "0.12", optional = true }
 rdrand = { version = "^0.8", optional = true }
 serde = { version = "1.0.125", optional = true }


### PR DESCRIPTION
Bump kbs-types dependency to version 0.11 and drop the use of the tee-sev which we no longer use (and it's broken in kbs-types).