### PR TITLE
test fails with arch_memory_regions missing argument #3

### DIFF
--- a/src/arch/src/aarch64/linux/regs.rs
+++ b/src/arch/src/aarch64/linux/regs.rs
@@ -153,7 +153,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         match setup_regs(&vcpu, 0, 0x0, &mem).unwrap_err() {

--- a/src/arch/src/aarch64/mod.rs
+++ b/src/arch/src/aarch64/mod.rs
@@ -123,7 +123,7 @@ mod tests {
 
     #[test]
     fn test_regions_lt_1024gb() {
-        let (_mem_info, regions) = arch_memory_regions(1usize << 29, 0);
+        let (_mem_info, regions) = arch_memory_regions(1usize << 29, 0, None);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
         assert_eq!(1usize << 29, regions[0].1);
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_regions_gt_1024gb() {
-        let (_mem_info, regions) = arch_memory_regions(1usize << 41, 0);
+        let (_mem_info, regions) = arch_memory_regions(1usize << 41, 0, None);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
         assert_eq!(super::layout::DRAM_MEM_MAX_SIZE, regions[0].1 as u64);
@@ -139,15 +139,15 @@ mod tests {
 
     #[test]
     fn test_get_fdt_addr() {
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), 0x1000 + layout::DRAM_MEM_START);
     }

--- a/src/arch/src/riscv64/linux/regs.rs
+++ b/src/arch/src/riscv64/linux/regs.rs
@@ -90,7 +90,7 @@ mod tests {
         let kvm = Kvm::new().unwrap();
         let vm = kvm.create_vm().unwrap();
         let vcpu = vm.create_vcpu(0).unwrap();
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
 
         match setup_regs(&vcpu, 0, 0x0, &mem).unwrap_err() {

--- a/src/arch/src/riscv64/mod.rs
+++ b/src/arch/src/riscv64/mod.rs
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn test_regions_lt_1024gb() {
-        let (_mem_info, regions) = arch_memory_regions(1usize << 29, 0);
+        let (_mem_info, regions) = arch_memory_regions(1usize << 29, 0, None);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
         assert_eq!(1usize << 29, regions[0].1);
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn test_regions_gt_1024gb() {
-        let (_mem_info, regions) = arch_memory_regions(1usize << 41, 0);
+        let (_mem_info, regions) = arch_memory_regions(1usize << 41, 0, None);
         assert_eq!(1, regions.len());
         assert_eq!(GuestAddress(super::layout::DRAM_MEM_START), regions[0].0);
         assert_eq!(super::layout::DRAM_MEM_MAX_SIZE, regions[0].1 as u64);
@@ -128,15 +128,15 @@ mod tests {
 
     #[test]
     fn test_get_fdt_addr() {
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE - 0x1000, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), layout::DRAM_MEM_START);
 
-        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0);
+        let (_mem_info, regions) = arch_memory_regions(layout::FDT_MAX_SIZE + 0x1000, 0, None);
         let mem = GuestMemoryMmap::from_ranges(&regions).expect("Cannot initialize memory");
         assert_eq!(get_fdt_addr(&mem), 0x1000 + layout::DRAM_MEM_START);
     }


### PR DESCRIPTION
arch_memory_regions needs 3 arguments, while it previously used to need 2. This was updated in arch/src/x86, but not in aarch64 and riscv64

Added a 3rd parameter 'None' where it was missing.

Fixes: #435