### PR TITLE
init: set MS_SHARED for the root mount

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -1133,6 +1133,11 @@ int main(int argc, char **argv)
         }
     }
 
+    if (mount(NULL, "/", NULL, MS_REC | MS_SHARED, NULL) < 0) {
+        perror("Couldn't set shared propagation on the root mount");
+        exit(-1);
+    }
+
     setsid();
     ioctl(0, TIOCSCTTY, 1);
 


### PR DESCRIPTION
systemd expects container runtimes to do this[1], otherwise various things (such as credential passing) [break](https://github.com/systemd/systemd/issues/39501). It's generally the reasonable default and other container software might expect it to already be set as well.

[1]: https://systemd.io/CONTAINER_INTERFACE/