### PR TITLE
vmm/amdsnp: Remove sev library dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,15 +157,6 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bincode"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
@@ -190,7 +181,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
  "annotate-snippets",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -210,7 +201,7 @@ version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools",
@@ -224,18 +215,18 @@ dependencies = [
 
 [[package]]
 name = "bitfield"
-version = "0.19.1"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db1bcd90f88eabbf0cadbfb87a45bceeaebcd3b4bc9e43da379cd2ef0162590d"
+checksum = "21ba6517c6b0f2bf08be60e187ab64b038438f22dd755614d8fe4d4098c46419"
 dependencies = [
  "bitfield-macros",
 ]
 
 [[package]]
 name = "bitfield-macros"
-version = "0.19.1"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3787a07661997bfc05dd3431e379c0188573f78857080cf682e1393ab8e4d64c"
+checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -250,9 +241,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "block-buffer"
@@ -268,12 +259,6 @@ name = "bumpalo"
 version = "3.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bzip2"
@@ -356,12 +341,6 @@ dependencies = [
  "libc",
  "libloading",
 ]
-
-[[package]]
-name = "codicon"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
 
 [[package]]
 name = "colorchoice"
@@ -481,27 +460,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -573,21 +531,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "futures"
@@ -690,17 +633,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -708,7 +640,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi",
 ]
 
 [[package]]
@@ -741,12 +673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
 name = "hvf"
 version = "0.1.0"
 dependencies = [
@@ -763,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a46885ecbabe024b9e6e3ee9ee3a32ad05adf2b6269f45aa912793d9c54c805"
 dependencies = [
  "async-trait",
- "bincode 2.0.1",
+ "bincode",
  "cfg-if",
  "libc",
  "miniz_oxide",
@@ -843,7 +769,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "libc",
 ]
 
@@ -885,7 +811,7 @@ name = "krun_display"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.72.0",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "log",
  "static_assertions",
  "thiserror 2.0.12",
@@ -896,7 +822,7 @@ name = "krun_input"
 version = "0.1.0"
 dependencies = [
  "bindgen 0.72.0",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "libc",
  "log",
  "static_assertions",
@@ -918,7 +844,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b702df98508cb63ad89dd9beb9f6409761b30edca10d48e57941d3f11513a006"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "kvm-bindings",
  "libc",
  "vmm-sys-util 0.14.0",
@@ -983,7 +909,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "libc",
  "redox_syscall",
 ]
@@ -994,7 +920,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65f3a4b81b2a2d8c7f300643676202debd1b7c929dbf5c9bb89402ea11d19810"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cc",
  "convert_case",
  "cookie-factory",
@@ -1104,7 +1030,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b5b539a76e3f555fb143c3e67d5e05fa1d5fece02a515f6ecf41b3f1a081f58"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "libc",
  "nix 0.26.4",
  "rand",
@@ -1130,7 +1056,7 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cfg-if",
  "libc",
 ]
