### PR TITLE
Fix: Add block scope for variable declarations in switch case 'u'

### DIFF
--- a/init/jsmn.h
+++ b/init/jsmn.h
@@ -237,7 +237,7 @@ static int jsmn_parse_string(jsmn_parser *parser, char *js, const size_t len,
             case 't':
                 break;
             /* Allows escaped symbol \uXXXX */
-            case 'u':
+            case 'u': {
                 char unicode[5];
                 long ascii;
 
@@ -270,6 +270,7 @@ static int jsmn_parse_string(jsmn_parser *parser, char *js, const size_t len,
                 parser->pos--;
                 js[parser->pos] = (char)ascii;
                 break;
+            }
             /* Unexpected symbol */
             default:
                 parser->pos = start;


### PR DESCRIPTION
## Problem

Related to https://github.com/containers/libkrun/issues/501

The `case 'u':` label in the JSON string parser's switch statement declares variables (`unicode` and `ascii`) directly after the case label. In C, this is invalid syntax because all case labels share the same scope, and variable declarations require a proper block scope.

## Solution

Wrapped the `case 'u':` block in curly braces `{ }` to create a proper scope for the variable declarations. This ensures the code compiles correctly and follows standard C syntax.

## Changes

- Added opening brace `{` after `case 'u':` on line 240
- Added closing brace `}` before the `default:` case on line 273

## Testing

The code should now compile without errors. The functionality remains unchanged - this is purely a syntax fix.