### PR TITLE
rutabaga_gfx: fixes for wayland/sommelier

### DIFF
--- a/src/rutabaga_gfx/src/cross_domain/cross_domain_protocol.rs
+++ b/src/rutabaga_gfx/src/cross_domain/cross_domain_protocol.rs
@@ -31,10 +31,8 @@ pub const CROSS_DOMAIN_CHANNEL_TYPE_CAMERA: u32 = 0x0002;
 pub const CROSS_DOMAIN_CHANNEL_TYPE_PW: u32 = 0x0010;
 pub const CROSS_DOMAIN_CHANNEL_TYPE_X11: u32 = 0x0011;
 
-/// The maximum number of identifiers (value inspired by wp_linux_dmabuf)
-pub const CROSS_DOMAIN_MAX_IDENTIFIERS: usize = 4;
-/// As above, but inspired by sommelier
-pub const CROSS_DOMAIN_MAX_IDENTIFIERS_V2: usize = 28;
+/// The maximum number of identifiers (must match what sommelier expects)
+pub const CROSS_DOMAIN_MAX_IDENTIFIERS: usize = 28;
 
 /// virtgpu memory resource ID.  Also works with non-blob memory resources, despite the name.
 pub const CROSS_DOMAIN_ID_TYPE_VIRTGPU_BLOB: u32 = 1;
@@ -179,14 +177,14 @@ pub struct CrossDomainSendReceiveV2 {
     pub hdr: CrossDomainHeader,
     pub num_identifiers: u32,
     pub opaque_data_size: u32,
-    pub identifiers: [u32; CROSS_DOMAIN_MAX_IDENTIFIERS_V2],
-    pub identifier_types: [u32; CROSS_DOMAIN_MAX_IDENTIFIERS_V2],
-    pub identifier_sizes: [u32; CROSS_DOMAIN_MAX_IDENTIFIERS_V2],
+    pub identifiers: [u32; CROSS_DOMAIN_MAX_IDENTIFIERS],
+    pub identifier_types: [u32; CROSS_DOMAIN_MAX_IDENTIFIERS],
+    pub identifier_sizes: [u32; CROSS_DOMAIN_MAX_IDENTIFIERS],
     // Data of size "opaque data size follows"
 }
 
 impl CrossDomainSendReceiveBase for CrossDomainSendReceiveV2 {
-    const MAX_IDENTIFIERS: usize = CROSS_DOMAIN_MAX_IDENTIFIERS_V2;
+    const MAX_IDENTIFIERS: usize = CROSS_DOMAIN_MAX_IDENTIFIERS;
     fn hdr_mut(&mut self) -> &mut CrossDomainHeader {
         &mut self.hdr
     }

--- a/src/rutabaga_gfx/src/cross_domain/mod.rs
+++ b/src/rutabaga_gfx/src/cross_domain/mod.rs
@@ -1125,6 +1125,13 @@ impl RutabagaContext for CrossDomainContext {
         // Items that are removed from the table after one usage.
         match item {
             CrossDomainItem::ShmBlob(descriptor) => {
+                #[allow(unused_mut)]
+                let mut access = RUTABAGA_MAP_ACCESS_RW;
+                #[cfg(target_os = "linux")]
+                if fcntl(&descriptor, FcntlArg::F_GET_SEALS)? & libc::F_SEAL_WRITE != 0 {
+                    access &= !RUTABAGA_MAP_ACCESS_WRITE;
+                };
+
                 let hnd = RutabagaHandle {
                     os_handle: descriptor,
                     handle_type: RUTABAGA_MEM_HANDLE_TYPE_SHM,
@@ -1136,7 +1143,7 @@ impl RutabagaContext for CrossDomainContext {
                     blob: true,
                     blob_mem: resource_create_blob.blob_mem,
                     blob_flags: resource_create_blob.blob_flags,
-                    map_info: Some(RUTABAGA_MAP_CACHE_CACHED | RUTABAGA_MAP_ACCESS_RW),
+                    map_info: Some(RUTABAGA_MAP_CACHE_CACHED | access),
                     #[cfg(target_os = "macos")]
                     map_ptr: None,
                     info_2d: None,


### PR DESCRIPTION
I've been trying to get the Wayland forwarding to work as well as on crosvm.. With these fixes both sommelier and wayland-proxy-virtwl do actually work in muvm.

See the commit messages for details.

(is there any custom krun-specific client relying on `CROSS_DOMAIN_MAX_IDENTIFIERS: usize = 4;` ? :thinking:)