### PR TITLE
virtio/console: Remove use of unstable library feature

### DIFF
--- a/src/devices/src/virtio/console/port_queue_mapping.rs
+++ b/src/devices/src/virtio/console/port_queue_mapping.rs
@@ -24,7 +24,7 @@ pub(crate) fn queue_idx_to_port_id(queue_index: usize) -> (QueueDirection, usize
         _ => queue_index / 2 - 1,
     };
 
-    let direction = if queue_index.is_multiple_of(2) {
+    let direction = if queue_index % 2 == 0 {
         QueueDirection::Rx
     } else {
         QueueDirection::Tx


### PR DESCRIPTION
`is_multiple_of` is an unstable library feature.