### PR TITLE
Add support for the APIR capset

### DIFF
--- a/src/rutabaga_gfx/src/rutabaga_core.rs
+++ b/src/rutabaga_gfx/src/rutabaga_core.rs
@@ -261,7 +261,7 @@ struct RutabagaCapsetInfo {
     pub name: &'static str,
 }
 
-const RUTABAGA_CAPSETS: [RutabagaCapsetInfo; 9] = [
+const RUTABAGA_CAPSETS: [RutabagaCapsetInfo; 10] = [
     RutabagaCapsetInfo {
         capset_id: RUTABAGA_CAPSET_VIRGL,
         component: RutabagaComponentType::VirglRenderer,
@@ -306,6 +306,11 @@ const RUTABAGA_CAPSETS: [RutabagaCapsetInfo; 9] = [
         capset_id: RUTABAGA_CAPSET_GFXSTREAM_COMPOSER,
         component: RutabagaComponentType::Gfxstream,
         name: "gfxstream-composer",
+    },
+    RutabagaCapsetInfo {
+        capset_id: RUTABAGA_CAPSET_APIR,
+        component: RutabagaComponentType::VirglRenderer,
+        name: "apir",
     },
 ];
 
@@ -1273,6 +1278,7 @@ impl RutabagaBuilder {
                 push_capset(RUTABAGA_CAPSET_VIRGL2);
                 push_capset(RUTABAGA_CAPSET_VENUS);
                 push_capset(RUTABAGA_CAPSET_DRM);
+                push_capset(RUTABAGA_CAPSET_APIR);
             }
 
             #[cfg(feature = "gfxstream")]

--- a/src/rutabaga_gfx/src/rutabaga_utils.rs
+++ b/src/rutabaga_gfx/src/rutabaga_utils.rs
@@ -174,6 +174,7 @@ pub const RUTABAGA_CAPSET_DRM: u32 = 6;
 pub const RUTABAGA_CAPSET_GFXSTREAM_MAGMA: u32 = 7;
 pub const RUTABAGA_CAPSET_GFXSTREAM_GLES: u32 = 8;
 pub const RUTABAGA_CAPSET_GFXSTREAM_COMPOSER: u32 = 9;
+pub const RUTABAGA_CAPSET_APIR: u32 = 10;
 
 /// An error generated while using this crate.
 #[sorted]


### PR DESCRIPTION
This PR allows libkrun to support the new `virglrenderer` component proposed in this PR:
* [Introduce an API Remoting trampoline component](https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1590)

This `llama.cpp` PR demonstrates how to benefit from `Virglrenderer` API Remoting component:
* [ggml: new backend for Virglrenderer API Remoting acceleration](https://github.com/ggml-org/llama.cpp/pull/18718)

This PR shall remain as a draft until the PR has been accepted in Virglrenderer.
