### PR TITLE
libkrun_display.h: Fix incorect include guard

### DIFF
--- a/src/krun_display/libkrun_display.h
+++ b/src/krun_display/libkrun_display.h
@@ -1,5 +1,5 @@
-#ifndef _LIBKRUN_H
-#define _LIBKRUN_H
+#ifndef _LIBKRUN_DISPLAY_H
+#define _LIBKRUN_DISPLAY_H
 
 #include <inttypes.h>
 #include <stddef.h>
@@ -185,4 +185,4 @@ struct krun_display_backend {
 }
 #endif
 
-#endif // _LIBKRUN_H
+#endif // _LIBKRUN_DISPLAY_H


### PR DESCRIPTION
We never noticed, because the example that uses this is written in rust and uses the header through bindgen.