### PR TITLE
vsock/tsi: use EDGE_TRIGGERED on EventSet::OUT

### DIFF
--- a/src/devices/src/virtio/vsock/tsi_stream.rs
+++ b/src/devices/src/virtio/vsock/tsi_stream.rs
@@ -877,7 +877,7 @@ impl Proxy for TsiStreamProxy {
                 // OP_REQUEST and the vsock transport is fully established.
                 update.polling = Some((self.id(), self.fd.as_raw_fd(), EventSet::empty()));
             } else {
-                error!("EventSet::OUT while not connecting");
+                debug!("EventSet::OUT while not connecting");
             }
         }
 


### PR DESCRIPTION
When we're waiting on ProxyStatus::Connecting, we set EventSet::OUT to be informed when the socket has connected. Use EDGE_TRIGGERED along with it so the event is generated just once.

Fixes bogus errors on #526 