### PR TITLE
ci: switch to krun homebrew tap

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Install packages (macOS)
       if: runner.os == 'macOS'
       shell: bash
-      run: brew tap slp/krunkit && brew install virglrenderer clang-format llvm
+      run: brew tap slp/krun && brew install virglrenderer clang-format llvm
 
     - name: Install packages (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
The krunkit tap is deprecated, switch to the krun one.