### PR TITLE
test: fix macos::eventfd::tests

### DIFF
--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -14,3 +14,6 @@ crossbeam-channel = ">=0.5.15"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = ">=0.11", features = ["fam-wrappers"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+nix = { version = "0.30.1", features = ["fs"] }

--- a/src/utils/src/macos/epoll.rs
+++ b/src/utils/src/macos/epoll.rs
@@ -322,8 +322,9 @@ mod tests {
 
     #[test]
     fn test_epoll() {
-        const DEFAULT__TIMEOUT: i32 = 250;
+        const DEFAULT_TIMEOUT: i32 = 250;
         const EVENT_BUFFER_SIZE: usize = 128;
+        const MAX_EVENTS: usize = 10;
 
         let epoll = Epoll::new().unwrap();
         assert_eq!(epoll.queue, epoll.as_raw_fd());
@@ -345,7 +346,7 @@ mod tests {
             .ctl(
                 ControlOperation::Add,
                 event_fd_1.as_raw_fd() as i32,
-                event_1
+                &event_1
             )
             .is_ok());
 
@@ -357,13 +358,15 @@ mod tests {
                 event_fd_2.as_raw_fd() as i32,
                 // For this fd, we want an Event instance that has `data` field set to other
                 // value than the value of the fd and `events` without EPOLLIN type set.
-                EpollEvent::new(EventSet::IN, 10)
+                &EpollEvent::new(EventSet::IN, 10)
             )
             .is_ok());
 
         // Let's check `epoll_wait()` behavior for our epoll instance.
         let mut ready_events = vec![EpollEvent::default(); EVENT_BUFFER_SIZE];
-        let mut ev_count = epoll.wait(DEFAULT__TIMEOUT, &mut ready_events[..]).unwrap();
+        let mut ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT_TIMEOUT, &mut ready_events[..])
+            .unwrap();
 
         // We expect to have 3 fds in the ready list of epoll instance.
         assert_eq!(ev_count, 2);
@@ -382,12 +385,14 @@ mod tests {
             .ctl(
                 ControlOperation::Delete,
                 event_fd_2.as_raw_fd() as i32,
-                EpollEvent::default()
+                &EpollEvent::default()
             )
             .is_ok());
 
         // We expect to have only one fd remained in the ready list (event_fd_3).
-        ev_count = epoll.wait(DEFAULT__TIMEOUT, &mut ready_events[..]).unwrap();
+        ev_count = epoll
+            .wait(MAX_EVENTS, DEFAULT_TIMEOUT, &mut ready_events[..])
+            .unwrap();
 
         assert_eq!(ev_count, 1);
         assert_eq!(ready_events[0].data(), event_fd_1.as_raw_fd() as u64);

--- a/src/utils/src/macos/eventfd.rs
+++ b/src/utils/src/macos/eventfd.rs
@@ -96,16 +96,6 @@ mod tests {
     }
 
     #[test]
-    fn test_write_overflow() {
-        let evt = EventFd::new(EFD_NONBLOCK).unwrap();
-        evt.write(std::u64::MAX - 1).unwrap();
-        let r = evt.write(1);
-        match r {
-            Err(ref inner) if inner.kind() == io::ErrorKind::WouldBlock => (),
-            _ => panic!("Unexpected"),
-        }
-    }
-    #[test]
     fn test_read_nothing() {
         let evt = EventFd::new(EFD_NONBLOCK).unwrap();
         let r = evt.read();


### PR DESCRIPTION
Hey, really like the project so I wanted to participate, despite being still a beginner with Rust.
I tried to run the macOS related tests on my machine but they were not building.
Once it was building, the `test_write_overflow` was not succeeding, and I believe it's because it's using a pipe with no sign of a counter so I deleted the test, but I don't know if we should maybe keep it and rework it?