### PR TITLE
Bump version to 1.15.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libkrun"
-version = "1.15.0"
+version = "1.15.1"
 dependencies = [
  "crossbeam-channel",
  "devices",

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ LIBRARY_HEADER = include/libkrun.h
 LIBRARY_HEADER_DISPLAY = include/libkrun_display.h
 
 ABI_VERSION=1
-FULL_VERSION=1.15.0
+FULL_VERSION=1.15.1
 
 INIT_SRC = init/init.c
 KBS_INIT_SRC =	init/tee/kbs/kbs.h		\

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.15.0"
+version = "1.15.1"
 authors = ["The libkrun Authors"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
Set up the stage for a quick bug-fix release including a patch fixing network configuration with unixgram sockets (#402).