### PR TITLE
init/nitro: Fix error from git rebase

### DIFF
--- a/init/nitro/device/signal.c
+++ b/init/nitro/device/signal.c
@@ -95,6 +95,7 @@ int sig_handler_init(unsigned int vsock_port, int shutdown_fd)
             close(vsock_fd);
             return ret;
         }
-
-        return 0;
     }
+
+    return 0;
+}


### PR DESCRIPTION
A closing brace was accidentally removed during a git rebase. Add it back.