### PR TITLE
nitro: Remove vsock proxying + documentation additions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,9 +1064,9 @@ dependencies = [
 
 [[package]]
 name = "nitro-enclaves"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc4f6ad5cab7056766551e23ffe2e80c445406d4719944a36816873deec109d"
+checksum = "8e263b205723b7e69812658f42eebbf790531e902ed0a4d77b8219f2006d5187"
 dependencies = [
  "bitflags 2.9.1",
  "libc",

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -771,6 +771,9 @@ int32_t krun_nitro_set_start_flags(uint32_t ctx_id, uint64_t start_flags);
  *  code once the microVM shuts down. If an error occurred before running the workload the process
  *  will exit() with an error exit code.
  *
+ *  In the nitro flavor, this function always returns. Upon success, this function will return the
+ *  CID of the nitro enclave that was started.
+ *
  * Error exit codes:
  *  125     - "init" cannot set up the environment inside the microVM.
  *  126     - "init" can find the executable to be run inside the microVM but cannot execute it.

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -36,7 +36,7 @@ hvf = { path = "../hvf" }
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
 kvm-ioctls = ">=0.21"
 nitro = { path = "../nitro", optional = true }
-nitro-enclaves = { version = "0.2.0", optional = true }
+nitro-enclaves = { version = "0.3.0", optional = true }
 vm-memory = ">=0.13"
 
 [lib]

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -12,8 +12,6 @@ use std::fs::File;
 #[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
 use std::os::fd::{FromRawFd, RawFd};
-#[cfg(feature = "nitro")]
-use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::slice;
 use std::sync::atomic::{AtomicI32, Ordering};
@@ -325,31 +323,10 @@ impl TryFrom<ContextConfig> for NitroEnclave {
             return Err(-libc::EINVAL);
         };
 
-        let Some(port_map) = ctx.unix_ipc_port_map else {
-            error!("enclave vsock not configured");
-            return Err(-libc::EINVAL);
-        };
-
-        if port_map.len() > 1 {
-            error!("too many nitro vsocks detected (max 1)");
-            return Err(-libc::EINVAL);
-        }
-
-        let ipc_stream = {
-            let mut vec = Vec::from_iter(port_map.values());
-            let Some((path, _)) = vec.pop() else {
-                error!("enclave vsock path not found");
-                return Err(-libc::EINVAL);
-            };
-
-            UnixStream::connect(path).unwrap()
-        };
-
         Ok(Self {
             image,
             mem_size_mib,
             vcpus,
-            ipc_stream,
             start_flags: ctx.nitro_start_flags,
         })
     }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1896,10 +1896,13 @@ fn krun_start_enter_nitro(ctx_id: u32) -> i32 {
         return -libc::EINVAL;
     };
 
-    if let Err(e) = enclave.run() {
-        error!("Error running nitro enclave: {e}");
-        return -libc::EINVAL;
-    }
+    // Return enclave CID if successfully ran.
+    match enclave.run() {
+        Ok(cid) => cid.try_into().unwrap(), // Safe to unwrap.
+        Err(e) => {
+            error!("Error running nitro enclave: {e}");
 
-    KRUN_SUCCESS
+            -libc::EINVAL
+        }
+    }
 }

--- a/src/nitro/Cargo.toml
+++ b/src/nitro/Cargo.toml
@@ -12,4 +12,4 @@ nix = { version = "0.26.0", features = ["ioctl", "poll"] }
 vsock = "0.5.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nitro-enclaves = "0.2.0"
+nitro-enclaves = "0.3.0"

--- a/src/nitro/src/enclaves.rs
+++ b/src/nitro/src/enclaves.rs
@@ -51,7 +51,7 @@ pub struct NitroEnclave {
 
 impl NitroEnclave {
     /// Run the enclave.
-    pub fn run(&mut self) -> Result<()> {
+    pub fn run(&mut self) -> Result<u32> {
         let device = Device::open().map_err(NitroError::DeviceOpen)?;
 
         let mut launcher = Launcher::new(&device).map_err(NitroError::VmCreate)?;
@@ -80,7 +80,7 @@ impl NitroEnclave {
 
         self.listen(VMADDR_CID_HYPERVISOR, cid + CID_TO_CONSOLE_PORT_OFFSET)?;
 
-        Ok(())
+        Ok(cid)
     }
 
     fn listen(&mut self, cid: u32, port: u32) -> Result<()> {


### PR DESCRIPTION
Allow callers of the libkrun-nitro API to be responsible for connecting the vsock infrastructure needed for console output, rather than the nitro crate. Also add some documentation clarifications w/r/t the libkrun API in the nitro flavor.