### PR TITLE
krun-sys: update bindgen dependency to v0.72.1

### DIFF
--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -86,38 +86,18 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
+ "itertools",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.72.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "shlex",
  "syn",
 ]
@@ -684,15 +664,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -704,7 +675,7 @@ dependencies = [
 name = "krun-sys"
 version = "1.11.1"
 dependencies = [
- "bindgen 0.69.5",
+ "bindgen",
  "pkg-config",
 ]
 
@@ -712,7 +683,7 @@ dependencies = [
 name = "krun_display"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.72.0",
+ "bindgen",
  "bitflags 2.9.1",
  "log",
  "static_assertions",
@@ -723,7 +694,7 @@ dependencies = [
 name = "krun_input"
 version = "0.1.0"
 dependencies = [
- "bindgen 0.72.0",
+ "bindgen",
  "bitflags 2.9.1",
  "libc",
  "log",
@@ -739,18 +710,6 @@ checksum = "cf3432d9f609fbede9f624d1dbefcce77985a9322de1d0e6d460ec05502b7fd0"
 dependencies = [
  "vmm-sys-util",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -910,12 +869,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"

--- a/krun-sys/Cargo.toml
+++ b/krun-sys/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 links = "krun"
 
 [build-dependencies]
-bindgen = { version = "0.69.4", default-features = false }
+bindgen = { version = "0.72.1", default-features = false }
 pkg-config = { version = "0.3", default-features = false }
 
 [features]

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -75,16 +75,14 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
  "itertools",
- "lazy_static",
- "lazycell",
  "proc-macro2",
  "quote",
  "regex",
@@ -230,18 +228,6 @@ dependencies = [
  "bindgen",
  "pkg-config",
 ]
-
-[[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
@@ -420,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "shlex"


### PR DESCRIPTION
It appears that this dependency was already updated in krun_display and krun_input, but not in krun-sys.

This is part of an upcoming effort to update packages that depend on bindgen in Fedora Linux to bindgen >= 0.72.1 to prevent breakage with LLVM 22 in Fedora 44+ (see https://fedoraproject.org/wiki/Changes/Bump_Minimum_Rust_Bindgen_To_v0.72 for context).

Note that there appears to be an issue with the current project layout (crates in subdirectories that *look* like workspace members but are not) - even running `cargo check` in the `krun-sys` subdirectory fails with recent Rust versions, so I'm not sure how this subproject is handled:

```
error: current package believes it's in a workspace when it's not:
current:   /home/deca/Workspace/forks/libkrun/krun-sys/Cargo.toml
workspace: /home/deca/Workspace/forks/libkrun/Cargo.toml

this may be fixable by adding `krun-sys` to the `workspace.members` array of the manifest located at: /home/deca/Workspace/forks/libkrun/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```
