### PR TITLE
virtio/fs: allow idmap mounts to virtiofs

### DIFF
--- a/src/devices/src/virtio/fs/fuse.rs
+++ b/src/devices/src/virtio/fs/fuse.rs
@@ -179,6 +179,9 @@ const HAS_INODE_DAX: u64 = 1 << 33;
 /// and mknod (single group that matches parent)
 const CREATE_SUPP_GROUP: u64 = 1 << 34;
 
+/// We need this for idmapped mounts support
+const ALLOW_IDMAP: u64 = 1 << 40;
+
 bitflags! {
     /// A bitfield passed in as a parameter to and returned from the `init` method of the
     /// `FileSystem` trait.
@@ -429,6 +432,9 @@ bitflags! {
         /// Add supplementary groups info to create, mkdir, symlink
         /// and mknod (single group that matches parent).
         const CREATE_SUPP_GROUP = CREATE_SUPP_GROUP;
+
+        /// Indicates if idmapped mounts are allowed for virtiofs.
+        const ALLOW_IDMAP = ALLOW_IDMAP;
     }
 }
 

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -1664,6 +1664,13 @@ impl FileSystem for PassthroughFs {
             return Ok(());
         }
 
+        // We use ctx.uid/ctx.gid for these checks, but when idmapped mounts
+        // support is enabled on the guest side, it means that "default_permissions"
+        // flag is set on virtiofs mount and FUSE_ACCESS request should never be
+        // sent to the userspace. Please, refer to the kernel commit
+        // ("fs/fuse: warn if fuse_access is called when idmapped mounts are allowed").
+        // In case when idmapped mounts are not enabled we are good to rely on ctx.uid/ctx.gid values.
+
         if (mode & libc::R_OK) != 0
             && ctx.uid != 0
             && (st.st_uid != ctx.uid || st.st_mode & 0o400 == 0)

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -1665,6 +1665,13 @@ impl FileSystem for PassthroughFs {
             return Ok(());
         }
 
+        // We use ctx.uid/ctx.gid for these checks, but when idmapped mounts
+        // support is enabled on the guest side, it means that "default_permissions"
+        // flag is set on virtiofs mount and FUSE_ACCESS request should never be
+        // sent to the userspace. Please, refer to the kernel commit
+        // ("fs/fuse: warn if fuse_access is called when idmapped mounts are allowed").
+        // In case when idmapped mounts are not enabled we are good to rely on ctx.uid/ctx.gid values.
+
         if (mode & libc::R_OK) != 0
             && ctx.uid != 0
             && (st.st_uid != ctx.uid || st.st_mode & 0o400 == 0)

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -889,7 +889,8 @@ impl<F: FileSystem + Sync> Server<F> {
             | FsOptions::ATOMIC_O_TRUNC
             | FsOptions::MAX_PAGES
             | FsOptions::SUBMOUNTS
-            | FsOptions::INIT_EXT;
+            | FsOptions::INIT_EXT
+            | FsOptions::ALLOW_IDMAP;
 
         if cfg!(target_os = "macos") {
             supported |= FsOptions::SECURITY_CTX;


### PR DESCRIPTION
Upstream have [supported][1] idmapped mounts by enable the extension. This is a port from upstream.

Most stuff have been done either by kernel side or by current implementation so we can declare the support directly.

Fixes #383 

[1]: https://gitlab.com/virtio-fs/virtiofsd/-/commit/a7545c68f