@@ -1141,7 +1067,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1154,7 +1080,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1193,60 +1119,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
-name = "openssl"
-version = "0.10.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
-dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-src"
-version = "300.5.0+3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
-
-[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,7 +1147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08e645ba5c45109106d56610b3ee60eb13a6f2beb8b74f8dc8186cf261788dda"
 dependencies = [
  "anyhow",
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "libc",
  "libspa",
  "libspa-sys",
@@ -1365,7 +1237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -1375,16 +1247,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1393,16 +1256,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
-dependencies = [
- "rand_core 0.6.4",
+ "getrandom",
 ]
 
 [[package]]
@@ -1411,18 +1265,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.1",
-]
-
-[[package]]
-name = "redox_users"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
-dependencies = [
- "getrandom 0.2.16",
- "libredox",
- "thiserror 2.0.12",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -1498,11 +1341,11 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1550,24 +1393,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-big-array"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1597,32 +1422,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "sev"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1750ba11a6a6bba3c220da714caa0226aa34e417dce3975d2953062240717dea"
-dependencies = [
- "base64",
- "bincode 1.3.3",
- "bitfield",
- "bitflags 2.9.1",
- "byteorder",
- "codicon",
- "dirs",
- "hex",
- "iocuddle",
- "lazy_static",
- "libc",
- "openssl",
- "rdrand",
- "serde",
- "serde-big-array",
- "serde_bytes",
- "static_assertions",
- "uuid",
 ]
 
 [[package]]
@@ -1753,7 +1552,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad59e5bf374211a1fdd8e7439a07d5a5e617fe97f5cf21d03bcd1bf8c82b73af"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "iocuddle",
  "kvm-bindings",
  "kvm-ioctls",
@@ -1933,15 +1732,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "js-sys",
- "serde",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
@@ -1990,12 +1782,15 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "arch_gen",
+ "bitfield",
+ "bitflags 2.10.0",
  "bzip2",
  "cpuid",
  "crossbeam-channel",
  "devices",
  "flate2",
  "hvf",
+ "iocuddle",
  "kbs-types",
  "kernel",
  "krun_display",
@@ -2009,7 +1804,6 @@ dependencies = [
  "polly",
  "serde",
  "serde_json",
- "sev",
  "tdx",
  "utils",
  "vm-memory",
@@ -2046,12 +1840,6 @@ dependencies = [
  "libc",
  "nix 0.29.0",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -2319,7 +2107,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
 ]
 
 [[package]]

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [features]
 tee = []
-amd-sev = [ "blk", "tee", "kbs-types", "serde", "serde_json", "sev" ]
+amd-sev = [ "blk", "bitfield", "bitflags", "iocuddle", "tee", "kbs-types", "serde", "serde_json" ]
 tdx = [ "blk", "tee", "kbs-types", "serde", "serde_json", "dep:tdx" ]
 net = []
 blk = []
@@ -39,7 +39,9 @@ polly = { path = "../polly" }
 kbs-types = { version = "0.13.0", optional = true }
 serde = { version = "1.0.125", optional = true }
 serde_json = { version = "1.0.64", optional = true }
-sev = { version = "6.0.0", features = ["openssl"], optional = true }
+iocuddle = { version = "0.1.1", optional = true }
+bitfield = { version = "0.19.4", optional = true }
+bitflags = { version = "2.10.0", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 bzip2 = "0.5"

--- a/src/vmm/src/linux/tee/amdsnp/launch/error.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/error.rs
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    convert::From,
+    error,
+    fmt::{Debug, Display},
+    io,
+};
+
+use std::os::raw::c_int;
+
+/// Error conditions returned by the SEV platform or by layers above it
+/// (i.e., the Linux kernel).
+///
+/// These error conditions are documented in the AMD SEV API spec, but
+/// their documentation has been copied here for completeness.
+#[derive(Debug, Clone, Copy, PartialEq)]
+#[repr(u32)]
+pub enum SevError {
+    /// The platform state is invalid for this command.
+    InvalidPlatformState = 0x0001,
+
+    /// The guest state is invalid for this command.
+    InvalidGuestState = 0x0002,
+
+    /// The platform configuration is invalid.
+    InvalidConfig = 0x0003,
+
+    /// A memory buffer is too small.
+    InvalidLen = 0x0004,
+
+    /// The platform is already owned.
+    AlreadyOwned = 0x0005,
+
+    /// The certificate is invalid.
+    InvalidCertificate = 0x0006,
+
+    /// Request is not allowed by guest policy.
+    PolicyFailure = 0x0007,
+
+    /// The guest is inactive.
+    Inactive = 0x0008,
+
+    /// The address provided is invalid.
+    InvalidAddress = 0x0009,
+
+    /// The provided signature is invalid.
+    BadSignature = 0x000A,
+
+    /// The provided measurement is invalid.
+    BadMeasurement = 0x000B,
+
+    /// The ASID is already owned.
+    AsidOwned = 0x000C,
+
+    /// The ASID is invalid.
+    InvalidAsid = 0x000D,
+
+    /// WBINVD instruction required.
+    WbinvdRequired = 0x000E,
+
+    /// `DF_FLUSH` invocation required.
+    DfFlushRequired = 0x000F,
+
+    /// The guest handle is invalid.
+    InvalidGuest = 0x0010,
+
+    /// The command issued is invalid.
+    InvalidCommand = 0x0011,
+
+    /// The guest is active.
+    Active = 0x0012,
+
+    /// A hardware condition has occurred affecting the platform. It is safe
+    /// to re-allocate parameter buffers.
+    HardwarePlatform = 0x0013,
+
+    /// A hardware condition has occurred affecting the platform. Re-allocating
+    /// parameter buffers is not safe.
+    HardwareUnsafe = 0x0014,
+
+    /// Feature is unsupported.
+    Unsupported = 0x0015,
+
+    /// A given parameter is invalid.
+    InvalidParam = 0x0016,
+
+    /// The SEV firmware has run out of a resource required to carry out the
+    /// command.
+    ResourceLimit = 0x0017,
+
+    /// The SEV platform observed a failed integrity check.
+    SecureDataInvalid = 0x0018,
+
+    /// The RMP page size is incorrect.
+    InvalidPageSize = 0x0019,
+
+    /// The RMP page state is incorrect
+    InvalidPageState = 0x001A,
+
+    /// The metadata entry is invalid.
+    InvalidMdataEntry = 0x001B,
+
+    /// The page ownership is incorrect
+    InvalidPageOwner = 0x001C,
+
+    /// The AEAD algorithm would have overflowed
+    AEADOFlow = 0x001D,
+
+    /// A Mailbox mode command was sent while the SEV FW was in Ring Buffer
+    /// mode. Ring Buffer mode has been exited; the Mailbox mode command
+    /// has been ignored. Retry is recommended.
+    RbModeExited = 0x001F, // 0x001F
+
+    /// The RMP must be reinitialized.
+    RMPInitRequired = 0x0020, // 0x0020
+
+    /// SVN of provided image is lower than the committed SVN.
+    BadSvn = 0x0021,
+
+    /// Firmware version anti-rollback.
+    BadVersion = 0x0022,
+
+    /// An invocation of SNP_SHUTDOWN is required to complete this action.
+    ShutdownRequired = 0x0023,
+
+    /// Update of the firmware internal state or a guest context page has failed.
+    UpdateFailed = 0x0024,
+
+    /// Installation of the committed firmware image required
+    RestoreRequired = 0x0025,
+
+    /// The RMP initialization failed.
+    RMPInitFailed = 0x0026,
+
+    /// The key requested is invalid, not present, or not allowed.
+    InvalidKey = 0x0027,
+
+    /// Unknown status code
+    UnknownError = 0x0000,
+}
+
+impl std::fmt::Display for SevError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let code = *self as u32;
+        match self {
+            SevError::InvalidPlatformState => {
+                write!(f, "Status Code: 0x{:x}: Invalid platform state.", code)
+            }
+            SevError::InvalidGuestState => {
+                write!(f, "Status Code: 0x{:x}: Invalid guest state.", code)
+            }
+            SevError::InvalidConfig => write!(
+                f,
+                "Status Code: 0x{:x}: Platform configuration invalid.",
+                code
+            ),
+            SevError::InvalidLen => {
+                write!(f, "Status Code: 0x{:x}: Memory buffer too small.", code)
+            }
+            SevError::AlreadyOwned => {
+                write!(f, "Status Code: 0x{:x}: Platform is already owned.", code)
+            }
+            SevError::InvalidCertificate => {
+                write!(f, "Status Code: 0x{:x}: Invalid certificate.", code)
+            }
+            SevError::PolicyFailure => write!(f, "Status Code: 0x{:x}: Policy failure.", code),
+            SevError::Inactive => write!(f, "Status Code: 0x{:x}: Guest is inactive.", code),
+            SevError::InvalidAddress => {
+                write!(f, "Status Code: 0x{:x}: Provided address is invalid.", code)
+            }
+            SevError::BadSignature => write!(
+                f,
+                "Status Code: 0x{:x}: Provided signature is invalid.",
+                code
+            ),
+            SevError::BadMeasurement => write!(
+                f,
+                "Status Code: 0x{:x}: Provided measurement is invalid.",
+                code
+            ),
+            SevError::AsidOwned => write!(f, "Status Code: 0x{:x}: ASID is already owned.", code),
+            SevError::InvalidAsid => write!(f, "Status Code: 0x{:x}: ASID is invalid.", code),
+            SevError::WbinvdRequired => {
+                write!(f, "Status Code: 0x{:x}: WBINVD instruction required.", code)
+            }
+            SevError::DfFlushRequired => write!(
+                f,
+                "Status Code: 0x{:x}: DF_FLUSH invocation required.",
+                code
+            ),
+            SevError::InvalidGuest => {
+                write!(f, "Status Code: 0x{:x}: Guest handle is invalid.", code)
+            }
+            SevError::InvalidCommand => {
+                write!(f, "Status Code: 0x{:x}: Issued command is invalid.", code)
+            }
+            SevError::Active => write!(f, "Status Code: 0x{:x}: Guest is active.", code),
+            SevError::HardwarePlatform => {
+                write!(
+                    f,
+                    "Status Code: 0x{:x}: Hardware condition occured, safe to re-allocate parameter buffers.",
+                    code
+                )
+            }
+            SevError::HardwareUnsafe => {
+                write!(
+                    f,
+                    "Status Code: 0x{:x}: Hardware condition occured, unsafe to re-allocate parameter buffers.",
+                    code
+                )
+            }
+            SevError::Unsupported => {
+                write!(f, "Status Code: 0x{:x}: Feature is unsupported.", code)
+            }
+            SevError::InvalidParam => {
+                write!(f, "Status Code: 0x{:x}: Given parameter is invalid.", code)
+            }
+            SevError::ResourceLimit => {
+                write!(
+                    f,
+                    "Status Code: 0x{:x}: SEV firmware has run out of required resources to carry out command.",
+                    code
+                )
+            }
+            SevError::SecureDataInvalid => write!(
+                f,
+                "Status Code: 0x{:x}: SEV platform observed a failed integrity check.",
+                code
+            ),
+            SevError::InvalidPageSize => write!(
+                f,
+                "Status Code: 0x{:x}: The RMP page size is incorrect.",
+                code
+            ),
+            SevError::InvalidPageState => write!(
+                f,
+                "Status Code: 0x{:x}: The RMP page state is incorrect.",
+                code
+            ),
+            SevError::InvalidMdataEntry => write!(
+                f,
+                "Status Code: 0x{:x}: The metadata entry is invalid.",
+                code
+            ),
+            SevError::InvalidPageOwner => write!(
+                f,
+                "Status Code: 0x{:x}: The page ownership is incorrect.",
+                code
+            ),
+            SevError::AEADOFlow => write!(
+                f,
+                "Status Code: 0x{:x}: The AEAD algorithm would have overflowed.",
+                code
+            ),
+            SevError::RbModeExited => write!(
+                f,
+                "Status Code: 0x{:x}: A Mailbox mode command was sent while the SEV FW was in Ring Buffer \
+                                    mode. Ring Buffer mode has been exited; the Mailbox mode command has \
+                                    been ignored. Retry is recommended.",
+                code
+            ),
+            SevError::RMPInitRequired => write!(
+                f,
+                "Status Code: 0x{:x}: The RMP must be reinitialized.",
+                code
+            ),
+            SevError::BadSvn => write!(
+                f,
+                "Status Code: 0x{:x}: SVN of provided image is lower than the committed SVN.",
+                code
+            ),
+            SevError::BadVersion => write!(
+                f,
+                "Status Code: 0x{:x}: Firmware version anti-rollback.",
+                code
+            ),
+            SevError::ShutdownRequired => write!(
+                f,
+                "Status Code: 0x{:x}: An invocation of SNP_SHUTDOWN is required to complete this action.",
+                code
+            ),
+            SevError::UpdateFailed => write!(
+                f,
+                "Status Code: 0x{:x}: Update of the firmware internal state or a guest context page has failed.",
+                code
+            ),
+            SevError::RestoreRequired => write!(
+                f,
+                "Status Code: 0x{:x}: Installation of the committed firmware image required.",
+                code
+            ),
+            SevError::RMPInitFailed => write!(
+                f,
+                "Status Code: 0x{:x}: The RMP initialization failed.",
+                code
+            ),
+            SevError::InvalidKey => write!(
+                f,
+                "Status Code: 0x{:x}: The key requested is invalid, not present, or not allowed.",
+                code
+            ),
+            SevError::UnknownError => write!(f, "Unknown SEV Error"),
+        }
+    }
+}
+
+impl From<u64> for SevError {
+    fn from(value: u64) -> Self {
+        Self::from(value as u32)
+    }
+}
+
+impl From<u32> for SevError {
+    #[inline]
+    fn from(error: u32) -> SevError {
+        match error {
+            0x01 => SevError::InvalidPlatformState,
+            0x02 => SevError::InvalidGuestState,
+            0x03 => SevError::InvalidConfig,
+            0x04 => SevError::InvalidLen,
+            0x05 => SevError::AlreadyOwned,
+            0x06 => SevError::InvalidCertificate,
+            0x07 => SevError::PolicyFailure,
+            0x08 => SevError::Inactive,
+            0x09 => SevError::InvalidAddress,
+            0x0A => SevError::BadSignature,
+            0x0B => SevError::BadMeasurement,
+            0x0C => SevError::AsidOwned,
+            0x0D => SevError::InvalidAsid,
+            0x0E => SevError::WbinvdRequired,
+            0x0F => SevError::DfFlushRequired,
+            0x10 => SevError::InvalidGuest,
+            0x11 => SevError::InvalidCommand,
+            0x12 => SevError::Active,
+            0x13 => SevError::HardwarePlatform,
+            0x14 => SevError::HardwareUnsafe,
+            0x15 => SevError::Unsupported,
+            0x16 => SevError::InvalidParam,
+            0x17 => SevError::ResourceLimit,
+            0x18 => SevError::SecureDataInvalid,
+            0x19 => SevError::InvalidPageSize,
+            0x1A => SevError::InvalidPageState,
+            0x1B => SevError::InvalidMdataEntry,
+            0x1C => SevError::InvalidPageOwner,
+            0x1D => SevError::AEADOFlow,
+            0x1F => SevError::RbModeExited,
+            0x20 => SevError::RMPInitRequired,
+            0x21 => SevError::BadSvn,
+            0x22 => SevError::BadVersion,
+            0x23 => SevError::ShutdownRequired,
+            0x24 => SevError::UpdateFailed,
+            0x25 => SevError::RestoreRequired,
+            0x26 => SevError::RMPInitFailed,
+            0x27 => SevError::InvalidKey,
+            _ => SevError::UnknownError,
+        }
+    }
+}
+
+impl From<SevError> for c_int {
+    fn from(err: SevError) -> Self {
+        match err {
+            SevError::InvalidPlatformState => 0x01,
+            SevError::InvalidGuestState => 0x02,
+            SevError::InvalidConfig => 0x03,
+            SevError::InvalidLen => 0x04,
+            SevError::AlreadyOwned => 0x05,
+            SevError::InvalidCertificate => 0x06,
+            SevError::PolicyFailure => 0x07,
+            SevError::Inactive => 0x08,
+            SevError::InvalidAddress => 0x09,
+            SevError::BadSignature => 0x0A,
+            SevError::BadMeasurement => 0x0B,
+            SevError::AsidOwned => 0x0C,
+            SevError::InvalidAsid => 0x0D,
+            SevError::WbinvdRequired => 0x0E,
+            SevError::DfFlushRequired => 0x0F,
+            SevError::InvalidGuest => 0x10,
+            SevError::InvalidCommand => 0x11,
+            SevError::Active => 0x12,
+            SevError::HardwarePlatform => 0x13,
+            SevError::HardwareUnsafe => 0x14,
+            SevError::Unsupported => 0x15,
+            SevError::InvalidParam => 0x16,
+            SevError::ResourceLimit => 0x17,
+            SevError::SecureDataInvalid => 0x18,
+            SevError::InvalidPageSize => 0x19,
+            SevError::InvalidPageState => 0x1A,
+            SevError::InvalidMdataEntry => 0x1B,
+            SevError::InvalidPageOwner => 0x1C,
+            SevError::AEADOFlow => 0x1D,
+            SevError::RbModeExited => 0x1F,
+            SevError::RMPInitRequired => 0x20,
+            SevError::BadSvn => 0x21,
+            SevError::BadVersion => 0x22,
+            SevError::ShutdownRequired => 0x23,
+            SevError::UpdateFailed => 0x24,
+            SevError::RestoreRequired => 0x25,
+            SevError::RMPInitFailed => 0x26,
+            SevError::InvalidKey => 0x27,
+            SevError::UnknownError => -1,
+        }
+    }
+}
+
+impl std::error::Error for SevError {}
+
+/// There are a number of error conditions that can occur between this
+/// layer all the way down to the SEV platform. Most of these cases have
+/// been enumerated; however, there is a possibility that some error
+/// conditions are not encapsulated here.
+#[derive(Debug)]
+pub enum FirmwareError {
+    /// The error condition is known.
+    KnownSev(SevError),
+
+    /// The error condition is unknown.
+    UnknownSev(u32),
+
+    /// IO Error
+    Io(std::io::Error),
+}
+
+impl error::Error for FirmwareError {}
+
+impl Display for FirmwareError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let err_description = match self {
+            FirmwareError::KnownSev(error) => format!("Known SEV FW Error: {error}"),
+            FirmwareError::UnknownSev(code) => {
+                format!("Unknown SEV FW Error Encountered: {code}")
+            }
+            FirmwareError::Io(error) => format!("IO Error Encountered: {error}"),
+        };
+
+        write!(f, "{err_description}")
+    }
+}
+
+impl std::convert::From<SevError> for FirmwareError {
+    fn from(sev_error: SevError) -> Self {
+        match sev_error {
+            SevError::UnknownError => FirmwareError::UnknownSev(sev_error as u32),
+            _ => FirmwareError::KnownSev(sev_error),
+        }
+    }
+}
+
+impl From<io::Error> for FirmwareError {
+    #[inline]
+    fn from(error: io::Error) -> FirmwareError {
+        FirmwareError::Io(error)
+    }
+}
+
+impl From<u64> for FirmwareError {
+    fn from(value: u64) -> Self {
+        Self::from(value as u32)
+    }
+}
+
+impl From<u32> for FirmwareError {
+    #[inline]
+    fn from(error: u32) -> FirmwareError {
+        match error {
+            0x00 => FirmwareError::Io(io::Error::last_os_error()),
+            0x01..0x027 => FirmwareError::KnownSev(error.into()),
+            _ => FirmwareError::UnknownSev(error),
+        }
+    }
+}
+
+impl From<FirmwareError> for c_int {
+    fn from(err: FirmwareError) -> Self {
+        match err {
+            FirmwareError::UnknownSev(_) | FirmwareError::Io(_) => -0x01,
+            FirmwareError::KnownSev(e) => e.into(),
+        }
+    }
+}

