### PR TITLE
net: implement a backend for tap devices

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -371,6 +371,36 @@ int32_t krun_add_net_unixgram(uint32_t ctx_id,
                               uint32_t flags);
 
 /**
+ * Adds an independent virtio-net device with the tap backend.
+ * Call to this function disables TSI backend.
+
+ * The "krun_add_net_*" functions can be called multiple times for
+ * adding multiple virtio-net devices. In the guest the interfaces
+ * will appear in the same order as they are added (that is, the
+ * first added interface will be "eth0", the second "eth1"...)
+ *
+ * Arguments:
+ *  "ctx_id"      - the configuration context ID.
+ *  "c_tap_name"  - a null-terminated string representing the tap
+ *                  device name.
+ *  "c_mac"       - MAC address as an array of 6 uint8_t entries.
+ *  "features"    - virtio-net features for the network interface.
+ *  "flags"       - generic flags for the network interface.
+ *
+ * Notes:
+ * If no network devices are added, networking uses the TSI backend.
+ * This function should be called before krun_set_port_map.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_add_net_tap(uint32_t ctx_id,
+                         char *c_tap_name,
+                         uint8_t *const c_mac,
+                         uint32_t features,
+                         uint32_t flags);
+
+/**
  * DEPRECATED. Use krun_add_net_unixstream instead.
  *
  * Configures the networking to use passt.

--- a/src/devices/src/virtio/net/backend.rs
+++ b/src/devices/src/virtio/net/backend.rs
@@ -1,3 +1,4 @@
+use std::io;
 use std::os::fd::RawFd;
 
 #[allow(dead_code)]
@@ -7,6 +8,11 @@ pub enum ConnectError {
     CreateSocket(nix::Error),
     Binding(nix::Error),
     SendingMagic(nix::Error),
+    // Tap backend errors.
+    OpenNetTun(nix::Error),
+    TunSetIff(io::Error),
+    TunSetVnetHdrSz(io::Error),
+    TunSetOffload(io::Error),
 }
 
 #[allow(dead_code)]

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -65,6 +65,8 @@ pub enum VirtioNetBackend {
     UnixstreamPath(PathBuf),
     UnixgramFd(RawFd),
     UnixgramPath(PathBuf, bool),
+    #[cfg(target_os = "linux")]
+    Tap(String),
 }
 
 pub struct Net {
@@ -198,6 +200,7 @@ impl VirtioDevice for Net {
             queue_evts,
             interrupt.clone(),
             mem.clone(),
+            self.acked_features,
             self.cfg_backend.clone(),
         );
         worker.run();

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -1,7 +1,9 @@
 // Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{io, result};
+use std::{io, mem, result};
+use virtio_bindings::virtio_net::virtio_net_hdr_v1;
+
 pub const MAX_BUFFER_SIZE: usize = 65562;
 pub const QUEUE_SIZE: u16 = 1024;
 pub const NUM_QUEUES: usize = 2;
@@ -16,6 +18,18 @@ pub mod device;
 mod unixgram;
 mod unixstream;
 mod worker;
+
+fn vnet_hdr_len() -> usize {
+    mem::size_of::<virtio_net_hdr_v1>()
+}
+
+// This initializes to all 0 the virtio_net_hdr part of a buf and return the length of the header
+// https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-2050006
+fn write_virtio_net_hdr(buf: &mut [u8]) -> usize {
+    let len = vnet_hdr_len();
+    buf[0..len].fill(0);
+    len
+}
 
 pub use self::device::Net;
 #[derive(Debug)]

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -15,6 +15,8 @@ pub const TX_INDEX: usize = 1;
 
 mod backend;
 pub mod device;
+#[cfg(target_os = "linux")]
+mod tap;
 mod unixgram;
 mod unixstream;
 mod worker;

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -1,0 +1,128 @@
+use libc::{
+    c_char, c_int, ifreq, IFF_NO_PI, IFF_TAP, IFF_VNET_HDR, TUN_F_CSUM, TUN_F_TSO4, TUN_F_TSO6,
+    TUN_F_UFO,
+};
+use nix::fcntl::{fcntl, open, FcntlArg, OFlag};
+use nix::sys::stat::Mode;
+use nix::unistd::{read, write};
+use nix::{ioctl_write_int, ioctl_write_ptr};
+use std::os::fd::{AsRawFd, RawFd};
+use std::{io, mem, ptr};
+use virtio_bindings::virtio_net::{
+    VIRTIO_NET_F_GUEST_CSUM, VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6,
+    VIRTIO_NET_F_GUEST_UFO,
+};
+
+use super::backend::{ConnectError, NetBackend, ReadError, WriteError};
+
+ioctl_write_ptr!(tunsetiff, b'T', 202, c_int);
+ioctl_write_int!(tunsetoffload, b'T', 208);
+ioctl_write_ptr!(tunsetvnethdrsz, b'T', 216, c_int);
+
+pub struct Tap {
+    fd: RawFd,
+}
+
+impl Tap {
+    /// Create an endpoint using the file descriptor of a tap device
+    pub fn new(tap_name: String, vnet_features: u64) -> Result<Self, ConnectError> {
+        let fd = match open("/dev/net/tun", OFlag::O_RDWR, Mode::empty()) {
+            Ok(fd) => fd,
+            Err(err) => return Err(ConnectError::OpenNetTun(err)),
+        };
+
+        let mut req: ifreq = unsafe { mem::zeroed() };
+
+        unsafe {
+            ptr::copy_nonoverlapping(
+                tap_name.as_ptr() as *const c_char,
+                req.ifr_name.as_mut_ptr(),
+                tap_name.len(),
+            );
+        }
+
+        req.ifr_ifru.ifru_flags = IFF_TAP as i16 | IFF_NO_PI as i16 | IFF_VNET_HDR as i16;
+
+        let mut offload_flags: u64 = 0;
+        if (vnet_features & (1 << VIRTIO_NET_F_GUEST_CSUM)) != 0 {
+            offload_flags |= TUN_F_CSUM as u64;
+        }
+        if (vnet_features & (1 << VIRTIO_NET_F_GUEST_TSO4)) != 0 {
+            offload_flags |= TUN_F_TSO4 as u64;
+        }
+        if (vnet_features & (1 << VIRTIO_NET_F_GUEST_TSO6)) != 0 {
+            offload_flags |= TUN_F_TSO6 as u64;
+        }
+        if (vnet_features & (1 << VIRTIO_NET_F_GUEST_UFO)) != 0 {
+            offload_flags |= TUN_F_UFO as u64;
+        }
+
+        unsafe {
+            if let Err(err) = tunsetiff(fd, &mut req as *mut _ as *mut _) {
+                return Err(ConnectError::TunSetIff(io::Error::from(err)));
+            }
+
+            // TODO(slp): replace hardcoded vnet size with cons
+            if let Err(err) = tunsetvnethdrsz(fd, &12) {
+                return Err(ConnectError::TunSetVnetHdrSz(io::Error::from(err)));
+            }
+
+            if let Err(err) = tunsetoffload(fd, offload_flags) {
+                return Err(ConnectError::TunSetOffload(io::Error::from(err)));
+            }
+        }
+
+        match fcntl(fd, FcntlArg::F_GETFL) {
+            Ok(flags) => {
+                if let Err(e) = fcntl(
+                    fd,
+                    FcntlArg::F_SETFL(OFlag::from_bits_truncate(flags) | OFlag::O_NONBLOCK),
+                ) {
+                    warn!("error switching to non-blocking: id={fd}, err={e}");
+                }
+            }
+            Err(e) => error!("couldn't obtain fd flags id={fd}, err={e}"),
+        };
+
+        Ok(Self { fd })
+    }
+}
+
+impl NetBackend for Tap {
+    /// Try to read a frame from the tap devie. If no bytes are available reports
+    /// ReadError::NothingRead.
+    fn read_frame(&mut self, buf: &mut [u8]) -> Result<usize, ReadError> {
+        let frame_length = match read(self.fd, buf) {
+            Ok(f) => f,
+            #[allow(unreachable_patterns)]
+            Err(nix::Error::EAGAIN | nix::Error::EWOULDBLOCK) => {
+                return Err(ReadError::NothingRead)
+            }
+            Err(e) => {
+                return Err(ReadError::Internal(e));
+            }
+        };
+        debug!("Read eth frame from tap: {frame_length} bytes");
+        Ok(frame_length)
+    }
+
+    /// Try to write a frame to the tap device.
+    fn write_frame(&mut self, _hdr_len: usize, buf: &mut [u8]) -> Result<(), WriteError> {
+        let ret = write(self.fd, buf).map_err(WriteError::Internal)?;
+        debug!("Written frame size={}, written={}", buf.len(), ret);
+        Ok(())
+    }
+
+    fn has_unfinished_write(&self) -> bool {
+        false
+    }
+
+    fn try_finish_write(&mut self, _hdr_len: usize, _buf: &[u8]) -> Result<(), WriteError> {
+        // The tap backend doesn't do partial writes.
+        Ok(())
+    }
+
+    fn raw_socket_fd(&self) -> RawFd {
+        self.fd.as_raw_fd()
+    }
+}

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -5,7 +5,7 @@ use crate::virtio::{InterruptTransport, Queue};
 
 use super::backend::{NetBackend, ReadError, WriteError};
 use super::device::{FrontendError, RxError, TxError, VirtioNetBackend};
-use super::{vnet_hdr_len, write_virtio_net_hdr};
+use super::vnet_hdr_len;
 
 use std::os::fd::AsRawFd;
 use std::thread;
@@ -435,10 +435,7 @@ impl NetWorker {
 
     /// Fills self.rx_frame_buf with an ethernet frame from backend and prepends virtio_net_hdr to it
     fn read_into_rx_frame_buf_from_backend(&mut self) -> result::Result<(), ReadError> {
-        let mut len = 0;
-        len += write_virtio_net_hdr(&mut self.rx_frame_buf);
-        len += self.backend.read_frame(&mut self.rx_frame_buf[len..])?;
-        self.rx_frame_buf_len = len;
+        self.rx_frame_buf_len = self.backend.read_frame(&mut self.rx_frame_buf)?;
         Ok(())
     }
 }

--- a/src/devices/src/virtio/net/worker.rs
+++ b/src/devices/src/virtio/net/worker.rs
@@ -5,26 +5,14 @@ use crate::virtio::{InterruptTransport, Queue};
 
 use super::backend::{NetBackend, ReadError, WriteError};
 use super::device::{FrontendError, RxError, TxError, VirtioNetBackend};
+use super::{vnet_hdr_len, write_virtio_net_hdr};
 
 use std::os::fd::AsRawFd;
 use std::thread;
-use std::{cmp, mem, result};
+use std::{cmp, result};
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use utils::eventfd::EventFd;
-use virtio_bindings::virtio_net::virtio_net_hdr_v1;
 use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
-
-fn vnet_hdr_len() -> usize {
-    mem::size_of::<virtio_net_hdr_v1>()
-}
-
-// This initializes to all 0 the virtio_net_hdr part of a buf and return the length of the header
-// https://docs.oasis-open.org/virtio/virtio/v1.1/csprd01/virtio-v1.1-csprd01.html#x1-2050006
-fn write_virtio_net_hdr(buf: &mut [u8]) -> usize {
-    let len = vnet_hdr_len();
-    buf[0..len].fill(0);
-    len
-}
 
 pub struct NetWorker {
     queues: Vec<Queue>,

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -880,6 +880,59 @@ pub unsafe extern "C" fn krun_add_net_unixgram(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
+#[cfg(all(target_os = "linux", feature = "net"))]
+pub unsafe extern "C" fn krun_add_net_tap(
+    ctx_id: u32,
+    c_tap_name: *const c_char,
+    c_mac: *const u8,
+    features: u32,
+    flags: u32,
+) -> i32 {
+    if cfg!(not(feature = "net")) {
+        return -libc::ENOTSUP;
+    }
+
+    let tap_name = match CStr::from_ptr(c_tap_name).to_str() {
+        Ok(tap_name) => tap_name.to_string(),
+        Err(e) => {
+            debug!("Error parsing tap_name: {e:?}");
+            return -libc::EINVAL;
+        }
+    };
+
+    let mac: [u8; 6] = match slice::from_raw_parts(c_mac, 6).try_into() {
+        Ok(m) => m,
+        Err(_) => return -libc::EINVAL,
+    };
+
+    if (features & !NET_ALL_FEATURES) != 0 {
+        return -libc::EINVAL;
+    }
+
+    if features & (NET_FEATURE_GUEST_TSO4 | NET_FEATURE_GUEST_TSO6 | NET_FEATURE_GUEST_UFO) != 0
+        && features & NET_FEATURE_GUEST_CSUM == 0
+    {
+        debug!("Network tap backend requires GUEST_CSUM to be requested if any of GUEST_TSO4, GUEST_TSO6 and/or GUEST_UFO are required");
+        return -libc::EINVAL;
+    }
+
+    /* The tap backend doesn't support any flags */
+    if flags != 0 {
+        return -libc::EINVAL;
+    }
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            let cfg = ctx_cfg.get_mut();
+            create_virtio_net(cfg, VirtioNetBackend::Tap(tap_name), mac, features);
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+    KRUN_SUCCESS
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
 #[cfg(feature = "net")]
 pub unsafe extern "C" fn krun_set_passt_fd(ctx_id: u32, fd: c_int) -> i32 {
     if fd < 0 {

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -768,10 +768,6 @@ pub unsafe extern "C" fn krun_add_net_unixstream(
     features: u32,
     flags: u32,
 ) -> i32 {
-    if cfg!(not(feature = "net")) {
-        return -libc::ENOTSUP;
-    }
-
     let path = if !c_path.is_null() {
         match CStr::from_ptr(c_path).to_str() {
             Ok(path) => Some(PathBuf::from(path)),
@@ -828,10 +824,6 @@ pub unsafe extern "C" fn krun_add_net_unixgram(
     features: u32,
     flags: u32,
 ) -> i32 {
-    if cfg!(not(feature = "net")) {
-        return -libc::ENOTSUP;
-    }
-
     let path = if !c_path.is_null() {
         match CStr::from_ptr(c_path).to_str() {
             Ok(path) => Some(PathBuf::from(path)),
@@ -888,10 +880,6 @@ pub unsafe extern "C" fn krun_add_net_tap(
     features: u32,
     flags: u32,
 ) -> i32 {
-    if cfg!(not(feature = "net")) {
-        return -libc::ENOTSUP;
-    }
-
     let tap_name = match CStr::from_ptr(c_tap_name).to_str() {
         Ok(tap_name) => tap_name.to_string(),
         Err(e) => {
@@ -933,14 +921,23 @@ pub unsafe extern "C" fn krun_add_net_tap(
 
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
+#[cfg(all(not(target_os = "linux"), feature = "net"))]
+pub unsafe extern "C" fn krun_add_net_tap(
+    _ctx_id: u32,
+    _c_tap_name: *const c_char,
+    _c_mac: *const u8,
+    _features: u32,
+    _flags: u32,
+) -> i32 {
+    -libc::EINVAL
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
 #[cfg(feature = "net")]
 pub unsafe extern "C" fn krun_set_passt_fd(ctx_id: u32, fd: c_int) -> i32 {
     if fd < 0 {
         return -libc::EINVAL;
-    }
-
-    if cfg!(not(feature = "net")) {
-        return -libc::ENOTSUP;
     }
 
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
@@ -967,10 +964,6 @@ pub unsafe extern "C" fn krun_set_passt_fd(ctx_id: u32, fd: c_int) -> i32 {
 #[no_mangle]
 #[cfg(feature = "net")]
 pub unsafe extern "C" fn krun_set_gvproxy_path(ctx_id: u32, c_path: *const c_char) -> i32 {
-    if cfg!(not(feature = "net")) {
-        return -libc::ENOTSUP;
-    }
-
     let path_str = match CStr::from_ptr(c_path).to_str() {
         Ok(path) => path,
         Err(e) => {


### PR DESCRIPTION
Implement a new backend that allows network interfaces to use a tap device on the host to read/write frames.