### PR TITLE
include, block: add `krun_add_disk3` API

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -220,6 +220,60 @@ int32_t krun_add_disk2(uint32_t ctx_id,
                        uint32_t disk_format,
                        bool read_only);
 
+
+/* Supported sync modes */
+
+/**
+ * Ignore VIRTIO_BLK_F_FLUSH.
+ * WARNING: may lead to loss of data 
+ */ 
+#define KRUN_SYNC_NONE 0
+/**
+ * Honor VIRTIO_BLK_F_FLUSH requests, but relax strict hardware syncing on macOS.
+ * This is the recommended mode.
+ *
+ * On macOS this flushes the OS buffers, but does not ask the drive to flush
+ * its buffered data, which significantly improves performance. 
+ * On Linux this is the same as full sync.
+ */
+#define KRUN_SYNC_RELAXED 1
+/** 
+ * Honor VIRTIO_BLK_F_FLUSH, strictly flushing buffers to physical disk.
+ */
+#define KRUN_SYNC_FULL 2
+
+/**
+ * Adds a disk image to be used as a general partition for the microVM.
+ *
+ * This API is mutually exclusive with the deprecated krun_set_root_disk and
+ * krun_set_data_disk methods and must not be used together.
+ *
+ * SECURITY NOTE:
+ * See the security note for `krun_add_disk2`.
+ *
+ * Arguments:
+ *  "ctx_id"      - the configuration context ID.
+ *  "block_id"    - a null-terminated string representing the partition.
+ *  "disk_path"   - a null-terminated string representing the path leading to the disk image.
+ *  "disk_format" - the disk image format (i.e. KRUN_DISK_FORMAT_{RAW, QCOW2})
+ *  "read_only"   - whether the mount should be read-only. Required if the caller does not have
+ *                  write permissions (for disk images in /usr/share).
+ *  "direct_io"   - whether to bypass the host caches.
+ *  "sync_mode"   - whether to enable VIRTIO_BLK_F_FLUSH. On macOS, an additional relaxed sync
+ *                  mode is available, which is enabled by default, and will not ask the drive
+ *                  to flush its buffered data.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+ int32_t krun_add_disk3(uint32_t ctx_id,
+                       const char *block_id,
+                       const char *disk_path,
+                       uint32_t disk_format,
+                       bool read_only,
+                       bool direct_io,
+                       uint32_t sync_mode);
+
 /**
  * NO LONGER SUPPORTED. DO NOT USE.
  *

--- a/src/devices/src/virtio/block/mod.rs
+++ b/src/devices/src/virtio/block/mod.rs
@@ -40,3 +40,43 @@ pub enum ImageType {
     Qcow2,
     Vmdk,
 }
+
+impl TryFrom<u32> for ImageType {
+    type Error = ();
+
+    fn try_from(disk_format: u32) -> Result<Self, Self::Error> {
+        match disk_format {
+            0 => Ok(ImageType::Raw),
+            1 => Ok(ImageType::Qcow2),
+            2 => Ok(ImageType::Vmdk),
+            _ => {
+                // Do not continue if the user cannot specify a valid disk format
+                Err(())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum SyncMode {
+    None,
+    Relaxed,
+    #[default]
+    Full,
+}
+
+impl TryFrom<u32> for SyncMode {
+    type Error = ();
+
+    fn try_from(sync_mode: u32) -> Result<Self, Self::Error> {
+        match sync_mode {
+            0 => Ok(SyncMode::None),
+            1 => Ok(SyncMode::Relaxed),
+            2 => Ok(SyncMode::Full),
+            _ => {
+                // Do not continue if the user cannot specify a valid sync mode
+                Err(())
+            }
+        }
+    }
+}

--- a/src/vmm/src/vmm_config/block.rs
+++ b/src/vmm/src/vmm_config/block.rs
@@ -2,7 +2,10 @@ use std::collections::VecDeque;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 
-use devices::virtio::{block::ImageType, Block, CacheType};
+use devices::virtio::{
+    block::{ImageType, SyncMode},
+    Block, CacheType,
+};
 
 #[derive(Debug)]
 pub enum BlockConfigError {
@@ -28,6 +31,8 @@ pub struct BlockDeviceConfig {
     pub disk_image_path: String,
     pub disk_image_format: ImageType,
     pub is_disk_read_only: bool,
+    pub direct_io: bool,
+    pub sync_mode: SyncMode,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -63,6 +68,8 @@ impl BlockBuilder {
             config.disk_image_path,
             config.disk_image_format,
             config.is_disk_read_only,
+            config.direct_io,
+            config.sync_mode,
         )
         .map_err(BlockConfigError::CreateBlockDevice)
     }


### PR DESCRIPTION
Add the `krun_add_disk3` API that allows users to explicitly configure the sync and cache mode for a virtio-blk device. 

This is a followup to https://github.com/containers/libkrun/pull/428