### PR TITLE
lib: add krun_set_init_binary, backcompat via new krun_init crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,6 +815,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "krun_init"
+version = "0.1.0"
+
+[[package]]
 name = "krun_input"
 version = "0.1.0"
 dependencies = [
@@ -875,6 +879,7 @@ dependencies = [
  "env_logger",
  "hvf",
  "krun_display",
+ "krun_init",
  "krun_input",
  "kvm-bindings",
  "kvm-ioctls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["src/libkrun", "src/krun_input"]
+members = ["src/libkrun", "src/krun_input", "src/krun_init"]
 exclude = ["examples/gtk_display"]
 resolver = "2"
 

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -110,6 +110,24 @@ int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib)
 int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
 
 /**
+ * Sets the init binary payload that will be exposed as /init.krun inside the guest.
+ *
+ * IMPORTANT LIFETIME CONTRACT:
+ * The memory range [init_binary, init_binary + init_binary_len) is NOT copied.
+ * The caller MUST keep that memory valid and unchanged for the full VM lifetime
+ * in this context (until krun_start_enter() returns and the VM is torn down).
+ *
+ * Arguments:
+ *  "ctx_id"          - the configuration context ID.
+ *  "init_binary"     - pointer to init binary bytes.
+ *  "init_binary_len" - number of bytes at init_binary.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_init(uint32_t ctx_id, const uint8_t *init_binary, size_t init_binary_len);
+
+/**
  * DEPRECATED. Use krun_add_disk instead.
  *
  * Sets the path to the disk image that contains the file-system to be used as root for the microVM.

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -3,7 +3,6 @@ name = "devices"
 version = "0.1.0"
 authors = ["The Chromium OS Authors"]
 edition = "2021"
-build = "build.rs"
 
 [features]
 tee = []

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -59,6 +59,7 @@ impl Fs {
         shared_dir: String,
         exit_code: Arc<AtomicI32>,
         allow_root_dir_delete: bool,
+        init_payload: Option<&'static [u8]>,
     ) -> super::Result<Fs> {
         let avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
 
@@ -70,6 +71,7 @@ impl Fs {
         let fs_cfg = passthrough::Config {
             root_dir: shared_dir,
             allow_root_dir_delete,
+            init_payload,
             ..Default::default()
         };
 

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -33,8 +33,6 @@ const EMPTY_CSTR: &[u8] = b"\0";
 const PROC_CSTR: &[u8] = b"/proc/self/fd\0";
 const INIT_CSTR: &[u8] = b"init.krun\0";
 
-static INIT_BINARY: &[u8] = include_bytes!(env!("KRUN_INIT_BINARY_PATH"));
-
 type Inode = u64;
 type Handle = u64;
 
@@ -328,6 +326,7 @@ pub struct Config {
     /// Table of exported FDs to share with other subsystems.
     pub export_table: Option<ExportTable>,
     pub allow_root_dir_delete: bool,
+    pub init_payload: Option<&'static [u8]>,
 }
 
 impl Default for Config {
@@ -343,6 +342,7 @@ impl Default for Config {
             export_fsid: 0,
             export_table: None,
             allow_root_dir_delete: false,
+            init_payload: None,
         }
     }
 }
@@ -439,7 +439,11 @@ impl PassthroughFs {
         Ok(PassthroughFs {
             inodes: RwLock::new(MultikeyBTreeMap::new()),
             next_inode: AtomicU64::new(fuse::ROOT_ID + 2),
-            init_inode: fuse::ROOT_ID + 1,
+            init_inode: if cfg.init_payload.is_some() {
+                fuse::ROOT_ID + 1
+            } else {
+                0
+            },
 
             handles: RwLock::new(BTreeMap::new()),
             next_handle: AtomicU64::new(1),
@@ -454,6 +458,12 @@ impl PassthroughFs {
             cap_fowner,
             cfg,
         })
+    }
+
+    fn init_payload(&self) -> io::Result<&[u8]> {
+        self.cfg
+            .init_payload
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOENT))
     }
 
     fn open_inode(&self, inode: Inode, mut flags: i32) -> io::Result<File> {
@@ -996,7 +1006,7 @@ impl FileSystem for PassthroughFs {
 
         if self.init_inode != 0 && name == init_name {
             let mut st: libc::stat64 = unsafe { mem::zeroed() };
-            st.st_size = INIT_BINARY.len() as i64;
+            st.st_size = self.init_payload()?.len() as i64;
             st.st_ino = self.init_inode;
             st.st_mode = 0o100_755;
 
@@ -1235,13 +1245,16 @@ impl FileSystem for PassthroughFs {
     ) -> io::Result<usize> {
         debug!("read: {inode:?}");
         if inode == self.init_inode {
+            let init_payload = self.init_payload()?;
             let off: usize = offset.try_into().map_err(|_| einval())?;
-            let len = if off + (size as usize) < INIT_BINARY.len() {
-                size as usize
-            } else {
-                INIT_BINARY.len() - off
-            };
-            return w.write(&INIT_BINARY[off..(off + len)]);
+            if off >= init_payload.len() {
+                // Read past EOF should return 0 bytes.
+                return Ok(0);
+            }
+
+            let remaining = init_payload.len() - off;
+            let len = remaining.min(size as usize);
+            return w.write(&init_payload[off..(off + len)]);
         }
 
         let data = self
@@ -2088,6 +2101,7 @@ impl FileSystem for PassthroughFs {
         debug!("setupmapping: ino {inode:?} addr={addr:x} len={len}");
 
         if inode == self.init_inode {
+            let init_payload = self.init_payload()?;
             let ret = unsafe {
                 libc::mmap(
                     addr as *mut libc::c_void,
@@ -2102,15 +2116,15 @@ impl FileSystem for PassthroughFs {
                 return Err(io::Error::last_os_error());
             }
 
-            let to_copy = if len as usize > INIT_BINARY.len() {
-                INIT_BINARY.len()
+            let to_copy = if len as usize > init_payload.len() {
+                init_payload.len()
             } else {
                 len as usize
             };
             unsafe {
                 libc::memcpy(
                     addr as *mut libc::c_void,
-                    INIT_BINARY.as_ptr() as *const _,
+                    init_payload.as_ptr() as *const _,
                     to_copy,
                 )
             };

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -37,8 +37,6 @@ const SECURITY_CAPABILITY: &[u8] = b"security.capability\0";
 
 const UID_MAX: u32 = u32::MAX - 1;
 
-static INIT_BINARY: &[u8] = include_bytes!(env!("KRUN_INIT_BINARY_PATH"));
-
 type Inode = u64;
 type Handle = u64;
 
@@ -517,6 +515,7 @@ pub struct Config {
     /// Table of exported FDs to share with other subsystems. Not supported for macos.
     pub export_table: Option<ExportTable>,
     pub allow_root_dir_delete: bool,
+    pub init_payload: Option<&'static [u8]>,
 }
 
 impl Default for Config {
@@ -532,6 +531,7 @@ impl Default for Config {
             export_fsid: 0,
             export_table: None,
             allow_root_dir_delete: false,
+            init_payload: None,
         }
     }
 }
@@ -580,7 +580,11 @@ impl PassthroughFs {
         Ok(PassthroughFs {
             inodes: RwLock::new(MultikeyBTreeMap::new()),
             next_inode: AtomicU64::new(fuse::ROOT_ID + 2),
-            init_inode: fuse::ROOT_ID + 1,
+            init_inode: if cfg.init_payload.is_some() {
+                fuse::ROOT_ID + 1
+            } else {
+                0
+            },
 
             handles: RwLock::new(BTreeMap::new()),
             next_handle: AtomicU64::new(1),
@@ -592,6 +596,12 @@ impl PassthroughFs {
             announce_submounts: AtomicBool::new(false),
             cfg,
         })
+    }
+
+    fn init_payload(&self) -> io::Result<&[u8]> {
+        self.cfg
+            .init_payload
+            .ok_or_else(|| linux_error(io::Error::from_raw_os_error(libc::ENOENT)))
     }
 
     fn inode_to_handle(&self, inode: Inode, supports_fd: bool) -> io::Result<InodeHandle> {
@@ -1205,7 +1215,7 @@ impl FileSystem for PassthroughFs {
 
         if self.init_inode != 0 && name == _init_name {
             let mut st: bindings::stat64 = unsafe { mem::zeroed() };
-            st.st_size = INIT_BINARY.len() as i64;
+            st.st_size = self.init_payload()?.len() as i64;
             st.st_ino = self.init_inode;
             st.st_mode = 0o100_755;
 
@@ -1457,15 +1467,18 @@ impl FileSystem for PassthroughFs {
     ) -> io::Result<usize> {
         debug!("read: {inode:?}");
         if inode == self.init_inode {
+            let init_payload = self.init_payload()?;
             let off: usize = offset
                 .try_into()
                 .map_err(|_| io::Error::from_raw_os_error(libc::EINVAL))?;
-            let len = if off + (size as usize) < INIT_BINARY.len() {
-                size as usize
-            } else {
-                INIT_BINARY.len() - off
-            };
-            return w.write(&INIT_BINARY[off..(off + len)]);
+            if off >= init_payload.len() {
+                // Read past EOF should return 0 bytes.
+                return Ok(0);
+            }
+
+            let remaining = init_payload.len() - off;
+            let len = remaining.min(size as usize);
+            return w.write(&init_payload[off..(off + len)]);
         }
 
         let data = self

--- a/src/krun_init/Cargo.toml
+++ b/src/krun_init/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "krun_init"
+version = "0.1.0"
+edition = "2021"
+build = "build.rs"
+
+[lib]
+path = "src/lib.rs"

--- a/src/krun_init/build.rs
+++ b/src/krun_init/build.rs
@@ -39,20 +39,31 @@ fn build_default_init() -> PathBuf {
         .unwrap_or_else(|e| panic!("failed to execute {cc}: {e}"));
 
     if !status.success() {
-        panic!("failed to compile init/init.c: {status}");
+        panic!("failed to compile init/init.c with {cc}: {status}");
     }
+
     init_bin
 }
 
 fn main() {
+    let manifest_dir = PathBuf::from(std::env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let repo_init_bin = manifest_dir.join("../..").join("init/init");
+    println!("cargo:rerun-if-changed={}", repo_init_bin.display());
+
     let init_binary_path = std::env::var_os("KRUN_INIT_BINARY_PATH")
         .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            let init_path = build_default_init();
-            // SAFETY: The build script is single threaded.
-            unsafe { std::env::set_var("KRUN_INIT_BINARY_PATH", &init_path) };
-            init_path
-        });
+        .or_else(|| {
+            if repo_init_bin.exists() {
+                Some(repo_init_bin)
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(build_default_init);
+
+    // SAFETY: The build script is single threaded.
+    unsafe { std::env::set_var("KRUN_INIT_BINARY_PATH", &init_binary_path) };
+
     println!(
         "cargo:rustc-env=KRUN_INIT_BINARY_PATH={}",
         init_binary_path.display()

--- a/src/krun_init/src/lib.rs
+++ b/src/krun_init/src/lib.rs
@@ -1,0 +1,1 @@
+pub static DEFAULT_INIT: &[u8] = include_bytes!(env!("KRUN_INIT_BINARY_PATH"));

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -32,6 +32,7 @@ devices = { path = "../devices" }
 polly = { path = "../polly" }
 utils = { path = "../utils" }
 vmm = { path = "../vmm" }
+krun_init = { path = "../krun_init" }
 rand = "0.9.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -34,8 +34,7 @@ use std::os::fd::{BorrowedFd, FromRawFd, RawFd};
 use std::path::PathBuf;
 use std::slice;
 use std::sync::atomic::{AtomicI32, Ordering};
-use std::sync::LazyLock;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use utils::eventfd::EventFd;
 use vmm::resources::{
     DefaultVirtioConsoleConfig, PortConfig, SerialConsoleConfig, TsiFlags, VirtioConsoleConfigMode,
@@ -52,7 +51,7 @@ use vmm::vmm_config::fs::FsDeviceConfig;
 use vmm::vmm_config::kernel_bundle::KernelBundle;
 #[cfg(feature = "tee")]
 use vmm::vmm_config::kernel_bundle::{InitrdBundle, QbootBundle};
-use vmm::vmm_config::kernel_cmdline::{KernelCmdlineConfig, DEFAULT_KERNEL_CMDLINE};
+use vmm::vmm_config::kernel_cmdline::{InitPolicy, KernelCmdlineConfig, DEFAULT_KERNEL_CMDLINE};
 use vmm::vmm_config::machine_config::VmConfig;
 #[cfg(feature = "net")]
 use vmm::vmm_config::net::NetworkInterfaceConfig;
@@ -89,6 +88,9 @@ const INIT_PATH: &str = "/init.krun";
 
 static KRUNFW: LazyLock<Option<libloading::Library>> =
     LazyLock::new(|| unsafe { libloading::Library::new(KRUNFW_NAME).ok() });
+
+#[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+const DEFAULT_INIT_PAYLOAD: &[u8] = krun_init::DEFAULT_INIT;
 
 pub struct KrunfwBindings {
     get_kernel: libloading::Symbol<
@@ -164,6 +166,8 @@ struct ContextConfig {
     console_output: Option<PathBuf>,
     vmm_uid: Option<libc::uid_t>,
     vmm_gid: Option<libc::gid_t>,
+    #[cfg(not(feature = "tee"))]
+    init_payload: Option<&'static [u8]>,
 }
 
 impl ContextConfig {
@@ -230,6 +234,16 @@ impl ContextConfig {
 
     fn set_args(&mut self, args: String) {
         self.args = Some(args);
+    }
+
+    #[cfg(not(feature = "tee"))]
+    fn set_init_binary(&mut self, init_binary: &'static [u8]) {
+        self.init_payload = Some(init_binary);
+    }
+
+    #[cfg(not(feature = "tee"))]
+    fn get_init_binary(&self) -> &'static [u8] {
+        self.init_payload.unwrap_or(DEFAULT_INIT_PAYLOAD)
     }
 
     fn get_args(&self) -> String {
@@ -595,7 +609,40 @@ pub unsafe extern "C" fn krun_set_root(ctx_id: u32, c_root_path: *const c_char) 
                 // Default to a conservative 512 MB window.
                 shm_size: Some(1 << 29),
                 allow_root_dir_delete: false,
+                init_payload: Some(cfg.get_init_binary()),
             });
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+#[cfg(not(feature = "tee"))]
+pub unsafe extern "C" fn krun_set_init(
+    ctx_id: u32,
+    init_binary: *const u8,
+    init_binary_len: size_t,
+) -> i32 {
+    if init_binary.is_null() || init_binary_len == 0 {
+        return -libc::EINVAL;
+    }
+
+    // SAFETY CONTRACT: The caller guarantees that this memory range remains
+    // valid for the full VM lifetime (until krun_start_enter() returns and the
+    // context is dropped). We do not copy the bytes.
+    let payload: &'static [u8] = slice::from_raw_parts(init_binary, init_binary_len);
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg_entry) => {
+            let ctx_cfg = ctx_cfg_entry.get_mut();
+            ctx_cfg.set_init_binary(payload);
+
+            for fs_cfg in &mut ctx_cfg.vmr.fs {
+                fs_cfg.init_payload = Some(payload);
+            }
         }
         Entry::Vacant(_) => return -libc::ENOENT,
     }
@@ -628,6 +675,7 @@ pub unsafe extern "C" fn krun_add_virtiofs(
                 shared_dir: path.to_string(),
                 shm_size: None,
                 allow_root_dir_delete: false,
+                init_payload: Some(cfg.get_init_binary()),
             });
         }
         Entry::Vacant(_) => return -libc::ENOENT,
@@ -662,6 +710,7 @@ pub unsafe extern "C" fn krun_add_virtiofs2(
                 shared_dir: path.to_string(),
                 shm_size: Some(shm_size.try_into().unwrap()),
                 allow_root_dir_delete: false,
+                init_payload: Some(cfg.get_init_binary()),
             });
         }
         Entry::Vacant(_) => return -libc::ENOENT,
@@ -2294,6 +2343,7 @@ pub unsafe extern "C" fn krun_set_root_disk_remount(
                 // Default to a conservative 512 MB window.
                 shm_size: Some(1 << 29),
                 allow_root_dir_delete: true,
+                init_payload: Some(ctx_cfg.get_init_binary()),
             });
 
             ctx_cfg.set_block_root(device, fstype, options);
@@ -2603,6 +2653,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
             ctx_cfg.get_env(),
         )),
         epilog: Some(format!(" -- {}", ctx_cfg.get_args())),
+        init_policy: InitPolicy::InitKrunFromVirtioFs,
     };
 
     if ctx_cfg.vmr.set_kernel_cmdline(kernel_cmdline).is_err() {

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -60,6 +60,8 @@ use crate::terminal::{term_restore_mode, term_set_raw_mode};
 use crate::vmm_config::block::BlockBuilder;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use crate::vmm_config::fs::FsDeviceConfig;
+#[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+use crate::vmm_config::kernel_cmdline::InitPolicy;
 use crate::vmm_config::kernel_cmdline::DEFAULT_KERNEL_CMDLINE;
 #[cfg(target_os = "linux")]
 use crate::vstate::KvmContext;
@@ -170,6 +172,8 @@ pub enum StartMicrovmError {
     MicroVMAlreadyRunning,
     /// Cannot start the VM because the kernel was not configured.
     MissingKernelConfig,
+    /// Cannot start the VM because init=/init.krun was requested without an init payload.
+    MissingInitPayload,
     /// Cannot start the VM because the size of the guest memory  was not specified.
     MissingMemSizeConfig,
     /// The net device configuration is missing the tap device.
@@ -345,6 +349,10 @@ impl Display for StartMicrovmError {
             }
             MicroVMAlreadyRunning => write!(f, "Microvm already running."),
             MissingKernelConfig => write!(f, "Cannot start microvm without kernel configuration."),
+            MissingInitPayload => write!(
+                f,
+                "Cannot start microvm with init=/init.krun without a /dev/root init payload."
+            ),
             MissingMemSizeConfig => {
                 write!(f, "Cannot start microvm without guest mem_size config.")
             }
@@ -607,6 +615,18 @@ pub fn build_microvm(
         );
         kernel_cmdline = Cmdline::new(arch::CMDLINE_MAX_SIZE);
         kernel_cmdline.insert_str(cmdline).unwrap();
+    }
+
+    #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+    if matches!(
+        vm_resources.kernel_cmdline.init_policy,
+        InitPolicy::InitKrunFromVirtioFs
+    ) && !vm_resources
+        .fs
+        .iter()
+        .any(|fs| fs.fs_id == "/dev/root" && fs.init_payload.is_some())
+    {
+        return Err(StartMicrovmError::MissingInitPayload);
     }
 
     #[cfg(not(feature = "tee"))]
@@ -1896,6 +1916,7 @@ fn attach_fs_devices(
                 config.shared_dir.clone(),
                 exit_code.clone(),
                 config.allow_root_dir_delete,
+                config.init_payload,
             )
             .unwrap(),
         ));

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -399,6 +399,7 @@ mod tests {
             prolog: None,
             krun_env: None,
             epilog: None,
+            init_policy: Default::default(),
         }
     }
 

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -4,4 +4,5 @@ pub struct FsDeviceConfig {
     pub shared_dir: String,
     pub shm_size: Option<usize>,
     pub allow_root_dir_delete: bool,
+    pub init_payload: Option<&'static [u8]>,
 }

--- a/src/vmm/src/vmm_config/kernel_cmdline.rs
+++ b/src/vmm/src/vmm_config/kernel_cmdline.rs
@@ -10,6 +10,16 @@ pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodu
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
                                           rootfstype=virtiofs rw quiet no-kvmapf";
 
+/// Contract for how init is provided to the guest.
+#[derive(Debug, Default, Eq, PartialEq, Clone, Copy)]
+pub enum InitPolicy {
+    /// No libkrun-specific init contract is required.
+    #[default]
+    Unspecified,
+    /// VM startup expects `/init.krun` to be provided by the synthetic virtio-fs entry.
+    InitKrunFromVirtioFs,
+}
+
 /// Strongly typed data structure used to configure the boot source of the
 /// microvm.
 #[derive(Debug, Default, Eq, PartialEq)]
@@ -17,6 +27,7 @@ pub struct KernelCmdlineConfig {
     pub prolog: Option<String>,
     pub krun_env: Option<String>,
     pub epilog: Option<String>,
+    pub init_policy: InitPolicy,
 }
 
 /// Errors associated with actions on `KernelCmdlineConfig`.


### PR DESCRIPTION
## Intent

Our goal with this PR is to prepare for a future Rust API where the main crate does **not** always embed or compile an `init` binary as part of being usable.

Today, `init.krun` is effectively a hard-wired implementation detail of the lower layers (especially `devices`), which makes sense for the current C-oriented flow, but creates friction for a slim Rust-first API design. We want to preserve the existing behavior for C consumers while moving toward a model where init payload is an explicit input, not an unconditional side effect of depending on core crates.

In short: keep the current default UX where needed, but stop forcing the init payload into every build shape.

## Approach

This PR splits policy from mechanism and introduces an explicit init contract.

First, it moves default init embedding/build responsibilities into a dedicated sibling crate (`krun_init`) instead of keeping that logic in `devices`. That lets us preserve current behavior (default payload is still available) without making `devices` itself always own the init artifact.

Second, it changes virtio-fs passthrough to accept init payload through configuration (`Option<Arc<[u8]>>`) rather than via a crate-level static include. The synthetic `/init.krun` inode is now exposed only when payload is present, which makes the behavior explicit and composable.

Third, it replaces the stringly cmdline check with a typed boot contract. We now express the requirement as `InitPolicy::InitKrunFromVirtioFs`, and enforce it centrally in `vmm::builder`. This keeps validation robust and avoids heuristic coupling to command-line text parsing.

Fourth, on the C side, it keeps backward-compatible defaults by auto-wiring the default init payload, and additionally introduces a runtime override API (`krun_set_init_binary`) so callers can inject their own init bytes for a context.

## Trade-offs

The main benefit is architectural clarity: core crates no longer implicitly force init embedding semantics, and the contract around `/init.krun` is explicit and validated in one place. This also gives us a clean migration path toward a Rust API where init choice is deliberate.

The cost is extra plumbing and a slightly larger configuration surface (`init_policy`, payload propagation through fs config). We also introduce another crate (`krun_init`) in the dependency graph, which is intentional but still additional structure to maintain.

Overall, this is a deliberate trade: modest complexity increase now in exchange for a cleaner long-term API boundary and less hidden policy in shared internals.
