### PR TITLE
aws-nitro: Relax dependencies for packaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1457,9 +1457,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.4.1"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a37d01603c37b5466f808de79f845c7116049b0579adb70a6b7d47c1fa3a952"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/src/aws_nitro/Cargo.toml
+++ b/src/aws_nitro/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2021"
 aws-nitro = []
 
 [dependencies]
-libc = "0.2.171"
-nix = { version = "0.30.1", features = ["poll"] }
-tar = "0.4.44"
-vsock = "0.5.1"
+libc = "0.2"
+nix = { version = "0.30", features = ["poll"] }
+tar = "0.4"
+vsock = "0.5"
 
 devices = { path = "../devices" }
 log = "0.4"
-signal-hook = "0.4.1"
+signal-hook = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nitro-enclaves = "0.6.0"


### PR DESCRIPTION
Relax the dependency versions of the awsnitro variant for a smoother packaging process. Each of the dependencies should now match the respective versions available in Fedora.