### PR TITLE
vmm: fix non_x86_64 && non-TEE memory region setup

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1552,6 +1552,23 @@ pub(crate) fn setup_vm(
         .map_err(StartMicrovmError::Internal)?;
     Ok(vm)
 }
+
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
+fn validate_tee_config(tee: Tee) -> std::result::Result<(), StartMicrovmError> {
+    match tee {
+        #[cfg(feature = "amd-sev")]
+        Tee::Snp => Ok(()),
+        #[cfg(feature = "tdx")]
+        Tee::Tdx => Ok(()),
+        _ => Err(StartMicrovmError::InvalidTee),
+    }
+}
+
+#[cfg(all(feature = "tee", not(target_arch = "x86_64")))]
+fn validate_tee_config(_tee: Tee) -> std::result::Result<(), StartMicrovmError> {
+    Err(StartMicrovmError::InvalidTee)
+}
+
 #[cfg(all(target_os = "linux", feature = "tee"))]
 pub(crate) fn setup_vm(
     kvm: &KvmContext,
@@ -1559,6 +1576,8 @@ pub(crate) fn setup_vm(
     resources: &super::resources::VmResources,
     #[cfg(feature = "tdx")] _sender: Sender<WorkerMessage>,
 ) -> std::result::Result<Vm, StartMicrovmError> {
+    validate_tee_config(resources.tee_config().tee)?;
+
     let mut vm = Vm::new(
         kvm.fd(),
         resources.tee_config(),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1802,6 +1802,23 @@ pub(crate) fn setup_vm(
         .map_err(StartMicrovmError::Internal)?;
     Ok(vm)
 }
+
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
+fn validate_tee_config(tee: Tee) -> std::result::Result<(), StartMicrovmError> {
+    match tee {
+        #[cfg(feature = "amd-sev")]
+        Tee::Snp => Ok(()),
+        #[cfg(feature = "tdx")]
+        Tee::Tdx => Ok(()),
+        _ => Err(StartMicrovmError::InvalidTee),
+    }
+}
+
+#[cfg(all(feature = "tee", not(target_arch = "x86_64")))]
+fn validate_tee_config(_tee: Tee) -> std::result::Result<(), StartMicrovmError> {
+    Err(StartMicrovmError::InvalidTee)
+}
+
 #[cfg(all(target_os = "linux", feature = "tee"))]
 pub(crate) fn setup_vm(
     kvm: &KvmContext,
@@ -1809,6 +1826,8 @@ pub(crate) fn setup_vm(
     resources: &super::resources::VmResources,
     #[cfg(feature = "tdx")] _sender: Sender<WorkerMessage>,
 ) -> std::result::Result<Vm, StartMicrovmError> {
+    validate_tee_config(resources.tee_config().tee)?;
+
     let mut vm = Vm::new(
         kvm.fd(),
         resources.tee_config(),

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -42,6 +42,8 @@ use crate::resources::TeeConfig;
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 #[cfg(target_arch = "x86_64")]
 use cpuid::{c3, filter_cpuid, t2, VmSpec};
+#[cfg(not(feature = "tee"))]
+use kvm_bindings::kvm_userspace_memory_region;
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{
     kvm_clock_data, kvm_debugregs, kvm_irqchip, kvm_lapic_state, kvm_mp_state, kvm_pit_state2,
@@ -49,14 +51,13 @@ use kvm_bindings::{
     KVM_CLOCK_TSC_STABLE, KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE,
     KVM_MAX_CPUID_ENTRIES,
 };
-use kvm_bindings::{
-    kvm_create_guest_memfd, kvm_userspace_memory_region, kvm_userspace_memory_region2,
-    KVM_API_VERSION, KVM_MEM_GUEST_MEMFD, KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN,
-};
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
+use kvm_bindings::{kvm_create_guest_memfd, kvm_userspace_memory_region2, KVM_MEM_GUEST_MEMFD};
 #[cfg(feature = "tee")]
 use kvm_bindings::{kvm_enable_cap, KVM_CAP_EXIT_HYPERCALL, KVM_MEMORY_EXIT_FLAG_PRIVATE};
-#[cfg(not(target_arch = "riscv64"))]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use kvm_bindings::{kvm_memory_attributes, KVM_MEMORY_ATTRIBUTE_PRIVATE};
+use kvm_bindings::{KVM_API_VERSION, KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
 use kvm_ioctls::{Cap::*, *};
 use utils::eventfd::EventFd;
 use utils::signal::{register_signal_handler, sigrtmin, Killable};
@@ -661,90 +662,121 @@ impl Vm {
         None
     }
 
-    #[allow(unused_mut)]
+    // GuestMemfd is generally intended for either of two purposes:
+    // * sharing the memory with out-of-process components, and conversely,
+    // * hiding the memory completely from the VMM process (Confidential Computing).
+    //
+    // We only use it for the second use case currently, so don't even try to use it
+    // outside of TEE builds. Software-protected VMs are only available on x86_64 and
+    // are marked with strongly-worded warnings about them being for development only,
+    // as of late 2025. Also, on other architectures like aarch64, guest_memfd in
+    // general is unstable for now, so don't try to use it without a reason.
+
+    #[cfg(not(feature = "tee"))]
+    fn create_guest_physical_memory_slot(
+        &mut self,
+        host_addr: u64,
+        start: u64,
+        region: &GuestRegionMmap,
+    ) -> Result<()> {
+        let memory_region = kvm_userspace_memory_region {
+            slot: self.next_mem_slot,
+            guest_phys_addr: start,
+            memory_size: region.len(),
+            userspace_addr: host_addr,
+            flags: 0,
+        };
+
+        // Safe because we mapped the memory region and ensured regions do not overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region(memory_region)
+                .map_err(Error::SetUserMemoryRegion)?;
+        };
+
+        Ok(())
+    }
+
+    #[cfg(all(feature = "tee", target_arch = "x86_64"))]
+    fn create_guest_physical_memory_slot(
+        &mut self,
+        host_addr: u64,
+        start: u64,
+        region: &GuestRegionMmap,
+    ) -> Result<()> {
+        let end = start + region.len();
+
+        if !self.fd.check_extension(GuestMemfd) {
+            return Err(Error::KvmCap(GuestMemfd));
+        }
+
+        // GuestMemfd is only used for confidential-memory setups in TEE builds.
+        let guest_memfd = self
+            .fd
+            .create_guest_memfd(kvm_create_guest_memfd {
+                size: region.size() as u64,
+                flags: 0,
+                reserved: [0; 6],
+            })
+            .map_err(Error::CreateGuestMemfd)?;
+
+        let memory_region = kvm_userspace_memory_region2 {
+            slot: self.next_mem_slot,
+            flags: KVM_MEM_GUEST_MEMFD,
+            guest_phys_addr: start,
+            memory_size: region.len(),
+            userspace_addr: host_addr,
+            guest_memfd_offset: 0,
+            guest_memfd: guest_memfd as u32,
+            pad1: 0,
+            pad2: [0; 14],
+        };
+
+        // Safe because we mapped the memory region and ensured regions do not overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region2(memory_region)
+                .map_err(Error::SetUserMemoryRegion)?;
+        };
+
+        let attr = kvm_memory_attributes {
+            address: start,
+            size: region.len(),
+            attributes: KVM_MEMORY_ATTRIBUTE_PRIVATE as u64,
+            flags: 0,
+        };
+
+        self.fd
+            .set_memory_attributes(attr)
+            .map_err(Error::SetMemoryAttributes)?;
+
+        self.guest_memfds.push((Range { start, end }, guest_memfd));
+
+        Ok(())
+    }
+
+    #[cfg(all(feature = "tee", not(target_arch = "x86_64")))]
+    fn create_guest_physical_memory_slot(
+        &mut self,
+        _host_addr: u64,
+        _start: u64,
+        _region: &GuestRegionMmap,
+    ) -> Result<()> {
+        // TEE support should be rejected during VM setup on non-x86_64 targets.
+        // Do not silently fall back to the non-TEE path here, because that would
+        // ignore an invalid TEE configuration and create a normal VM instead.
+        Err(Error::InvalidTee)
+    }
+
     fn memory_region_set(
         &mut self,
         guest_mem: &GuestMemoryMmap,
         region: &GuestRegionMmap,
     ) -> Result<()> {
-        let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap();
+        let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap() as u64;
         let start = region.start_addr().raw_value();
-        let end = start + region.len();
 
-        // GuestMemfd is generally intended for either of two purposes:
-        // * sharing the memory with out-of-process components, and conversely,
-        // * hiding the memory completely from the VMM process (Confidential Computing).
-        //
-        // We only use it for the second use case currently, so don't even try to use it
-        // outside of TEE builds. Software-protected VMs are only available on x86_64 and
-        // are marked with strongly-worded warnings about them being for development only,
-        // as of late 2025. Also, on other architectures like aarch64, guest_memfd in
-        // general is unstable for now, so don't try to use it without a reason.
-
-        if cfg!(not(feature = "tee")) {
-            let memory_region = kvm_userspace_memory_region {
-                slot: self.next_mem_slot,
-                guest_phys_addr: start,
-                memory_size: region.len(),
-                userspace_addr: host_addr as u64,
-                flags: 0,
-            };
-
-            // Safe because we mapped the memory region, we made sure that the regions
-            // are not overlapping.
-            unsafe {
-                self.fd
-                    .set_user_memory_region(memory_region)
-                    .map_err(Error::SetUserMemoryRegion)?;
-            };
-        } else {
-            if !self.fd.check_extension(GuestMemfd) {
-                return Err(Error::KvmCap(GuestMemfd));
-            }
-
-            // Create a guest_memfd and set the region.
-            let guest_memfd = self
-                .fd
-                .create_guest_memfd(kvm_create_guest_memfd {
-                    size: region.size() as u64,
-                    flags: 0,
-                    reserved: [0; 6],
-                })
-                .map_err(Error::CreateGuestMemfd)?;
-
-            let memory_region = kvm_userspace_memory_region2 {
-                slot: self.next_mem_slot,
-                flags: KVM_MEM_GUEST_MEMFD,
-                guest_phys_addr: start,
-                memory_size: region.len(),
-                userspace_addr: host_addr as u64,
-                guest_memfd_offset: 0,
-                guest_memfd: guest_memfd as u32,
-                pad1: 0,
-                pad2: [0; 14],
-            };
-
-            // Safe because we mapped the memory region, we made sure that the regions
-            // are not overlapping.
-            unsafe {
-                self.fd
-                    .set_user_memory_region2(memory_region)
-                    .map_err(Error::SetUserMemoryRegion)?;
-            };
-
-            let attr = kvm_memory_attributes {
-                address: start,
-                size: region.len(),
-                attributes: KVM_MEMORY_ATTRIBUTE_PRIVATE as u64,
-                flags: 0,
-            };
-
-            self.fd
-                .set_memory_attributes(attr)
-                .map_err(Error::SetMemoryAttributes)?;
-
-            self.guest_memfds.push((Range { start, end }, guest_memfd));
-        }
+        self.create_guest_physical_memory_slot(host_addr, start, region)?;
 
         self.next_mem_slot += 1;
 

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -42,6 +42,8 @@ use crate::resources::TeeConfig;
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 #[cfg(target_arch = "x86_64")]
 use cpuid::{VmSpec, c3, filter_cpuid, t2};
+#[cfg(not(feature = "tee"))]
+use kvm_bindings::kvm_userspace_memory_region;
 #[cfg(target_arch = "x86_64")]
 use kvm_bindings::{
     CpuId, KVM_CLOCK_TSC_STABLE, KVM_IRQCHIP_IOAPIC, KVM_IRQCHIP_PIC_MASTER, KVM_IRQCHIP_PIC_SLAVE,
@@ -49,14 +51,14 @@ use kvm_bindings::{
     kvm_lapic_state, kvm_mp_state, kvm_pit_state2, kvm_regs, kvm_sregs, kvm_vcpu_events, kvm_xcrs,
     kvm_xsave,
 };
-use kvm_bindings::{
-    KVM_API_VERSION, KVM_MEM_GUEST_MEMFD, KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN,
-    kvm_create_guest_memfd, kvm_userspace_memory_region, kvm_userspace_memory_region2,
-};
+use kvm_bindings::{KVM_API_VERSION, KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
 #[cfg(feature = "tee")]
 use kvm_bindings::{KVM_CAP_EXIT_HYPERCALL, KVM_MEMORY_EXIT_FLAG_PRIVATE, kvm_enable_cap};
-#[cfg(not(target_arch = "riscv64"))]
-use kvm_bindings::{KVM_MEMORY_ATTRIBUTE_PRIVATE, kvm_memory_attributes};
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
+use kvm_bindings::{
+    KVM_MEM_GUEST_MEMFD, KVM_MEMORY_ATTRIBUTE_PRIVATE, kvm_create_guest_memfd,
+    kvm_memory_attributes, kvm_userspace_memory_region2,
+};
 use kvm_ioctls::{Cap::*, *};
 use utils::eventfd::EventFd;
 use utils::signal::{Killable, register_signal_handler, sigrtmin};
@@ -661,90 +663,121 @@ impl Vm {
         None
     }
 
-    #[allow(unused_mut)]
+    // GuestMemfd is generally intended for either of two purposes:
+    // * sharing the memory with out-of-process components, and conversely,
+    // * hiding the memory completely from the VMM process (Confidential Computing).
+    //
+    // We only use it for the second use case currently, so don't even try to use it
+    // outside of TEE builds. Software-protected VMs are only available on x86_64 and
+    // are marked with strongly-worded warnings about them being for development only,
+    // as of late 2025. Also, on other architectures like aarch64, guest_memfd in
+    // general is unstable for now, so don't try to use it without a reason.
+
+    #[cfg(not(feature = "tee"))]
+    fn create_guest_physical_memory_slot(
+        &mut self,
+        host_addr: u64,
+        start: u64,
+        region: &GuestRegionMmap,
+    ) -> Result<()> {
+        let memory_region = kvm_userspace_memory_region {
+            slot: self.next_mem_slot,
+            guest_phys_addr: start,
+            memory_size: region.len(),
+            userspace_addr: host_addr,
+            flags: 0,
+        };
+
+        // Safe because we mapped the memory region and ensured regions do not overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region(memory_region)
+                .map_err(Error::SetUserMemoryRegion)?;
+        };
+
+        Ok(())
+    }
+
+    #[cfg(all(feature = "tee", target_arch = "x86_64"))]
+    fn create_guest_physical_memory_slot(
+        &mut self,
+        host_addr: u64,
+        start: u64,
+        region: &GuestRegionMmap,
+    ) -> Result<()> {
+        let end = start + region.len();
+
+        if !self.fd.check_extension(GuestMemfd) {
+            return Err(Error::KvmCap(GuestMemfd));
+        }
+
+        // GuestMemfd is only used for confidential-memory setups in TEE builds.
+        let guest_memfd = self
+            .fd
+            .create_guest_memfd(kvm_create_guest_memfd {
+                size: region.size() as u64,
+                flags: 0,
+                reserved: [0; 6],
+            })
+            .map_err(Error::CreateGuestMemfd)?;
+
+        let memory_region = kvm_userspace_memory_region2 {
+            slot: self.next_mem_slot,
+            flags: KVM_MEM_GUEST_MEMFD,
+            guest_phys_addr: start,
+            memory_size: region.len(),
+            userspace_addr: host_addr,
+            guest_memfd_offset: 0,
+            guest_memfd: guest_memfd as u32,
+            pad1: 0,
+            pad2: [0; 14],
+        };
+
+        // Safe because we mapped the memory region and ensured regions do not overlap.
+        unsafe {
+            self.fd
+                .set_user_memory_region2(memory_region)
+                .map_err(Error::SetUserMemoryRegion)?;
+        };
+
+        let attr = kvm_memory_attributes {
+            address: start,
+            size: region.len(),
+            attributes: KVM_MEMORY_ATTRIBUTE_PRIVATE as u64,
+            flags: 0,
+        };
+
+        self.fd
+            .set_memory_attributes(attr)
+            .map_err(Error::SetMemoryAttributes)?;
+
+        self.guest_memfds.push((Range { start, end }, guest_memfd));
+
+        Ok(())
+    }
+
+    #[cfg(all(feature = "tee", not(target_arch = "x86_64")))]
+    fn create_guest_physical_memory_slot(
+        &mut self,
+        _host_addr: u64,
+        _start: u64,
+        _region: &GuestRegionMmap,
+    ) -> Result<()> {
+        // TEE support should be rejected during VM setup on non-x86_64 targets.
+        // Do not silently fall back to the non-TEE path here, because that would
+        // ignore an invalid TEE configuration and create a normal VM instead.
+        Err(Error::InvalidTee)
+    }
+
     fn memory_region_set(
         &mut self,
         guest_mem: &GuestMemoryMmap,
         region: &GuestRegionMmap,
     ) -> Result<()> {
-        let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap();
+        let host_addr = guest_mem.get_host_address(region.start_addr()).unwrap() as u64;
         let start = region.start_addr().raw_value();
-        let end = start + region.len();
 
-        // GuestMemfd is generally intended for either of two purposes:
-        // * sharing the memory with out-of-process components, and conversely,
-        // * hiding the memory completely from the VMM process (Confidential Computing).
-        //
-        // We only use it for the second use case currently, so don't even try to use it
-        // outside of TEE builds. Software-protected VMs are only available on x86_64 and
-        // are marked with strongly-worded warnings about them being for development only,
-        // as of late 2025. Also, on other architectures like aarch64, guest_memfd in
-        // general is unstable for now, so don't try to use it without a reason.
-
-        if cfg!(not(feature = "tee")) {
-            let memory_region = kvm_userspace_memory_region {
-                slot: self.next_mem_slot,
-                guest_phys_addr: start,
-                memory_size: region.len(),
-                userspace_addr: host_addr as u64,
-                flags: 0,
-            };
-
-            // Safe because we mapped the memory region, we made sure that the regions
-            // are not overlapping.
-            unsafe {
-                self.fd
-                    .set_user_memory_region(memory_region)
-                    .map_err(Error::SetUserMemoryRegion)?;
-            };
-        } else {
-            if !self.fd.check_extension(GuestMemfd) {
-                return Err(Error::KvmCap(GuestMemfd));
-            }
-
-            // Create a guest_memfd and set the region.
-            let guest_memfd = self
-                .fd
-                .create_guest_memfd(kvm_create_guest_memfd {
-                    size: region.size() as u64,
-                    flags: 0,
-                    reserved: [0; 6],
-                })
-                .map_err(Error::CreateGuestMemfd)?;
-
-            let memory_region = kvm_userspace_memory_region2 {
-                slot: self.next_mem_slot,
-                flags: KVM_MEM_GUEST_MEMFD,
-                guest_phys_addr: start,
-                memory_size: region.len(),
-                userspace_addr: host_addr as u64,
-                guest_memfd_offset: 0,
-                guest_memfd: guest_memfd as u32,
-                pad1: 0,
-                pad2: [0; 14],
-            };
-
-            // Safe because we mapped the memory region, we made sure that the regions
-            // are not overlapping.
-            unsafe {
-                self.fd
-                    .set_user_memory_region2(memory_region)
-                    .map_err(Error::SetUserMemoryRegion)?;
-            };
-
-            let attr = kvm_memory_attributes {
-                address: start,
-                size: region.len(),
-                attributes: KVM_MEMORY_ATTRIBUTE_PRIVATE as u64,
-                flags: 0,
-            };
-
-            self.fd
-                .set_memory_attributes(attr)
-                .map_err(Error::SetMemoryAttributes)?;
-
-            self.guest_memfds.push((Range { start, end }, guest_memfd));
-        }
+        self.create_guest_physical_memory_slot(host_addr, start, region)?;
 
         self.next_mem_slot += 1;
 

--- a/src/vmm/src/worker.rs
+++ b/src/vmm/src/worker.rs
@@ -1,20 +1,20 @@
 use std::io;
 use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use utils::worker_message::MemoryProperties;
 use utils::worker_message::WorkerMessage;
 
 use crossbeam_channel::Receiver;
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use crossbeam_channel::Sender;
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use kvm_bindings::{kvm_memory_attributes, KVM_MEMORY_ATTRIBUTE_PRIVATE};
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use libc::{fallocate, madvise, FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, MADV_DONTNEED};
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use std::ffi::c_void;
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use vm_memory::{
     guest_memory::GuestMemory, Address, GuestAddress, GuestMemoryRegion, MemoryRegionAddress,
 };
@@ -59,15 +59,21 @@ impl super::Vmm {
                     .send(self.vm.fd().set_irq_line(irq, active).is_ok())
                     .unwrap();
             }
-            WorkerMessage::ConvertMemory(_sender, _properties) =>
-            {
-                #[cfg(feature = "tee")]
-                self.convert_memory(_sender, _properties)
+            WorkerMessage::ConvertMemory(_sender, _properties) => {
+                #[cfg(all(feature = "tee", target_arch = "x86_64"))]
+                {
+                    self.convert_memory(_sender, _properties);
+                }
+
+                #[cfg(not(all(feature = "tee", target_arch = "x86_64")))]
+                {
+                    let _ = _sender.send(false);
+                }
             }
         }
     }
 
-    #[cfg(feature = "tee")]
+    #[cfg(all(feature = "tee", target_arch = "x86_64"))]
     fn convert_memory(&self, sender: Sender<bool>, properties: MemoryProperties) {
         let Some((guest_memfd, region_start)) = self.kvm_vm().guest_memfd_get(properties.gpa)
         else {

--- a/src/vmm/src/worker.rs
+++ b/src/vmm/src/worker.rs
@@ -1,20 +1,20 @@
 use std::io;
 use std::sync::{Arc, Mutex};
 
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use utils::worker_message::MemoryProperties;
 use utils::worker_message::WorkerMessage;
 
 use crossbeam_channel::Receiver;
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use crossbeam_channel::Sender;
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use kvm_bindings::{KVM_MEMORY_ATTRIBUTE_PRIVATE, kvm_memory_attributes};
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, MADV_DONTNEED, fallocate, madvise};
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use std::ffi::c_void;
-#[cfg(feature = "tee")]
+#[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use vm_memory::{
     Address, GuestAddress, GuestMemoryRegion, MemoryRegionAddress, guest_memory::GuestMemory,
 };
@@ -62,15 +62,21 @@ impl super::Vmm {
                     .send(self.vm.fd().set_irq_line(irq, active).is_ok())
                     .unwrap();
             }
-            WorkerMessage::ConvertMemory(_sender, _properties) =>
-            {
-                #[cfg(feature = "tee")]
-                self.convert_memory(_sender, _properties)
+            WorkerMessage::ConvertMemory(_sender, _properties) => {
+                #[cfg(all(feature = "tee", target_arch = "x86_64"))]
+                {
+                    self.convert_memory(_sender, _properties);
+                }
+
+                #[cfg(not(all(feature = "tee", target_arch = "x86_64")))]
+                {
+                    let _ = _sender.send(false);
+                }
             }
         }
     }
 
-    #[cfg(feature = "tee")]
+    #[cfg(all(feature = "tee", target_arch = "x86_64"))]
     fn convert_memory(&self, sender: Sender<bool>, properties: MemoryProperties) {
         let Some((guest_memfd, region_start)) = self.kvm_vm().guest_memfd_get(properties.gpa)
         else {


### PR DESCRIPTION
## Background

In non-x86 builds that don't use TEE features, `vstate.rs` uses `cfg!()` to distinguish between TEE and non-TEE paths.

`cfg!()` only generates a compile-time constant; the code in the branch still participates in compilation and type checking. As a result, in a normal riscv64 build, code related to `guest_memfd` and memory attributes will also be flagged for errors, leading to compilation failures.

Verify CMD
`cargo check -p vmm --target riscv64gc-unknown-linux-gnu`