--- a/src/vmm/src/linux/tee/amdsnp/launch/firmware.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/firmware.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Operations for managing the SEV platform.
+
+use std::{
+    fs::{File, OpenOptions},
+    os::fd::{AsRawFd, RawFd},
+};
+
+/// A handle to the SEV platform.
+#[cfg(target_os = "linux")]
+pub struct Firmware(File);
+
+#[cfg(target_os = "linux")]
+impl Firmware {
+    /// Create a handle to the SEV platform.
+    pub fn open() -> std::io::Result<Firmware> {
+        Ok(Firmware(
+            OpenOptions::new().read(true).write(true).open("/dev/sev")?,
+        ))
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl AsRawFd for Firmware {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0.as_raw_fd()
+    }
+}

--- a/src/vmm/src/linux/tee/amdsnp/launch/linux/ioctl.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/linux/ioctl.rs
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! A collection of type-safe ioctl implementations for the AMD Secure Encrypted Virtualization
+//! (SEV) platform. These ioctls are exported by the Linux kernel.
+
+use crate::impl_const_id;
+
+use crate::linux::tee::amdsnp::launch::{error::FirmwareError, linux::snp};
+
+use std::{
+    marker::PhantomData,
+    os::{raw::c_ulong, unix::io::AsRawFd},
+};
+
+use iocuddle::*;
+
+// These enum ordinal values are defined in the Linux kernel
+// source code: arch/x86/include/uapi/asm/kvm.h
+impl_const_id! {
+    /// The ioctl sub number
+    pub Id => u32;
+
+    snp::Init2 = 22,
+
+    snp::LaunchStart = 100,
+    snp::LaunchUpdate<'_> = 101,
+    snp::LaunchFinish<'_> = 102,
+}
+
+const KVM: Group = Group::new(0xAE);
+const ENC_OP: Ioctl<WriteRead, &c_ulong> = unsafe { KVM.write_read(0xBA) };
+
+pub const KVM_MEMORY_ATTRIBUTE_PRIVATE: u64 = 1 << 3;
+
+// Note: the iocuddle::Ioctl::lie() constructor has been used here because
+// KVM_MEMORY_ENCRYPT_OP ioctl was defined like this:
+//
+// _IOWR(KVMIO, 0xba, unsigned long)
+//
+// Instead of something like this:
+//
+// _IOWR(KVMIO, 0xba, struct kvm_sev_cmd)
+//
+// which would require extra work to wrap around the design decision for
+// that ioctl.
+
+/// Use the KVM_SEV_INIT2 ioctl to initialize the SEV platform context.
+pub const INIT2: Ioctl<WriteRead, &Command<snp::Init2>> = unsafe { ENC_OP.lie() };
+
+/// Corresponds to the `KVM_MEMORY_ENCRYPT_REG_REGION` ioctl
+pub const ENC_REG_REGION: Ioctl<Write, &KvmEncRegion> =
+    unsafe { KVM.read::<KvmEncRegion>(0xBB).lie() };
+
+/// Corresponds to the `KVM_SET_MEMORY_ATTRIBUTES` ioctl
+pub const SET_MEMORY_ATTRIBUTES: Ioctl<Write, &KvmSetMemoryAttributes> =
+    unsafe { KVM.write::<KvmSetMemoryAttributes>(0xd2) };
+
+/// Initialize the flow to launch a guest.
+pub const SNP_LAUNCH_START: Ioctl<WriteRead, &Command<snp::LaunchStart>> = unsafe { ENC_OP.lie() };
+
+/// Insert pages into the guest physical address space.
+pub const SNP_LAUNCH_UPDATE: Ioctl<WriteRead, &Command<snp::LaunchUpdate>> =
+    unsafe { ENC_OP.lie() };
+
+/// Complete the guest launch flow.
+pub const SNP_LAUNCH_FINISH: Ioctl<WriteRead, &Command<snp::LaunchFinish>> =
+    unsafe { ENC_OP.lie() };
+
+/// Corresponds to the kernel struct `kvm_enc_region`
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct KvmEncRegion<'a> {
+    addr: u64,
+    size: u64,
+    phantom: PhantomData<&'a [u8]>,
+}
+
+impl<'a> KvmEncRegion<'a> {
+    /// Create a new `KvmEncRegion` referencing some memory assigned to the virtual machine.
+    pub fn new(data: &'a [u8]) -> Self {
+        Self {
+            addr: data.as_ptr() as _,
+            size: data.len() as _,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Register the encrypted memory region to a virtual machine
+    pub fn register(&mut self, vm_fd: &mut impl AsRawFd) -> std::io::Result<std::os::raw::c_uint> {
+        ENC_REG_REGION.ioctl(vm_fd, self)
+    }
+}
+
+/// Corresponds to the kernel struct `kvm_memory_attributes`
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
+pub struct KvmSetMemoryAttributes {
+    addr: u64,
+    size: u64,
+    attributes: u64,
+    flags: u64,
+}
+
+impl KvmSetMemoryAttributes {
+    /// Create a new `KvmEncRegion` referencing some memory assigned to the virtual machine.
+    pub fn new(data: u64, len: u64, attributes: u64) -> Self {
+        Self {
+            addr: data,
+            size: len,
+            attributes,
+            flags: 0,
+        }
+    }
+
+    /// Register the encrypted memory region to a virtual machine
+    pub fn set_attributes(
+        &mut self,
+        vm_fd: &mut impl AsRawFd,
+    ) -> std::io::Result<std::os::raw::c_uint> {
+        SET_MEMORY_ATTRIBUTES.ioctl(vm_fd, self)
+    }
+}
+
+/// A generic SEV command
+#[repr(C)]
+pub struct Command<'a, T: Id> {
+    code: u32,
+    data: u64,
+    error: u32,
+    sev_fd: u32,
+    _phantom: PhantomData<&'a T>,
+}
+
+impl<'a, T: Id> Command<'a, T> {
+    /// create the command from a subcommand reference
+    pub fn from(sev: &'a impl AsRawFd, subcmd: &'a T) -> Self {
+        Self {
+            code: T::ID,
+            data: subcmd as *const T as _,
+            error: 0,
+            sev_fd: sev.as_raw_fd() as _,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// encapsulate a SEV errors in command as a Firmware error.
+    pub fn encapsulate(&self) -> FirmwareError {
+        FirmwareError::from(self.error)
+    }
+}

--- a/src/vmm/src/linux/tee/amdsnp/launch/linux/mod.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/linux/mod.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Operations and types for launching on Linux
+pub(crate) mod ioctl;
+
+pub(crate) mod snp;

--- a/src/vmm/src/linux/tee/amdsnp/launch/linux/snp.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/linux/snp.rs
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Types for interacting with the KVM SEV-SNP guest management API.
+
+use crate::linux::tee::amdsnp::*;
+
+use std::marker::PhantomData;
+
+/// Structure passed into KVM_SEV_INIT2 command.
+#[derive(Default)]
+#[repr(C, packed)]
+pub struct Init2 {
+    /// Initial value of features field in VMSA. (Must be 0 for SEV)
+    vmsa_features: u64,
+
+    /// Always set to 0
+    flags: u32,
+
+    /// Maximum guest GHCB version allowed. (Currently 0 for SEV and 1 for SEV-ES and SEV-SNP)
+    ghcb_version: u16,
+
+    pad1: u16,
+
+    pad2: [u32; 8],
+}
+
+impl Init2 {
+    /// Default INIT2 values for SEV-SNP
+    pub fn init_default_snp() -> Self {
+        Self {
+            vmsa_features: 0,
+            flags: 0,
+            ghcb_version: 2,
+            pad1: Default::default(),
+            pad2: Default::default(),
+        }
+    }
+}
+
+#[repr(C)]
+pub struct LaunchStart {
+    /// Guest policy. See Table 7 of the AMD SEV-SNP Firmware
+    /// specification for a description of the guest policy structure.
+    policy: u64,
+
+    /// Hypervisor provided value to indicate guest OS visible workarounds.
+    /// The format is hypervisor defined.
+    gosvw: [u8; 16],
+
+    flags: u16,
+
+    pad0: [u8; 6],
+
+    pad1: [u64; 4],
+}
+
+impl From<Start> for LaunchStart {
+    fn from(start: Start) -> Self {
+        Self {
+            policy: start.policy.into(),
+            gosvw: start.gosvw,
+            flags: 0,
+            pad0: [0u8; 6],
+            pad1: [0u64; 4],
+        }
+    }
+}
+
+/// Insert pages into the guest physical address space.
+#[repr(C)]
+pub struct LaunchUpdate<'a> {
+    /// guest start frame number.
+    pub start_gfn: u64,
+
+    /// Userspace address of the page needed to be encrypted.
+    pub uaddr: u64,
+
+    /// Length of the page needed to be encrypted:
+    /// (end encryption uaddr = uaddr + len).
+    pub len: u64,
+
+    /// Encoded page type. See Table 58 if the SNP Firmware specification.
+    pub page_type: u8,
+
+    pad0: u8,
+
+    flags: u16,
+
+    pad1: u32,
+
+    pad2: [u64; 4],
+
+    _phantom: PhantomData<&'a [u8]>,
+}
+
+impl From<Update<'_>> for LaunchUpdate<'_> {
+    fn from(update: Update) -> Self {
+        Self {
+            start_gfn: update.start_gfn,
+            uaddr: update.uaddr.as_ptr() as _,
+            len: update.uaddr.len() as _,
+            page_type: update.page_type as _,
+            pad0: 0,
+            flags: 0,
+            pad1: 0,
+            pad2: [0u64; 4],
+            _phantom: PhantomData,
+        }
+    }
+}
+
+pub const KVM_SEV_SNP_FINISH_DATA_SIZE: usize = 32;
+
+/// Complete the guest launch flow.
+#[repr(C)]
+pub struct LaunchFinish<'a> {
+    /// Userspace address of the ID block. Ignored if ID_BLOCK_EN is 0.
+    id_block_uaddr: u64,
+
+    /// Userspace address of the authentication information of the ID block. Ignored if ID_BLOCK_EN is 0.
+    id_auth_uaddr: u64,
+
+    /// Indicates that the ID block is present.
+    id_block_en: u8,
+
+    /// Indicates that the author key is present in the ID authentication information structure.
+    /// Ignored if ID_BLOCK_EN is 0.
+    auth_key_en: u8,
+
+    /// Opaque host-supplied data to describe the guest. The firmware does not interpret this value.
+    host_data: [u8; KVM_SEV_SNP_FINISH_DATA_SIZE],
+
+    pad: [u8; 6],
+
+    _phantom: PhantomData<&'a [u8]>,
+}
+
+impl From<Finish<'_, '_>> for LaunchFinish<'_> {
+    fn from(finish: Finish) -> Self {
+        let id_block = if let Some(addr) = finish.id_block {
+            addr.as_ptr() as u64
+        } else {
+            0
+        };
+
+        let id_auth = if let Some(addr) = finish.id_auth {
+            addr.as_ptr() as u64
+        } else {
+            0
+        };
+
+        Self {
+            id_block_uaddr: id_block,
+            id_auth_uaddr: id_auth,
+            id_block_en: u8::from(finish.id_block.is_some()),
+            auth_key_en: u8::from(finish.id_auth.is_some()),
+            host_data: finish.host_data,
+            pad: [0u8; 6],
+            _phantom: PhantomData,
+        }
+    }
+}

