### PR TITLE
Introduce krun_has_feature() API

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -977,6 +977,35 @@ int32_t krun_set_nested_virt(uint32_t ctx_id, bool enabled);
  */
 int32_t krun_check_nested_virt(void);
 
+/* Feature constants for krun_has_feature() */
+#define KRUN_FEATURE_NET 0
+#define KRUN_FEATURE_BLK 1
+#define KRUN_FEATURE_GPU 2
+#define KRUN_FEATURE_SND 3
+#define KRUN_FEATURE_INPUT 4
+#define KRUN_FEATURE_EFI 5
+#define KRUN_FEATURE_TEE 6
+#define KRUN_FEATURE_AMD_SEV 7
+#define KRUN_FEATURE_INTEL_TDX 8
+#define KRUN_FEATURE_AWS_NITRO 9
+#define KRUN_FEATURE_VIRGL_RESOURCE_MAP2 10
+
+/**
+ * Checks if a specific feature was enabled at build time.
+ *
+ * Arguments:
+ *  "feature" - one of the KRUN_FEATURE_* constants.
+ *
+ * Returns:
+ *  1 if the feature is supported, 0 if not supported, or a negative error
+ *  number on failure (e.g., -EINVAL for invalid/unknown feature constant).
+ *
+ * Notes:
+ *  When linking against an older version of libkrun, this function may
+ *  return -EINVAL for feature constants that were added in newer versions.
+ */
+int32_t krun_has_feature(uint64_t feature);
+
 /**
  * Get the maximum number of vCPUs supported by the hypervisor.
  *

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1844,6 +1844,38 @@ pub unsafe extern "C" fn krun_check_nested_virt() -> i32 {
     -libc::EOPNOTSUPP
 }
 
+const KRUN_FEATURE_NET: u64 = 0;
+const KRUN_FEATURE_BLK: u64 = 1;
+const KRUN_FEATURE_GPU: u64 = 2;
+const KRUN_FEATURE_SND: u64 = 3;
+const KRUN_FEATURE_INPUT: u64 = 4;
+const KRUN_FEATURE_EFI: u64 = 5;
+const KRUN_FEATURE_TEE: u64 = 6;
+const KRUN_FEATURE_AMD_SEV: u64 = 7;
+const KRUN_FEATURE_INTEL_TDX: u64 = 8;
+const KRUN_FEATURE_AWS_NITRO: u64 = 9;
+const KRUN_FEATURE_VIRGL_RESOURCE_MAP2: u64 = 10;
+
+#[no_mangle]
+pub extern "C" fn krun_has_feature(feature: u64) -> c_int {
+    let supported = match feature {
+        KRUN_FEATURE_NET => cfg!(feature = "net"),
+        KRUN_FEATURE_BLK => cfg!(feature = "blk"),
+        KRUN_FEATURE_GPU => cfg!(feature = "gpu"),
+        KRUN_FEATURE_SND => cfg!(feature = "snd"),
+        KRUN_FEATURE_INPUT => cfg!(feature = "input"),
+        KRUN_FEATURE_EFI => cfg!(feature = "efi"),
+        KRUN_FEATURE_TEE => cfg!(feature = "tee"),
+        KRUN_FEATURE_AMD_SEV => cfg!(feature = "amd-sev"),
+        KRUN_FEATURE_INTEL_TDX => cfg!(feature = "tdx"),
+        KRUN_FEATURE_AWS_NITRO => cfg!(feature = "aws-nitro"),
+        KRUN_FEATURE_VIRGL_RESOURCE_MAP2 => cfg!(feature = "virgl_resource_map2"),
+        _ => return -libc::EINVAL,
+    };
+
+    supported as c_int
+}
+
 /// Gets the maximum number of vCPUs supported by the hypervisor.
 ///
 /// Returns the maximum number of vCPUs that can be created by this hypervisor,


### PR DESCRIPTION
Introduce a function to query at runtime whether a specific feature was enabled at build time. This allows applications to check for optional capabilities before attempting to use them. This is especially useful for our tests and examples.