### PR TITLE
init/nitro: Fix typo

### DIFF
--- a/init/nitro/archive.c
+++ b/init/nitro/archive.c
@@ -127,7 +127,7 @@ int archive_extract(void *buf, size_t size)
 
     writer = writer_init();
     if (writer == NULL) {
-        archive_cleanup(r, NULL);
+        archive_cleanup(reader, NULL);
         return -1;
     }
 


### PR DESCRIPTION
This modification should've been rebased in another commit.