--- a/src/vmm/src/linux/tee/amdsnp/launch/mod.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/mod.rs
@@ -1,0 +1,381 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! Everything one needs to launch an AMD SEV encrypted virtual machine.
+//!
+//! This module contains types for establishing a secure channel with the
+//! AMD Secure Processor for purposes of attestation as well as abstractions
+//! for navigating the AMD SEV launch process for a virtual machine.
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+pub mod error;
+pub mod firmware;
+pub(crate) mod util;
+
+use super::error::FirmwareError;
+
+#[cfg(target_os = "linux")]
+use linux::{ioctl::*, snp::*};
+
+use std::{fmt::Display, marker::PhantomData, os::unix::io::AsRawFd, result::Result};
+
+use bitfield::bitfield;
+use bitflags::bitflags;
+
+/// Launcher type-state that indicates a brand new launch.
+pub struct New;
+
+/// Launcher type-state that indicates a SNP in-progress.
+pub struct Started;
+
+/// Facilitates the correct execution of the SEV launch process.
+pub struct Launcher<T, U: AsRawFd, V: AsRawFd> {
+    vm_fd: U,
+    sev: V,
+    state: PhantomData<T>,
+}
+
+impl<T, U: AsRawFd, V: AsRawFd> AsRef<U> for Launcher<T, U, V> {
+    /// Give access to the vm fd to create vCPUs or such.
+    fn as_ref(&self) -> &U {
+        &self.vm_fd
+    }
+}
+
+impl<T, U: AsRawFd, V: AsRawFd> AsMut<U> for Launcher<T, U, V> {
+    /// Give access to the vm fd to create vCPUs or such.
+    fn as_mut(&mut self) -> &mut U {
+        &mut self.vm_fd
+    }
+}
+
+impl<U: AsRawFd, V: AsRawFd> Launcher<New, U, V> {
+    /// Begin the SEV-SNP launch process by creating a Launcher and issuing the
+    /// KVM_SNP_INIT ioctl.
+    pub fn new(vm_fd: U, sev: V) -> Result<Self, FirmwareError> {
+        let mut launcher = Launcher {
+            vm_fd,
+            sev,
+            state: PhantomData,
+        };
+
+        let init = Init2::init_default_snp();
+
+        let mut cmd = Command::from(&launcher.sev, &init);
+
+        INIT2
+            .ioctl(&mut launcher.vm_fd, &mut cmd)
+            .map_err(|_| cmd.encapsulate())?;
+
+        Ok(launcher)
+    }
+
+    /// Initialize the flow to launch a guest.
+    pub fn start(mut self, start: Start) -> Result<Launcher<Started, U, V>, FirmwareError> {
+        let launch_start = LaunchStart::from(start);
+        let mut cmd = Command::from(&self.sev, &launch_start);
+
+        SNP_LAUNCH_START
+            .ioctl(&mut self.vm_fd, &mut cmd)
+            .map_err(|_| cmd.encapsulate())?;
+
+        let launcher = Launcher {
+            vm_fd: self.vm_fd,
+            sev: self.sev,
+            state: PhantomData,
+        };
+
+        Ok(launcher)
+    }
+}
+
+impl<U: AsRawFd, V: AsRawFd> Launcher<Started, U, V> {
+    /// Encrypt guest SNP data.
+    pub fn update_data(
+        &mut self,
+        mut update: Update,
+        gpa: u64,
+        gpa_len: u64,
+    ) -> Result<(), FirmwareError> {
+        loop {
+            let launch_update_data = LaunchUpdate::from(update);
+            let mut cmd = Command::from(&self.sev, &launch_update_data);
+
+            // Register the encryption region
+            KvmEncRegion::new(update.uaddr).register(&mut self.vm_fd)?;
+
+            // Set memory attributes to private
+            KvmSetMemoryAttributes::new(gpa, gpa_len, KVM_MEMORY_ATTRIBUTE_PRIVATE)
+                .set_attributes(&mut self.vm_fd)?;
+
+            // Perform the SNP_LAUNCH_UPDATE ioctl call
+            match SNP_LAUNCH_UPDATE.ioctl(&mut self.vm_fd, &mut cmd) {
+                Ok(_) => {
+                    // Check if the entire range has been processed
+                    if launch_update_data.len == 0 {
+                        break;
+                    }
+
+                    // Update the `update` object with the remaining range
+                    update.start_gfn = launch_update_data.start_gfn;
+                    update.uaddr = unsafe {
+                        std::slice::from_raw_parts(
+                            launch_update_data.uaddr as *const u8,
+                            launch_update_data.len as usize,
+                        )
+                    };
+                }
+                Err(e) if e.raw_os_error() == Some(libc::EAGAIN) => {
+                    // Retry the operation if `-EAGAIN` is returned
+                    continue;
+                }
+                Err(_) => {
+                    // Handle other errors
+                    return Err(cmd.encapsulate());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Complete the SNP launch process.
+    pub fn finish(mut self, finish: Finish) -> Result<(U, V), FirmwareError> {
+        let launch_finish = LaunchFinish::from(finish);
+        let mut cmd = Command::from(&self.sev, &launch_finish);
+
+        SNP_LAUNCH_FINISH
+            .ioctl(&mut self.vm_fd, &mut cmd)
+            .map_err(|_| cmd.encapsulate())?;
+
+        Ok((self.vm_fd, self.sev))
+    }
+}
+
+/// Encapsulates the various data needed to begin the launch process.
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+pub struct Start {
+    /// Describes a policy that the AMD Secure Processor will enforce.
+    pub(crate) policy: GuestPolicy,
+
+    /// Hypervisor provided value to indicate guest OS visible workarounds.The format is hypervisor defined.
+    pub(crate) gosvw: [u8; 16],
+
+    /// Indicates that this launch flow is launching an IMI for the purpose of guest-assisted migration.
+    pub(crate) flags: u16,
+}
+
+impl Start {
+    /// Encapsulate all data needed for the SNP_LAUNCH_START ioctl.
+    pub fn new(policy: GuestPolicy, gosvw: [u8; 16]) -> Self {
+        Self {
+            policy,
+            gosvw,
+            flags: 0,
+        }
+    }
+}
+
+/// Encoded page types for a launch update. See Table 58 of the SNP Firmware
+/// specification for further details.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[repr(C)]
+#[non_exhaustive]
+pub enum PageType {
+    /// A normal data page.
+    Normal = 0x1,
+
+    /// A VMSA page.
+    Vmsa = 0x2,
+
+    /// A page full of zeroes.
+    Zero = 0x3,
+
+    /// A page that is encrypted but not measured
+    Unmeasured = 0x4,
+
+    /// A page for the firmware to store secrets for the guest.
+    Secrets = 0x5,
+
+    /// A page for the hypervisor to provide CPUID function values.
+    Cpuid = 0x6,
+}
+
+/// Encapsulates the various data needed to begin the update process.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Update<'a> {
+    /// guest start frame number.
+    pub(crate) start_gfn: u64,
+
+    /// The userspace of address of the encrypted region.
+    pub(crate) uaddr: &'a [u8],
+
+    /// Encoded page type.
+    pub(crate) page_type: PageType,
+}
+
+impl<'a> Update<'a> {
+    /// Encapsulate all data needed for the SNP_LAUNCH_UPDATE ioctl.
+    pub fn new(start_gfn: u64, uaddr: &'a [u8], page_type: PageType) -> Self {
+        Self {
+            start_gfn,
+            uaddr,
+            page_type,
+        }
+    }
+}
+
+bitflags! {
+    #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
+    /// VMPL permission masks.
+    pub struct VmplPerms: u8 {
+        /// Page is readable by the VMPL.
+        const READ = 1;
+
+        /// Page is writeable by the VMPL.
+        const WRITE = 1 << 1;
+
+        /// Page is executable by the VMPL in CPL3.
+        const EXECUTE_USER = 1 << 2;
+
+        /// Page is executable by the VMPL in CPL2, CPL1, and CPL0.
+        const EXECUTE_SUPERVISOR = 1 << 3;
+    }
+}
+
+/// Encapsulates the data needed to complete a guest launch.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Finish<'a, 'b> {
+    /// The userspace address of the encrypted region.
+    pub(crate) id_block: Option<&'a [u8]>,
+
+    /// The userspace address of the authentication information of the ID block.
+    pub(crate) id_auth: Option<&'b [u8]>,
+
+    /// Opaque host-supplied data to describe the guest. The firmware does not interpret this
+    /// value.
+    pub(crate) host_data: [u8; KVM_SEV_SNP_FINISH_DATA_SIZE],
+}
+
+impl<'a, 'b> Finish<'a, 'b> {
+    /// Encapsulate all data needed for the SNP_LAUNCH_FINISH ioctl.
+    pub fn new(
+        id_block: Option<&'a [u8]>,
+        id_auth: Option<&'b [u8]>,
+        host_data: [u8; KVM_SEV_SNP_FINISH_DATA_SIZE],
+    ) -> Self {
+        Self {
+            id_block,
+            id_auth,
+            host_data,
+        }
+    }
+}
+
+bitfield! {
+    /// The firmware associates each guest with a guest policy that the guest owner provides. The
+    /// firmware restricts what actions the hypervisor can take on this guest according to the guest policy.
+    /// The policy also indicates the minimum firmware version to for the guest.
+    ///
+    /// The guest owner provides the guest policy to the firmware during launch. The firmware then binds
+    /// the policy to the guest. The policy cannot be changed throughout the lifetime of the guest. The
+    /// policy is also migrated with the guest and enforced by the destination platform firmware.
+    ///
+    /// | Bit(s) | Name              | Description                                                                                                        >
+    /// |--------|-------------------|-------------------------------------------------------------------------------------------------------------------->
+    /// | 7:0    | ABI_MINOR         | The minimum ABI minor version required for this guest to run.                                                      >
+    /// | 15:8   | ABI_MAJOR         | The minimum ABI major version required for this guest to run.                                                      >
+    /// | 16     | SMT               | 0: Host SMT usage is disallowed.<br>1: Host SMT usage is allowed.                                                  >
+    /// | 17     | -                 | Reserved. Must be one.                                                                                             >
+    /// | 18     | MIGRATE_MA        | 0: Association with a migration agent is disallowed.<br>1: Association with a migration agent is allowed           >
+    /// | 19     | DEBUG             | 0: Debugging is disallowed.<br>1: Debugging is allowed.                                                            >
+    /// | 20     | SINGLE_SOCKET     | 0: Guest can be activated on multiple sockets.<br>1: Guest can only be activated on one socket.                    >
+    /// | 21     | CXL_ALLOW         | 0: CXL cannot be populated with devices or memory.<br>1: CXL can be populated with devices or memory.              >
+    /// | 22     | MEM_AES_256_XTS   | 0: Allow either AES 128 XEX or AES 256 XTS for memory encryption.<br>1: Require AES 256 XTS for memory encryption. >
+    /// | 23     | RAPL_DIS          | 0: Allow Running Average Power Limit (RAPL).<br>1: RAPL must be disabled.                                          >
+    /// | 24     | CIPHERTEXT_HIDING | 0: Ciphertext hiding may be enabled or disabled.<br>1: Ciphertext hiding must be enabled.                          >
+    /// | 25     | PAGE_SWAP_DISABLE | 0: Disable Guest access to SNP_PAGE_MOVE, SNP_SWAP_OUT and SNP_SWAP_IN commands.                                   >
+    /// | 63:25  | -                 | Reserved. MBZ.                                                                                                     >
+    ///
+    #[repr(C)]
+    #[derive(Default, Clone, Copy, Eq, PartialEq, PartialOrd, Ord)]
+    pub struct GuestPolicy(u64);
+    impl Debug;
+    /// ABI_MINOR field: Indicates the minor API version.
+    pub abi_minor, set_abi_minor: 7, 0;
+    /// ABI_MAJOR field: Indicates the minor API version.
+    pub abi_major, set_abi_major: 15, 8;
+    /// SMT_ALLOWED field: Indicates the if SMT should be permitted.
+    pub smt_allowed, set_smt_allowed: 16;
+    /// MIGRATE_MA_ALLOWED field: Indicates the if migration is permitted with
+    /// the migration agent.
+    pub migrate_ma_allowed, set_migrate_ma_allowed: 18;
+    /// DEBUG_ALLOWED field: Indicates the if debugging should is permitted.
+    pub debug_allowed, set_debug_allowed: 19;
+    /// SINGLE_SOCKET_REQUIRED field: Indicates the if a single socket is required.
+    pub single_socket_required, set_single_socket_required: 20;
+    /// CXL_ALLOW field: (1) can populate CXL devices/memory, (0) cannot populate CXL devices/memory
+    pub cxl_allowed, set_cxl_allowed: 21;
+    /// MEM_AES_256_XTS field: (1) require AES 256 XTS encryption, (0) allows either AES 128 XEX or AES 256 XTS encryption
+    pub mem_aes_256_xts, set_mem_aes_256_xts: 22;
+    /// RAPL_DIS field: (1) RAPL must be disabled, (0) allow RAPL
+    pub rapl_dis, set_rapl_dis: 23;
+    /// CIPHERTEXT_HIDING field: (1) ciphertext hiding must be enabled, (0) ciphertext hiding may be enabled/disabled
+    pub ciphertext_hiding, set_ciphertext_hiding: 24;
+    /// Guest policy to disable Guest access to SNP_PAGE_MOVE, SNP_SWAP_OUT, and SNP_SWAP_IN commands. If this policy
+    /// option is selected to disable these Page Move commands, then these commands will return POLICY_FAILURE.
+    /// 0: Do not disable Guest support for the commands.
+    /// 1: Disable Guest support for the commands.
+    pub page_swap_disabled, set_page_swap_disabled: 25;
+}
+
+impl Display for GuestPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            r#"Guest Policy (0x{:x}):
+  ABI Major:     {}
+  ABI Minor:     {}
+  SMT Allowed:   {}
+  Migrate MA:    {}
+  Debug Allowed: {}
+  Single Socket: {}
+  CXL Allowed:   {}
+  AEX 256 XTS:   {}
+  RAPL Allowed:  {}
+  Ciphertext hiding: {}
+  Page Swap Disable: {}"#,
+            self.0,
+            self.abi_major(),
+            self.abi_minor(),
+            self.smt_allowed(),
+            self.migrate_ma_allowed(),
+            self.debug_allowed(),
+            self.single_socket_required(),
+            self.cxl_allowed(),
+            self.mem_aes_256_xts(),
+            self.rapl_dis(),
+            self.ciphertext_hiding(),
+            self.page_swap_disabled()
+        )
+    }
+}
+
+impl From<GuestPolicy> for u64 {
+    fn from(value: GuestPolicy) -> Self {
+        // Bit 17 of the guest policy is reserved and must always be set to 1.
+        let reserved: u64 = 1 << 17;
+
+        value.0 | reserved
+    }
+}
+
+impl From<u64> for GuestPolicy {
+    fn from(value: u64) -> Self {
+        // Bit 17 of the guest policy is reserved and must always be set to 1.
+        let reserved: u64 = 1 << 17;
+
+        GuestPolicy(value | reserved)
+    }
+}

