### PR TITLE
Fix the library install name and path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ ifeq ($(SEV),1)
 endif
 ifeq ($(OS),Darwin)
 ifeq ($(EFI),1)
-	install_name_tool -id libkrun-efi.dylib target/release/libkrun.dylib
+	install_name_tool -id $(PREFIX)/$(LIBDIR_$(OS))/$(KRUN_SONAME_$(OS)) target/release/libkrun.dylib
 endif
 	mv target/release/libkrun.dylib target/release/$(KRUN_BASE_$(OS))
 endif


### PR DESCRIPTION
The install_name is supposed to be an absolute path, and use the soname rather than the developer symlink.

Avoids using `DYLD_FALLBACK_LIBRARY_PATH=/usr/local/lib`. Homebrew changes the install_name downstream, in /opt.

The default is the absolute path of the build directory (not wanted)

Typical error: `dyld[36629]: Library not loaded: libkrun-efi.dylib`