### PR TITLE
fs/macos: fix ghost files are double fd closing

### DIFF
--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -657,9 +657,17 @@ impl PassthroughFs {
         let mut ds = data.dirstream.lock().unwrap();
 
         let dir_stream = if ds.stream == 0 {
-            let dir = unsafe { libc::fdopendir(data.file.write().unwrap().as_raw_fd()) };
-            if dir.is_null() {
+            // fdopendir() takes ownership of the fd, so we need to obtain a new one
+            // to be donated.
+            let newfd = unsafe { libc::dup(data.file.write().unwrap().as_raw_fd()) };
+            if newfd < 0 {
                 return Err(linux_error(io::Error::last_os_error()));
+            }
+            let dir = unsafe { libc::fdopendir(newfd) };
+            if dir.is_null() {
+                let err = io::Error::last_os_error();
+                let _ = unsafe { libc::close(newfd) };
+                return Err(linux_error(err));
             }
             ds.stream = dir as u64;
             dir
@@ -858,6 +866,9 @@ impl PassthroughFs {
             }
             Ok(())
         } else {
+            if let Some(unlinked_fd) = unlinked_fd {
+                unsafe { libc::close(unlinked_fd) };
+            }
             Err(linux_error(err))
         }
     }
@@ -1114,9 +1125,10 @@ impl FileSystem for PassthroughFs {
             .cloned()
             .ok_or_else(ebadf)?;
 
-        let ds = data.dirstream.lock().unwrap();
+        let mut ds = data.dirstream.lock().unwrap();
         if ds.stream != 0 {
             unsafe { libc::closedir(ds.stream as *mut libc::DIR) };
+            ds.stream = 0;
         }
 
         self.do_release(inode, handle)


### PR DESCRIPTION
Ghost files were caused by a bug introduced in #513, while the double fd closing came from using the HandleData->File fd with fdopendir, which takes ownership of the fd.