### PR TITLE
feat: allow overriding embedded binary paths via env variables

### DIFF
--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -3,6 +3,7 @@ name = "devices"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
+build = "build.rs"
 
 [features]
 tee = []

--- a/src/devices/build.rs
+++ b/src/devices/build.rs
@@ -1,0 +1,10 @@
+fn main() {
+    let init_binary_path = std::env::var("KRUN_INIT_BINARY_PATH").unwrap_or_else(|_| {
+        format!(
+            "{}/../../init/init",
+            std::env::var("CARGO_MANIFEST_DIR").unwrap()
+        )
+    });
+    println!("cargo:rustc-env=KRUN_INIT_BINARY_PATH={init_binary_path}");
+    println!("cargo:rerun-if-env-changed=KRUN_INIT_BINARY_PATH");
+}

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -33,7 +33,7 @@ const EMPTY_CSTR: &[u8] = b"\0";
 const PROC_CSTR: &[u8] = b"/proc/self/fd\0";
 const INIT_CSTR: &[u8] = b"init.krun\0";
 
-static INIT_BINARY: &[u8] = include_bytes!("../../../../../../init/init");
+static INIT_BINARY: &[u8] = include_bytes!(env!("KRUN_INIT_BINARY_PATH"));
 
 type Inode = u64;
 type Handle = u64;

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -37,7 +37,7 @@ const SECURITY_CAPABILITY: &[u8] = b"security.capability\0";
 
 const UID_MAX: u32 = u32::MAX - 1;
 
-static INIT_BINARY: &[u8] = include_bytes!("../../../../../../init/init");
+static INIT_BINARY: &[u8] = include_bytes!(env!("KRUN_INIT_BINARY_PATH"));
 
 type Inode = u64;
 type Handle = u64;

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -3,6 +3,7 @@ name = "vmm"
 version = "0.1.0"
 authors = ["Amazon Firecracker team <firecracker-devel@amazon.com>"]
 edition = "2021"
+build = "build.rs"
 
 [features]
 tee = []

--- a/src/vmm/build.rs
+++ b/src/vmm/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    #[cfg(target_arch = "aarch64")]
+    {
+        let edk2_binary_path = std::env::var("KRUN_EDK2_BINARY_PATH").unwrap_or_else(|_| {
+            format!(
+                "{}/../../edk2/KRUN_EFI.silent.fd",
+                std::env::var("CARGO_MANIFEST_DIR").unwrap()
+            )
+        });
+        println!("cargo:rustc-env=KRUN_EDK2_BINARY_PATH={edk2_binary_path}");
+        println!("cargo:rerun-if-env-changed=KRUN_EDK2_BINARY_PATH");
+    }
+}

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -101,7 +101,7 @@ use vm_memory::{GuestAddress, GuestMemoryMmap};
 
 #[cfg(target_arch = "aarch64")]
 #[allow(dead_code)]
-static EDK2_BINARY: &[u8] = include_bytes!("../../../edk2/KRUN_EFI.silent.fd");
+static EDK2_BINARY: &[u8] = include_bytes!(env!("KRUN_EDK2_BINARY_PATH"));
 
 /// Errors associated with starting the instance.
 #[derive(Debug)]


### PR DESCRIPTION
This PR allows overriding the currently hard-coded paths of `INIT_BINARY` (and also `EDK2_BINARY`) at build time.

I've had an issue when using the `devices` crate from outside the `libkrun` tree:

Currently, it's perfectly possible to include the crate in my own project (using the `git` crate location type in my `Cargo.toml`), but the build will fail because the `init` binary included in `virtio::fs::<os>::passthrough` cannot be found.

To fix this, I've replaced

```rust
static INIT_BINARY: &[u8] = include_bytes!("../../../../../../init/init");
```

with

```rust
static INIT_BINARY: &[u8] = include_bytes!(env!("INIT_BINARY_PATH"));
```

Now the `devices` crate can be built even when used out-of-tree. A nice side-effect is that this also allows the use of a custom `init` when desired.

If no `INIT_BINARY_PATH` env variable is set, it falls back to the currently used path, so this PR should remain backwards compatible.

I've noticed that `EDK2_BINARY` (in `vmm`) follows a similar approach, so I have updated that too - even though I am not currently using `aarch64`. I have not tested this myself, but believe it should be fine.
