### PR TITLE
arch: aarch64: Provide `initrd_size` to `arch_memory_regions`

### DIFF
--- a/src/arch/src/aarch64/linux/regs.rs
+++ b/src/arch/src/aarch64/linux/regs.rs
@@ -153,7 +153,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         match setup_regs(&vcpu, 0, 0x0, &mem).unwrap_err() {

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -137,7 +137,7 @@ mod tests {
 
     #[test]
     fn test_regions_lt_1024gb() {
-        let (_mem_info, regions) = arch_memory_regions(1usize << 29);
+        let (_mem_info, regions) = arch_memory_regions(1usize << 29, 0);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
         assert_eq!(1usize << 29, regions[0].1);
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_regions_gt_1024gb() {
-        let (_mem_info, regions) = arch_memory_regions(1usize << 41);
+        let (_mem_info, regions) = arch_memory_regions(1usize << 41, 0);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
         assert_eq!(super::layout::DRAM_MEM_MAX_SIZE, regions[0].1 as u64);
@@ -153,15 +153,15 @@ mod tests {
 
     #[test]
     fn test_get_fdt_addr() {
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000, 0);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE, 0);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), 0x1000 + layout::DRAM_MEM_START);
     }


### PR DESCRIPTION
`arch_memory_regions` requires two arguments now while our tests still try to invoke it with only `size`, provide `initrd_size` to make tests work correctly.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>