### PR TITLE
vmm/builder: correctly handle invalid fd for serial console

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -747,12 +747,12 @@ pub fn build_microvm(
     let mut serial_ttys = Vec::new();
 
     for s in &vm_resources.serial_consoles {
-        let input = unsafe { BorrowedFd::borrow_raw(s.input_fd) };
-        if input.is_terminal() {
-            serial_ttys.push(input);
-        }
         let input: Option<Box<dyn devices::legacy::ReadableFd + Send>> = if s.input_fd >= 0 {
-            Some(Box::new(unsafe { File::from_raw_fd(s.input_fd) }))
+            let file = unsafe { File::from_raw_fd(s.input_fd) };
+            if file.is_terminal() {
+                serial_ttys.push(unsafe { BorrowedFd::borrow_raw(file.as_raw_fd()) });
+            }
+            Some(Box::new(file))
         } else {
             None
         };


### PR DESCRIPTION
Commit bf3f2bfed385 ("builder: set raw mode for ttys on serial devices") added support for raw for TTYs on serial devices, but didn't seem to take into account that the provided 'input_fd' may be invalid -- a condition supported by code below that checks for positive values. As a result, we may run into a panic as part of BorrowedFd::borrow_raw()'s sanity checks.
Fix this issue by moving code around slightly.