### PR TITLE
aarch64: Expose pointer authentication to guests

### DIFF
--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -1203,6 +1203,13 @@ impl Vcpu {
             kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_POWER_OFF;
         }
 
+        if vm_fd.check_extension(kvm_ioctls::Cap::ArmPtrAuthAddress) {
+            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PTRAUTH_ADDRESS;
+        }
+        if vm_fd.check_extension(kvm_ioctls::Cap::ArmPtrAuthGeneric) {
+            kvi.features[0] |= 1 << kvm_bindings::KVM_ARM_VCPU_PTRAUTH_GENERIC;
+        }
+
         self.fd.vcpu_init(&kvi).map_err(Error::VcpuArmInit)?;
         arch::aarch64::regs::setup_regs(&self.fd, self.id, kernel_load_addr.raw_value(), guest_mem)
             .map_err(Error::REGSConfiguration)?;


### PR DESCRIPTION
Pointer authentication is an Arm CPU feature that may be used to mitigate
against various security vulnerabilities. It is not exposed to KVM guests
by default, so do so.

Signed-off-by: Peter Collingbourne <pcc@google.com>