### PR TITLE
net: support multiple network interfaces

### DIFF
--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -175,7 +175,7 @@ int start_passt()
     int socket_fds[2];
     const int PARENT = 0;
     const int CHILD = 1;
-    
+
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, socket_fds) < 0) {
         perror("Failed to create passt socket fd");
         return -1;
@@ -186,13 +186,13 @@ int start_passt()
         perror("fork");
         return -1;
     }
-    
+
     if (pid == 0) { // child
         if (close(socket_fds[PARENT]) < 0) {
             perror("close PARENT");
         }
 
-        char fd_as_str[16]; 
+        char fd_as_str[16];
         snprintf(fd_as_str, sizeof(fd_as_str), "%d", socket_fds[CHILD]);
 
         printf("passing fd %s to passt", fd_as_str);

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -149,27 +149,6 @@ bool parse_cmdline(int argc, char *const argv[], struct cmdline *cmdline)
     return false;
 }
 
-int connect_to_passt(char const *socket_path)
-{
-    struct sockaddr_un addr;
-    int socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (socket_fd < 0) {
-        perror("Failed to create passt socket fd");
-        return -1;
-    }
-
-    memset(&addr, 0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
-
-    if (connect(socket_fd, (const struct sockaddr *) &addr, sizeof(addr)) < 0) {
-        perror("Failed to bind passt socket");
-        return -1;
-    }
-
-    return socket_fd;
-}
-
 int start_passt()
 {
     int socket_fds[2];
@@ -297,16 +276,25 @@ int main(int argc, char *const argv[])
             return -1;
         }
     } else {
-        int passt_fd = cmdline.passt_socket_path ? connect_to_passt(cmdline.passt_socket_path) : start_passt();
+        uint8_t mac[] = {0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee};
+        if (cmdline.passt_socket_path != NULL) {
+            if (err = krun_add_net_unixstream(ctx_id, cmdline.passt_socket_path, -1, &mac[0], COMPAT_NET_FEATURES, 0)) {
+                errno = -err;
+                perror("Error configuring net mode");
+                return -1;
+            }
+        } else {
+            int passt_fd = start_passt();
 
-        if (passt_fd < 0) {
-            return -1;
-        }
+            if (passt_fd < 0) {
+                return -1;
+            }
 
-        if (err = krun_set_passt_fd(ctx_id, passt_fd)) {
-            errno = -err;
-            perror("Error configuring net mode");
-            return -1;
+            if (err = krun_add_net_unixstream(ctx_id, NULL, passt_fd, &mac[0], COMPAT_NET_FEATURES, 0)) {
+                errno = -err;
+                perror("Error configuring net mode");
+                return -1;
+            }
         }
     }
 

--- a/examples/external_kernel.c
+++ b/examples/external_kernel.c
@@ -149,29 +149,6 @@ bool parse_cmdline(int argc, char *const argv[], struct cmdline *cmdline)
     return false;
 }
 
