### PR TITLE
misc: configure gemini for manual reviews

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,11 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: 'MEDIUM'
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+    include_drafts: false
+ignore_patterns: []


### PR DESCRIPTION
Configure Gemini Code Assist to only act on a PR when explicitly requested (i.e. with "/gemini review").