### PR TITLE
libkrun, fs: Restrict the usage of REMOVE_ROOT_DIR_REQ ioctl

### DIFF
--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -54,7 +54,12 @@ pub struct Fs {
 }
 
 impl Fs {
-    pub fn new(fs_id: String, shared_dir: String, exit_code: Arc<AtomicI32>) -> super::Result<Fs> {
+    pub fn new(
+        fs_id: String,
+        shared_dir: String,
+        exit_code: Arc<AtomicI32>,
+        allow_root_dir_delete: bool,
+    ) -> super::Result<Fs> {
         let avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
 
         let tag = fs_id.into_bytes();
@@ -64,6 +69,7 @@ impl Fs {
 
         let fs_cfg = passthrough::Config {
             root_dir: shared_dir,
+            allow_root_dir_delete,
             ..Default::default()
         };
 

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -356,6 +356,7 @@ pub struct Config {
     pub export_fsid: u64,
     /// Table of exported FDs to share with other subsystems.
     pub export_table: Option<ExportTable>,
+    pub allow_root_dir_delete: bool,
 }
 
 impl Default for Config {
@@ -370,6 +371,7 @@ impl Default for Config {
             proc_sfd_rawfd: None,
             export_fsid: 0,
             export_table: None,
+            allow_root_dir_delete: false,
         }
     }
 }
@@ -2259,7 +2261,7 @@ impl FileSystem for PassthroughFs {
                 exit_code.store(arg as i32, Ordering::SeqCst);
                 Ok(Vec::new())
             }
-            VIRTIO_IOC_REMOVE_ROOT_DIR_REQ => {
+            VIRTIO_IOC_REMOVE_ROOT_DIR_REQ if self.cfg.allow_root_dir_delete => {
                 std::fs::remove_dir_all(&self.cfg.root_dir)?;
                 Ok(Vec::new())
             }

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -432,6 +432,7 @@ pub struct Config {
     pub export_fsid: u64,
     /// Table of exported FDs to share with other subsystems. Not supported for macos.
     pub export_table: Option<ExportTable>,
+    pub allow_root_dir_delete: bool,
 }
 
 impl Default for Config {
@@ -446,6 +447,7 @@ impl Default for Config {
             proc_sfd_rawfd: None,
             export_fsid: 0,
             export_table: None,
+            allow_root_dir_delete: false,
         }
     }
 }
@@ -2419,7 +2421,7 @@ impl FileSystem for PassthroughFs {
                 exit_code.store(arg as i32, Ordering::SeqCst);
                 Ok(Vec::new())
             }
-            VIRTIO_IOC_REMOVE_ROOT_DIR_REQ => {
+            VIRTIO_IOC_REMOVE_ROOT_DIR_REQ if self.cfg.allow_root_dir_delete => {
                 std::fs::remove_dir_all(&self.cfg.root_dir)?;
                 Ok(Vec::new())
             }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -592,6 +592,7 @@ pub unsafe extern "C" fn krun_set_root(ctx_id: u32, c_root_path: *const c_char) 
                 shared_dir,
                 // Default to a conservative 512 MB window.
                 shm_size: Some(1 << 29),
+                allow_root_dir_delete: false,
             });
         }
         Entry::Vacant(_) => return -libc::ENOENT,
@@ -624,6 +625,7 @@ pub unsafe extern "C" fn krun_add_virtiofs(
                 fs_id: tag.to_string(),
                 shared_dir: path.to_string(),
                 shm_size: None,
+                allow_root_dir_delete: false,
             });
         }
         Entry::Vacant(_) => return -libc::ENOENT,
@@ -657,6 +659,7 @@ pub unsafe extern "C" fn krun_add_virtiofs2(
                 fs_id: tag.to_string(),
                 shared_dir: path.to_string(),
                 shm_size: Some(shm_size.try_into().unwrap()),
+                allow_root_dir_delete: false,
             });
         }
         Entry::Vacant(_) => return -libc::ENOENT,
@@ -2288,6 +2291,7 @@ pub unsafe extern "C" fn krun_set_root_disk_remount(
                 shared_dir: empty_root.to_string_lossy().into(),
                 // Default to a conservative 512 MB window.
                 shm_size: Some(1 << 29),
+                allow_root_dir_delete: true,
             });
 
             ctx_cfg.set_block_root(device, fstype, options);

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1890,6 +1890,7 @@ fn attach_fs_devices(
                 config.fs_id.clone(),
                 config.shared_dir.clone(),
                 exit_code.clone(),
+                config.allow_root_dir_delete,
             )
             .unwrap(),
         ));

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -3,4 +3,5 @@ pub struct FsDeviceConfig {
     pub fs_id: String,
     pub shared_dir: String,
     pub shm_size: Option<usize>,
+    pub allow_root_dir_delete: bool,
 }


### PR DESCRIPTION
Restrict the usage of VIRTIO_IOC_REMOVE_ROOT_DIR_REQ which deletes the root filesystem. Make it only available on the throwaway filesystem used by krun_set_root_disk_remount.