### PR TITLE
Fix external kernel memory region calculation

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1450,9 +1450,13 @@ pub fn create_guest_memory(
                 };
             arch::arch_memory_regions(mem_size, Some(kernel_guest_addr), kernel_size, 0, None)
         }
-        Payload::ExternalKernel(external_kernel) => {
-            arch::arch_memory_regions(mem_size, None, 0, external_kernel.initramfs_size, None)
-        }
+        Payload::ExternalKernel(external_kernel) => arch::arch_memory_regions(
+            mem_size,
+            None,
+            0,
+            external_kernel.initramfs_size,
+            firmware_size,
+        ),
         #[cfg(feature = "tee")]
         Payload::Tee => {
             let (kernel_guest_addr, kernel_size) =


### PR DESCRIPTION
The external kernel payload type was not passing the firmware size to the architecture-specific memory region calculation function. This could lead to incorrect memory layout when using external kernels with firmware. The change ensures the firmware size is properly accounted for in the memory region setup. This inconsistency caused VM creation to fail with HV_DENIED (-85377017) on macOS when using direct kernel boot with the Hypervisor.framework.