-int connect_to_passt(char const *socket_path)
-{
-    struct sockaddr_un addr;
-    int socket_fd = socket(AF_UNIX, SOCK_STREAM, 0);
-    if (socket_fd < 0)
-    {
-        perror("Failed to create passt socket fd");
-        return -1;
-    }
-
-    memset(&addr, 0, sizeof(addr));
-    addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
-
-    if (connect(socket_fd, (const struct sockaddr *)&addr, sizeof(addr)) < 0)
-    {
-        perror("Failed to bind passt socket");
-        return -1;
-    }
-
-    return socket_fd;
-}
-
 int start_passt()
 {
     int socket_fds[2];
@@ -287,18 +264,25 @@ int main(int argc, char *const argv[])
 
     if (cmdline.net_mode == NET_MODE_PASST)
     {
-        int passt_fd = cmdline.passt_socket_path ? connect_to_passt(cmdline.passt_socket_path) : start_passt();
+        uint8_t mac[] = {0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee};
+        if (cmdline.passt_socket_path != NULL) {
+            if (err = krun_add_net_unixstream(ctx_id, cmdline.passt_socket_path, -1, &mac[0], COMPAT_NET_FEATURES, 0)) {
+                errno = -err;
+                perror("Error configuring net mode");
+                return -1;
+            }
+        } else {
+            int passt_fd = start_passt();
 
-        if (passt_fd < 0)
-        {
-            return -1;
-        }
+            if (passt_fd < 0) {
+                return -1;
+            }
 
-        if (err = krun_set_passt_fd(ctx_id, passt_fd))
-        {
-            errno = -err;
-            perror("Error configuring net mode");
-            return -1;
+            if (err = krun_add_net_unixstream(ctx_id, NULL, passt_fd, &mac[0], COMPAT_NET_FEATURES, 0)) {
+                errno = -err;
+                perror("Error configuring net mode");
+                return -1;
+            }
         }
     }
 

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -13,8 +13,8 @@ pub const TX_INDEX: usize = 1;
 
 mod backend;
 pub mod device;
-mod gvproxy;
-mod passt;
+mod unixgram;
+mod unixstream;
 mod worker;
 
 pub use self::device::Net;

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -1,6 +1,6 @@
 use crate::legacy::IrqChip;
-use crate::virtio::net::gvproxy::Gvproxy;
-use crate::virtio::net::passt::Passt;
+use crate::virtio::net::unixgram::Unixgram;
+use crate::virtio::net::unixstream::Unixstream;
 use crate::virtio::net::{MAX_BUFFER_SIZE, QUEUE_SIZE, RX_INDEX, TX_INDEX};
 use crate::virtio::{Queue, VIRTIO_MMIO_INT_VRING};
 use crate::Error as DeviceError;
@@ -64,9 +64,17 @@ impl NetWorker {
         cfg_backend: VirtioNetBackend,
     ) -> Self {
         let backend = match cfg_backend {
-            VirtioNetBackend::Passt(fd) => Box::new(Passt::new(fd)) as Box<dyn NetBackend + Send>,
-            VirtioNetBackend::Gvproxy(path) => {
-                Box::new(Gvproxy::new(path).unwrap()) as Box<dyn NetBackend + Send>
+            VirtioNetBackend::UnixstreamFd(fd) => {
+                Box::new(Unixstream::new(fd)) as Box<dyn NetBackend + Send>
+            }
+            VirtioNetBackend::UnixstreamPath(path) => {
+                Box::new(Unixstream::open(path).unwrap()) as Box<dyn NetBackend + Send>
+            }
+            VirtioNetBackend::UnixgramFd(fd) => {
+                Box::new(Unixgram::new(fd)) as Box<dyn NetBackend + Send>
+            }
+            VirtioNetBackend::UnixgramPath(path, vfkit_magic) => {
+                Box::new(Unixgram::open(path, vfkit_magic).unwrap()) as Box<dyn NetBackend + Send>
             }
         };
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -104,7 +104,7 @@ pub struct VmResources {
     pub block: BlockBuilder,
     /// The network devices builder.
     #[cfg(feature = "net")]
-    pub net_builder: NetBuilder,
+    pub net: NetBuilder,
     /// TEE configuration
     #[cfg(feature = "tee")]
     pub tee_config: TeeConfig,
@@ -282,8 +282,7 @@ impl VmResources {
         &mut self,
         config: NetworkInterfaceConfig,
     ) -> Result<NetworkInterfaceError> {
-        self.net_builder.build(config)?;
-        Ok(())
+        self.net.insert(config)
     }
 
     #[cfg(feature = "tee")]


### PR DESCRIPTION
So far, we were assuming the microVM will have a single network interface. But we have at least one new usecase (namely, running Android), that requires having multiple interfaces.

Refactor the API to support adding mulitple interfaces, while we keep compatibility with the old API.

While there, also allow the user to set up the network device flags.