### PR TITLE
Simplify booting from block devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,7 @@ dependencies = [
  "nitro-enclaves",
  "once_cell",
  "polly",
+ "rand 0.9.2",
  "utils",
  "vm-memory",
  "vmm",
@@ -1103,7 +1104,7 @@ dependencies = [
  "bitflags 2.9.1",
  "libc",
  "nix 0.26.4",
- "rand 0.9.1",
+ "rand 0.9.2",
  "vsock",
 ]
 
@@ -1396,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -852,6 +852,25 @@ int32_t krun_nitro_set_image(uint32_t ctx_id, const char *image_path,
 int32_t krun_nitro_set_start_flags(uint32_t ctx_id, uint64_t start_flags);
 
 /**
+ * Configure block device to be used as root filesystem.
+ *
+ * Arguments:
+ *  "ctx_id" - the configuration context ID.
+ *  "device" - a null-terminated string specifying the root device
+ *             (e.g. "/dev/vda1", must refer to a previously configured block device)
+ *  "fstype" - a null-terminated string specifying the filesystem type (e.g. "ext4", can be set to "auto" or NULL)
+ *  "options" - a null-terminated string with a comma-separated list of mount options (can be NULL)
+ *
+ * Notes:
+ *  This function can be used if you want a root filesystem backed by a block device instead of a virtiofs path.
+ *  Because libkrun uses its own built-in init process (implemented as a virtual file in the virtiofs driver),
+ *  you'd normally have to copy the executable into every filesystem image (or partition) you intend to boot from.
+ *  This is obviously difficult to maintain, so instead we can create a dummy virtiofs root behind the scenes,
+ *  execute init from it as usual and then switch to the actual root configured by this function.
+ */
+int32_t krun_set_root_disk_remount(uint32_t ctx_id, const char *device, const char *fstype, const char *options);
+
+/**
  * Starts and enters the microVM with the configured parameters. The VMM will attempt to take over
  * stdin/stdout to manage them on behalf of the process running inside the isolated environment,
  * simulating that the latter has direct control of the terminal.

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -2126,6 +2126,10 @@ impl FileSystem for PassthroughFs {
         const VIRTIO_IOC_EXIT_CODE_REQ: u32 =
             request_code_none!(VIRTIO_IOC_MAGIC, VIRTIO_IOC_TYPE_EXIT_CODE) as u32;
 
+        const VIRTIO_IOC_REMOVE_ROOT_DIR_CODE: u8 = 3;
+        const VIRTIO_IOC_REMOVE_ROOT_DIR_REQ: u32 =
+            request_code_none!(VIRTIO_IOC_MAGIC, VIRTIO_IOC_REMOVE_ROOT_DIR_CODE) as u32;
+
         match cmd {
             VIRTIO_IOC_EXPORT_FD_REQ => {
                 if out_size as usize != VIRTIO_IOC_EXPORT_FD_SIZE {
@@ -2158,6 +2162,10 @@ impl FileSystem for PassthroughFs {
             }
             VIRTIO_IOC_EXIT_CODE_REQ => {
                 exit_code.store(arg as i32, Ordering::SeqCst);
+                Ok(Vec::new())
+            }
+            VIRTIO_IOC_REMOVE_ROOT_DIR_REQ => {
+                std::fs::remove_dir_all(&self.cfg.root_dir)?;
                 Ok(Vec::new())
             }
             _ => Err(io::Error::from_raw_os_error(libc::EOPNOTSUPP)),

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -2123,10 +2123,15 @@ impl FileSystem for PassthroughFs {
         // We can't use nix::request_code_none here since it's system-dependent
         // and we need the value from Linux.
         const VIRTIO_IOC_EXIT_CODE_REQ: u32 = 0x7602;
+        const VIRTIO_IOC_REMOVE_ROOT_DIR_REQ: u32 = 0x7603;
 
         match cmd {
             VIRTIO_IOC_EXIT_CODE_REQ => {
                 exit_code.store(arg as i32, Ordering::SeqCst);
+                Ok(Vec::new())
+            }
+            VIRTIO_IOC_REMOVE_ROOT_DIR_REQ => {
+                std::fs::remove_dir_all(&self.cfg.root_dir)?;
                 Ok(Vec::new())
             }
             _ => Err(io::Error::from_raw_os_error(libc::EOPNOTSUPP)),

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -30,6 +30,7 @@ devices = { path = "../devices" }
 polly = { path = "../polly" }
 utils = { path = "../utils" }
 vmm = { path = "../vmm" }
+rand = "0.9.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { path = "../hvf" }

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -30,6 +30,13 @@ pub struct BlockDeviceConfig {
     pub is_disk_read_only: bool,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlockRootConfig {
+    pub device: String,
+    pub fstype: Option<String>,
+    pub options: Option<String>,
+}
+
 #[derive(Default)]
 pub struct BlockBuilder {
     pub list: VecDeque<Arc<Mutex<Block>>>,


### PR DESCRIPTION
I had an idea how to simplify booting from block devices. Since `init.krun` is a virtual file implemented in the virtiofs `passthrough` module, we'd normally have to manually copy it to the device from which we want to boot and also adjust kernel cmdline to override the default root settings.

Instead, if `krun_set_root()` was never called but there is a block device, we can still create a dummy rootfs just for executing init and then switch to the real root with a similar mechanism initramfs would use.

This relies on setting `KRUN_BLOCK_ROOT` environment variable (internally) as well as reading `/proc/filesystems` so we can implement the behavior of `mount -t auto` for the real root.

I also added another custom ioctl which I use for cleaning up the temporary root when no longer needed.