### PR TITLE
libkrun: only create shutdown_efd on macOS

### DIFF
--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -459,10 +459,16 @@ pub unsafe extern "C" fn krun_init_log(target: RawFd, level: u32, style: u32, op
 
 #[no_mangle]
 pub extern "C" fn krun_create_ctx() -> i32 {
+    let shutdown_efd = if cfg!(target_arch = "aarch64") && cfg!(target_os = "macos") {
+        Some(EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap())
+    } else {
+        None
+    };
+
     let ctx_cfg = {
         ContextConfig {
             krunfw: KrunfwBindings::new(),
-            shutdown_efd: Some(EventFd::new(utils::eventfd::EFD_NONBLOCK).unwrap()),
+            shutdown_efd,
             ..Default::default()
         }
     };


### PR DESCRIPTION
We're only using shutdown_efd on macOS, so avoid creating it on other platforms.

Combined with the fact that crun closes every file descriptor between krun_create_ctx() and krun_start_enter(), this was triggering a double close() that ended closing a random file descriptor.

Reported-by: Matej Hrica <mhrica@redhat.com>