### PR TITLE
examples: Fix obsolete comment

### DIFF
--- a/examples/external_kernel.c
+++ b/examples/external_kernel.c
@@ -235,7 +235,7 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
-    // Configure the number of vCPUs (2) and the amount of RAM (1024 MiB).
+    // Configure the number of vCPUs (2) and the amount of RAM (2048 MiB).
     if (err = krun_set_vm_config(ctx_id, 2, 2048))
     {
         errno = -err;


### PR DESCRIPTION
The code had been updated but not the comment.
Maybe replacing `(2048 MiB)` with `(in MiB)` would avoid the problem from occurring again, but this version matched the code in `chroot_vm.c` (from which it is probably copied ?)