### PR TITLE
include: libkrun: add `krun_set_pidfile` API

### DIFF
--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -325,6 +325,12 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    if (err = krun_set_pidfile(ctx_id, "/tmp/testing.pid")) {
+        errno = -err;
+        perror("Error setting pidfile");
+        return -1;
+    }
+
     // Start and enter the microVM. Unless there is some error while creating the microVM
     // this function never returns.
     if (err = krun_start_enter(ctx_id)) {

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -901,6 +901,18 @@ int32_t krun_nitro_set_start_flags(uint32_t ctx_id, uint64_t start_flags);
 int32_t krun_set_root_disk_remount(uint32_t ctx_id, const char *device, const char *fstype, const char *options);
 
 /**
+ * Configure the pidfile path.
+ *
+ * Arguments:
+ *  "ctx_id" - the configuration context ID.
+ *  "path" - path to the pidfile.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_pidfile(uint32_t ctx_id, const char *path);
+
+/**
  * Starts and enters the microVM with the configured parameters. The VMM will attempt to take over
  * stdin/stdout to manage them on behalf of the process running inside the isolated environment,
  * simulating that the latter has direct control of the terminal.


### PR DESCRIPTION
Add a new `krun_set_pidfile` API to allow the user to specify a path in which to write the current process's ID.

This was inspired by a new option I'm working on for krunkit: https://github.com/containers/krunkit/pull/71. I figured it could be useful for users here as well. 