### PR TITLE
console: avoid logging error on ENOTTY

### DIFF
--- a/src/devices/src/virtio/console/device.rs
+++ b/src/devices/src/virtio/console/device.rs
@@ -47,7 +47,12 @@ pub(crate) fn get_win_size() -> (u16, u16) {
     let ret = unsafe { tiocgwinsz(0, &mut ws) };
 
     if let Err(err) = ret {
-        error!("Couldn't get terminal dimensions: {err}");
+        match err {
+            // If the port isn't a TTY, this is expected to fail. Avoid logging
+            // an error in that case.
+            nix::errno::Errno::ENOTTY => {}
+            _ => error!("Couldn't get terminal dimensions: {err}"),
+        }
         (0, 0)
     } else {
         (ws.cols, ws.rows)


### PR DESCRIPTION
If the device backing the port is not a TTY, it is expected that we'll receive an ENOTTY error. Avoid logging an error in that case.