### PR TITLE
fix(Makefile): add libkrun.dylib symlink for EFI builds on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,11 @@ install: libkrun.pc
 	install -m 644 libkrun.pc $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/pkgconfig
 	install -m 755 $(LIBRARY_RELEASE_$(OS)) $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/
 	cd $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/ ; ln -sf $(KRUN_BINARY_$(OS)) $(KRUN_SONAME_$(OS)) ; ln -sf $(KRUN_SONAME_$(OS)) $(KRUN_BASE_$(OS))
+ifeq ($(OS),Darwin)
+ifeq ($(EFI),1)
+	cd $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/ ; ln -sf libkrun-efi.$(ABI_VERSION).dylib libkrun.dylib
+endif
+endif
 
 clean:
 	rm -f $(INIT_BINARY)


### PR DESCRIPTION
## Fix macOS EFI build: add libkrun.dylib symlink for pkg-config compatibility

### Problem

When building libkrun on macOS with `EFI=1`, the library is installed as `libkrun-efi.1.dylib`, but `libkrun.pc` references `-lkrun`. This causes linking failures for consumers using pkg-config:

```
ld: library 'krun' not found
```

Affected consumers include `krun-sys` (the Rust FFI bindings in this repo) and any other project using `pkg-config --libs libkrun`.

### Solution

Add a `libkrun.dylib` symlink pointing to `libkrun-efi.1.dylib` during installation when building with EFI on Darwin. This aligns the installed library with what `libkrun.pc` declares.

### Changes

In the `install:` target, after the EFI library is installed:

```makefile
ifeq ($(OS),Darwin)
ifeq ($(EFI),1)
	cd $(DESTDIR)$(PREFIX)/$(LIBDIR_$(OS))/ ; ln -sf libkrun-efi.$(ABI_VERSION).dylib libkrun.dylib
endif
endif
```

### Why this approach?

- **Minimal change** - Single symlink, no changes to `.pc.in` or `krun-sys`
- **Consistent with Linux** - Linux uses `libkrun.so`; macOS now has matching `libkrun.dylib`
- **Standard practice** - Unix library versioning commonly uses symlinks
- **Intent-preserving** - The `.pc` file already uses `libkrun` as the stable API name

### Testing

After this fix:

```bash
# Build and install with EFI
make EFI=1
sudo make EFI=1 install

# Verify symlink exists
ls -la /usr/local/lib/libkrun.dylib
# libkrun.dylib -> libkrun-efi.1.dylib

# pkg-config now works
pkg-config --libs libkrun
# -L/usr/local/lib -lkrun

# krun-sys builds without manual workarounds
cd krun-sys && cargo build
```
