### PR TITLE
KRUN_* environment variables should be preserved when a custom kernel cmdline is configured

### DIFF
--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2120,10 +2120,9 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     }
 
     let boot_source = BootSourceConfig {
-        kernel_cmdline_prolog: Some(format!(
-            "{} init={} {} {} {} {} {}",
-            DEFAULT_KERNEL_CMDLINE,
-            INIT_PATH,
+        kernel_cmdline_prolog: Some(format!("{} init={}", DEFAULT_KERNEL_CMDLINE, INIT_PATH)),
+        kernel_cmdline_krun_env: Some(format!(
+            " {} {} {} {} {}",
             ctx_cfg.get_exec_path(),
             ctx_cfg.get_workdir(),
             ctx_cfg.get_block_root(),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -555,6 +555,10 @@ pub fn build_microvm(
         kernel_cmdline.insert_str(DEFAULT_KERNEL_CMDLINE).unwrap();
     }
 
+    if let Some(cmdline) = &vm_resources.boot_config.kernel_cmdline_krun_env {
+        kernel_cmdline.insert_str(cmdline.as_str()).unwrap();
+    }
+
     #[cfg(not(feature = "tee"))]
     #[allow(unused_mut)]
     let mut vm = setup_vm(&guest_memory, vm_resources.nested_enabled)?;

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -334,6 +334,7 @@ mod tests {
     fn default_boot_cfg() -> BootSourceConfig {
         BootSourceConfig {
             kernel_cmdline_prolog: None,
+            kernel_cmdline_krun_env: None,
             kernel_cmdline_epilog: None,
         }
     }

--- a/src/vmm/src/vmm_config/boot_source.rs
+++ b/src/vmm/src/vmm_config/boot_source.rs
@@ -17,6 +17,7 @@ pub struct BootSourceConfig {
     /// The boot arguments to pass to the kernel. If this field is uninitialized, the default
     /// kernel command line is used: `reboot=k panic=1 pci=off nomodule 8250.nr_uarts=0`.
     pub kernel_cmdline_prolog: Option<String>,
+    pub kernel_cmdline_krun_env: Option<String>,
     pub kernel_cmdline_epilog: Option<String>,
 }
 


### PR DESCRIPTION
All settings like exec path, working directory, rlimits or any custom environment variables are ignored if there is an external kernel configured with a non-empty cmdline. This PR addresses the issue.