### PR TITLE
Bump version to 1.17.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libkrun"
-version = "1.17.0"
+version = "1.17.2"
 dependencies = [
  "aws-nitro",
  "crossbeam-channel",

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LIBRARY_HEADER_DISPLAY = include/libkrun_display.h
 LIBRARY_HEADER_INPUT = include/libkrun_input.h
 
 ABI_VERSION=1
-FULL_VERSION=1.17.0
+FULL_VERSION=1.17.2
 
 INIT_SRC = init/init.c
 KBS_INIT_SRC =	init/tee/kbs/kbs.h		\

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.17.0"
+version = "1.17.2"
 authors = ["The libkrun Authors"]
 edition = "2021"
 build = "build.rs"


### PR DESCRIPTION
Set up the stage for 1.17.2. This is an expedited release to address a broken 1.17.1 release that was missing bumping the library version.