### PR TITLE
net: add a new flag NET_FLAG_INCLUDE_VNET_HEADER

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -326,6 +326,7 @@ int32_t krun_add_virtiofs2(uint32_t ctx_id,
 /* Send the VFKIT magic after establishing the connection,
    as required by gvproxy in vfkit mode. */
 #define NET_FLAG_VFKIT 1 << 0
+#define NET_FLAG_INCLUDE_VNET_HEADER 1 << 1
 
 /* TSI (Transparent Socket Impersonation) feature flags for vsock */
 #define KRUN_TSI_HIJACK_INET  (1 << 0)

--- a/src/devices/src/virtio/net/device.rs
+++ b/src/devices/src/virtio/net/device.rs
@@ -54,6 +54,7 @@ struct VirtioNetConfig {
     mac: [u8; 6],
     status: u16,
     max_virtqueue_pairs: u16,
+    include_vnet_header: bool,
 }
 
 // Safe because it only has data and has no implicit padding.
@@ -88,6 +89,7 @@ impl Net {
         cfg_backend: VirtioNetBackend,
         mac: [u8; 6],
         features: u32,
+        include_vnet_header: bool,
     ) -> Result<Self> {
         let avail_features = features as u64
             | (1 << VIRTIO_NET_F_MAC)
@@ -98,6 +100,7 @@ impl Net {
             mac,
             status: 0,
             max_virtqueue_pairs: 0,
+            include_vnet_header,
         };
 
         Ok(Net {
@@ -187,6 +190,7 @@ impl VirtioDevice for Net {
             interrupt.clone(),
             mem.clone(),
             self.acked_features,
+            self.config.include_vnet_header,
             self.cfg_backend.clone(),
         ) {
             Ok(worker) => {

--- a/src/devices/src/virtio/net/mod.rs
+++ b/src/devices/src/virtio/net/mod.rs
@@ -6,8 +6,13 @@ use virtio_bindings::virtio_net::virtio_net_hdr_v1;
 
 use super::QueueConfig;
 
-pub const MAX_BUFFER_SIZE: usize = 65562;
-const QUEUE_SIZE: u16 = 1024;
+/// Each frame forwarded to a unixstream backend is prepended by a 4 byte "header".
+/// It is interpreted as a big-endian u32 integer and is the length of the following ethernet frame.
+/// In order to avoid unnecessary allocations and copies, the TX buffer is allocated with extra
+/// space to accommodate this header.
+const FRAME_HEADER_LEN: usize = 4;
+pub const MAX_BUFFER_SIZE: usize = 65562 + FRAME_HEADER_LEN;
+pub const QUEUE_SIZE: u16 = 1024;
 pub const NUM_QUEUES: usize = 2;
 pub static QUEUE_CONFIG: [QueueConfig; NUM_QUEUES] = [QueueConfig::new(QUEUE_SIZE); NUM_QUEUES];
 

--- a/src/devices/src/virtio/net/tap.rs
+++ b/src/devices/src/virtio/net/tap.rs
@@ -14,6 +14,7 @@ use virtio_bindings::virtio_net::{
 };
 
 use super::backend::{ConnectError, NetBackend, ReadError, WriteError};
+use super::{write_virtio_net_hdr, FRAME_HEADER_LEN};
 
 ioctl_write_ptr!(tunsetiff, b'T', 202, c_int);
 ioctl_write_int!(tunsetoffload, b'T', 208);
@@ -21,11 +22,16 @@ ioctl_write_ptr!(tunsetvnethdrsz, b'T', 216, c_int);
 
 pub struct Tap {
     fd: OwnedFd,
+    include_vnet_header: bool,
 }
 
 impl Tap {
     /// Create an endpoint using the file descriptor of a tap device
-    pub fn new(tap_name: String, vnet_features: u64) -> Result<Self, ConnectError> {
+    pub fn new(
+        tap_name: String,
+        vnet_features: u64,
+        include_vnet_header: bool,
+    ) -> Result<Self, ConnectError> {
         let fd = match open("/dev/net/tun", OFlag::O_RDWR, Mode::empty()) {
             Ok(fd) => fd,
             Err(err) => return Err(ConnectError::OpenNetTun(err)),
@@ -41,7 +47,11 @@ impl Tap {
             );
         }
 
-        req.ifr_ifru.ifru_flags = IFF_TAP as i16 | IFF_NO_PI as i16 | IFF_VNET_HDR as i16;
+        let mut ifru_flags = IFF_TAP as i16 | IFF_NO_PI as i16;
+        if include_vnet_header {
+            ifru_flags |= IFF_VNET_HDR as i16;
+        }
+        req.ifr_ifru.ifru_flags = ifru_flags;
 
         let mut offload_flags: u64 = 0;
         if (vnet_features & (1 << VIRTIO_NET_F_GUEST_CSUM)) != 0 {
@@ -84,7 +94,10 @@ impl Tap {
             Err(e) => error!("couldn't obtain fd flags id={fd:?}, err={e}"),
         };
 
-        Ok(Self { fd })
+        Ok(Self {
+            fd,
+            include_vnet_header,
+        })
     }
 }
 
@@ -92,7 +105,13 @@ impl NetBackend for Tap {
     /// Try to read a frame from the tap devie. If no bytes are available reports
     /// ReadError::NothingRead.
     fn read_frame(&mut self, buf: &mut [u8]) -> Result<usize, ReadError> {
-        let frame_length = match read(&self.fd, buf) {
+        let buf_offset = if !self.include_vnet_header {
+            write_virtio_net_hdr(buf)
+        } else {
+            0
+        };
+
+        let frame_length = match read(&self.fd, &mut buf[buf_offset..]) {
             Ok(f) => f,
             #[allow(unreachable_patterns)]
             Err(nix::Error::EAGAIN | nix::Error::EWOULDBLOCK) => {
@@ -103,12 +122,17 @@ impl NetBackend for Tap {
             }
         };
         debug!("Read eth frame from tap: {frame_length} bytes");
-        Ok(frame_length)
+        Ok(buf_offset + frame_length)
     }
 
     /// Try to write a frame to the tap device.
-    fn write_frame(&mut self, _hdr_len: usize, buf: &mut [u8]) -> Result<(), WriteError> {
-        let ret = write(&self.fd, buf).map_err(WriteError::Internal)?;
+    fn write_frame(&mut self, hdr_len: usize, buf: &mut [u8]) -> Result<(), WriteError> {
+        let buf_offset = if !self.include_vnet_header {
+            hdr_len
+        } else {
+            FRAME_HEADER_LEN
+        };
+        let ret = write(&self.fd, &buf[buf_offset..]).map_err(WriteError::Internal)?;
         debug!("Written frame size={}, written={}", buf.len(), ret);
         Ok(())
     }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -888,6 +888,9 @@ pub unsafe extern "C" fn krun_set_data_disk(ctx_id: u32, c_disk_path: *const c_c
 #[cfg(feature = "net")]
 const NET_FLAG_VFKIT: u32 = 1 << 0;
 
+#[cfg(feature = "net")]
+const NET_FLAG_INCLUDE_VNET_HEADER: u32 = 1 << 1;
+
 /* Taken from uapi/linux/virtio_net.h */
 #[cfg(feature = "net")]
 const NET_FEATURE_CSUM: u32 = 1 << 0;
@@ -965,19 +968,21 @@ pub unsafe extern "C" fn krun_add_net_unixstream(
         Err(_) => return -libc::EINVAL,
     };
 
-    /* The unixstream backend doesn't support any flags */
-    if flags != 0 {
-        return -libc::EINVAL;
-    }
-
     if (features & !NET_ALL_FEATURES) != 0 {
         return -libc::EINVAL;
     }
 
+    // Unixstream backends don't support NET_FLAG_VFKIT.
+    if (flags & !NET_FLAG_INCLUDE_VNET_HEADER) != 0 {
+        return -libc::EINVAL;
+    }
+
+    let include_vnet_header: bool = flags & NET_FLAG_INCLUDE_VNET_HEADER != 0;
+
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
-            create_virtio_net(cfg, backend, mac, features);
+            create_virtio_net(cfg, backend, mac, features, include_vnet_header);
         }
         Entry::Vacant(_) => return -libc::ENOENT,
     }
@@ -1020,10 +1025,11 @@ pub unsafe extern "C" fn krun_add_net_unixgram(
         return -libc::EINVAL;
     }
 
-    if (flags & !NET_FLAG_VFKIT) != 0 {
+    if (flags & !(NET_FLAG_VFKIT | NET_FLAG_INCLUDE_VNET_HEADER)) != 0 {
         return -libc::EINVAL;
     }
     let send_vfkit_magic: bool = flags & NET_FLAG_VFKIT != 0;
+    let include_vnet_header: bool = flags & NET_FLAG_INCLUDE_VNET_HEADER != 0;
 
     let backend = if let Some(path) = path {
         VirtioNetBackend::UnixgramPath(path, send_vfkit_magic)
@@ -1034,7 +1040,7 @@ pub unsafe extern "C" fn krun_add_net_unixgram(
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
-            create_virtio_net(cfg, backend, mac, features);
+            create_virtio_net(cfg, backend, mac, features, include_vnet_header);
         }
         Entry::Vacant(_) => return -libc::ENOENT,
     }
@@ -1083,7 +1089,7 @@ pub unsafe extern "C" fn krun_add_net_tap(
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
-            create_virtio_net(cfg, VirtioNetBackend::Tap(tap_name), mac, features);
+            create_virtio_net(cfg, VirtioNetBackend::Tap(tap_name), mac, features, true);
         }
         Entry::Vacant(_) => return -libc::ENOENT,
     }
@@ -1963,12 +1969,14 @@ fn create_virtio_net(
     backend: VirtioNetBackend,
     mac: [u8; 6],
     features: u32,
+    include_vnet_header: bool,
 ) {
     let network_interface_config = NetworkInterfaceConfig {
         iface_id: format!("eth{}", ctx_cfg.net_index),
         backend,
         mac,
         features,
+        include_vnet_header,
     };
     ctx_cfg.net_index += 1;
     ctx_cfg
@@ -2615,7 +2623,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
             let mac = ctx_cfg
                 .legacy_mac
                 .unwrap_or([0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee]);
-            create_virtio_net(&mut ctx_cfg, backend, mac, NET_COMPAT_FEATURES);
+            create_virtio_net(&mut ctx_cfg, backend, mac, NET_COMPAT_FEATURES, false);
         }
     }
 

--- a/src/vmm/src/vmm_config/net.rs
+++ b/src/vmm/src/vmm_config/net.rs
@@ -18,6 +18,8 @@ pub struct NetworkInterfaceConfig {
     pub mac: [u8; 6],
     /// virtio-net features for the network interface.
     pub features: u32,
+    /// Whether vnet headers should be sent to and received from the network backend.
+    pub include_vnet_header: bool,
 }
 
 /// Errors associated with `NetworkInterfaceConfig`.
@@ -65,7 +67,13 @@ impl NetBuilder {
     /// Creates a Net device from a NetworkInterfaceConfig.
     pub fn create_net(cfg: NetworkInterfaceConfig) -> Result<Net> {
         // Create and return the Net device
-        Net::new(cfg.iface_id, cfg.backend, cfg.mac, cfg.features)
-            .map_err(NetworkInterfaceError::CreateNetworkDevice)
+        Net::new(
+            cfg.iface_id,
+            cfg.backend,
+            cfg.mac,
+            cfg.features,
+            cfg.include_vnet_header,
+        )
+        .map_err(NetworkInterfaceError::CreateNetworkDevice)
     }
 }


### PR DESCRIPTION
This flag should be used to indicate to libkrun that downstream network backend wants to receive and transmit the virtio-net header along with Ethernet frames.

Network backends using this flag can then forward unmodified headers to another VM or build a sensible virtio_net_hdr (e.g. with GSO fields correctly set) such that receiving VM handles GSO'd frames properly.