### PR TITLE
virtio/console: cols/rows order match the specs

### DIFF
--- a/src/devices/src/virtio/console/console_control.rs
+++ b/src/devices/src/virtio/console/console_control.rs
@@ -29,10 +29,10 @@ unsafe impl ByteValued for VirtioConsoleControl {}
 #[derive(Copy, Clone, Debug, Default)]
 #[repr(C, packed)]
 pub struct VirtioConsoleResize {
-    // NOTE: the order of these fields in the actual kernel implementation and in the spec are swapped,
-    // we follow the order in the kernel to get it working correctly
-    pub rows: u16,
+    // NOTE: the order of these fields in older Linux kernels and in the spec were swapped.
+    // Linux changed it in commit 5326ab737a47 to match the specs.
     pub cols: u16,
+    pub rows: u16,
 }
 
 // Safe because it only has data and has no implicit padding.


### PR DESCRIPTION
For many years, the Linux kernel implemented the order of cols and rows swapped with respect of the specifications. In commit 5326ab737a47 it was changed to match the specs.

There's no good way to address this. You either get a working virtio-console on newer kernels or on older kernels, but never on both. Making this configurable via the API would just mean dumping the burden onto the users.

Fedora 43 and libkrunfw 5.2.0 already ship with a kernel with a "fixed" virtio-console, so let's follow suit and use the spec's order here too.