### PR TITLE
feat: krun_set_rootfs_read_only

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -475,6 +475,19 @@ int32_t krun_set_kernel(uint32_t ctx_id,
                         const char *cmdline);
 
 /**
+ * Sets the read-only flag for the kernel boot arguments. This results in the root
+ * filesystem being mounted read-only.
+ * Arguments:
+ *  "ctx_id"        - the configuration context ID.
+ *  "read_only"     - true when the root filesystem should be mounted read-only.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+*/
+int32_t krun_set_rootfs_read_only(uint32_t ctx_id,
+                                  bool read_only);
+
+/**
  * Sets environment variables to be configured in the context of the executable.
  *
  * Arguments:

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -531,7 +531,9 @@ pub fn build_microvm(
     } else if let Some(cmdline) = &vm_resources.boot_config.kernel_cmdline_prolog {
         kernel_cmdline.insert_str(cmdline).unwrap();
     } else {
-        kernel_cmdline.insert_str(DEFAULT_KERNEL_CMDLINE).unwrap();
+        kernel_cmdline
+            .insert_str(format!("{DEFAULT_KERNEL_CMDLINE} rw"))
+            .unwrap();
     }
 
     #[cfg(not(feature = "tee"))]

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -5,10 +5,10 @@ use std::fmt::{Display, Formatter, Result};
 
 #[cfg(target_os = "linux")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
-                                          rootfstype=virtiofs rw quiet no-kvmapf";
+                                          rootfstype=virtiofs quiet no-kvmapf";
 #[cfg(target_os = "macos")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
-                                          rootfstype=virtiofs rw quiet no-kvmapf";
+                                          rootfstype=virtiofs quiet no-kvmapf";
 
 /// Strongly typed data structure used to configure the boot source of the
 /// microvm.


### PR DESCRIPTION
Introduce `krun_set_rootfs_read_only` which affects the `"ro"` or `"rw"` flags being injected into kernel command-line arguments.

This should be mutually exclusive from `krun_set_kernel`. I'm happy to refine this to add some validation for that situation. I think I'd have to make the flag an `Option<bool>` or it wouldn't be possible to distinguish someone actively setting the rootfs to rw (by passing `false`) from the default situation in a later call to `krun_set_kernel`.

Fixes #343
