### PR TITLE
gtk_display: Fix keyboard focus not being grabbed

### DIFF
--- a/examples/krun_gtk_display/src/display_worker.rs
+++ b/examples/krun_gtk_display/src/display_worker.rs
@@ -393,6 +393,7 @@ impl ScanoutWindow {
 
         if let Some(keyboard_event_tx) = keyboard_event_tx {
             picture.set_focusable(true);
+            picture.grab_focus();
             attach_keyboard(keyboard_event_tx, &picture);
         }
         attach_per_display_inputs(&picture, &overlay, per_display_inputs);


### PR DESCRIPTION
This fixes a bug where keyboard wouldn't work in the VM until the user interacted with the window by mouse/touch (making it fullscreen).