--- a/src/vmm/src/linux/tee/amdsnp/launch/util/impl_const_id.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/util/impl_const_id.rs
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+//! A simple const generics substitute.
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_const_id {
+    (
+        $(#[$outer:meta])*
+        $visibility:vis $trait:ident => $id_ty:ty;
+        $(
+            $iocty:ty = $val:expr
+        ),* $(,)*
+    ) => {
+        $(#[$outer])*
+        $visibility trait $trait {
+            $(#[$outer])*
+            const ID: $id_ty;
+        }
+
+        $(
+            impl $trait for $iocty {
+                const ID: $id_ty = $val;
+            }
+        )*
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    struct A;
+    struct B;
+    struct C;
+
+    impl_const_id! {
+        Id => usize;
+        A = 1,
+        B = 2,
+        C = 3,
+    }
+
+    #[test]
+    fn test_const_id_macro() {
+        assert_eq!(A::ID, 1);
+        assert_eq!(B::ID, 2);
+        assert_eq!(C::ID, 3);
+    }
+}

--- a/src/vmm/src/linux/tee/amdsnp/launch/util/mod.rs
+++ b/src/vmm/src/linux/tee/amdsnp/launch/util/mod.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod impl_const_id;

--- a/src/vmm/src/linux/tee/amdsnp/mod.rs
+++ b/src/vmm/src/linux/tee/amdsnp/mod.rs
@@ -1,3 +1,5 @@
+pub(crate) mod launch;
+
 use std::{
     os::unix::io::{AsRawFd, RawFd},
     slice,
@@ -6,11 +8,7 @@ use std::{
 use crate::vstate::MeasuredRegion;
 use arch::x86_64::layout::*;
 
-use sev::{
-    error::FirmwareError,
-    firmware::{guest::GuestPolicy, host::Firmware},
-    launch::snp::*,
-};
+use launch::{error::FirmwareError, firmware::Firmware, *};
 
 use kvm_bindings::{kvm_enc_region, CpuId, KVM_CPUID_FLAG_SIGNIFCANT_INDEX};
 use kvm_ioctls::VmFd;

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -69,7 +69,7 @@ use vm_memory::{
 };
 
 #[cfg(feature = "amd-sev")]
-use sev::launch::snp;
+use super::tee::amdsnp::launch as snp;
 
 /// Signal number (SIGRTMIN) used to kick Vcpus.
 pub(crate) const VCPU_RTSIG_OFFSET: i32 = 0;


### PR DESCRIPTION
The sev library was useful when the SEV-SNP Linux API was unstable, but has become a source of issues when updating dependent packages. The KVM SEV-SNP API is now stable, so we can import a library just containing the launch API.

Works as intended, just need to release the initial version of sev-snp-launch to crates.io and this is ready to merge.