### PR TITLE
virtiofs: split exit-code reporting and VM-exit request

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -14,6 +14,7 @@
 #include <net/if.h>
 #include <sys/ioctl.h>
 #include <sys/mount.h>
+#include <sys/reboot.h>
 #include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
@@ -32,6 +33,7 @@
 
 #define KRUN_EXIT_CODE_IOCTL 0x7602
 #define KRUN_REMOVE_ROOT_DIR_IOCTL 0x7603
+#define KRUN_EXIT_VM_IOCTL 0x7604
 
 #define KRUN_MAGIC "KRUN"
 #define KRUN_FOOTER_LEN 12
@@ -1003,6 +1005,41 @@ void set_exit_code(int code)
     close(fd);
 }
 
+static void request_vm_exit(void)
+{
+    int fd;
+    int ret;
+    int virtiofs_check;
+
+    virtiofs_check = is_virtiofs("/");
+    if (virtiofs_check < 0) {
+        printf("Warning: Could not determine filesystem type for root\n");
+    }
+
+    if (virtiofs_check == 0) {
+        return;
+    }
+
+    fd = open("/", O_RDONLY);
+    if (fd < 0) {
+        perror("Couldn't open root filesystem to request VM exit");
+        return;
+    }
+
+    ret = ioctl(fd, KRUN_EXIT_VM_IOCTL, 0);
+    if (ret < 0) {
+        perror("Error using the ioctl to request VM exit");
+    }
+
+    close(fd);
+}
+
+static void shutdown_vm(void)
+{
+    sync();
+    request_vm_exit();
+}
+
 int try_mount(const char *source, const char *target, const char *fstype,
               unsigned long mountflags, const void *data)
 {
@@ -1241,13 +1278,12 @@ int main(int argc, char **argv)
             // Not the first child, ignore it.
         };
 
-        // The workload's entrypoint has exited, record its exit code and exit
-        // ourselves.
         if (WIFEXITED(status)) {
             set_exit_code(WEXITSTATUS(status));
         } else if (WIFSIGNALED(status)) {
             set_exit_code(WTERMSIG(status) + 128);
         }
+        shutdown_vm();
     }
 
     return 0;

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -2,7 +2,7 @@
 use crossbeam_channel::Sender;
 use std::cmp;
 use std::io::Write;
-use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
@@ -49,6 +49,8 @@ pub struct Fs {
     worker_thread: Option<JoinHandle<()>>,
     worker_stopfd: EventFd,
     exit_code: Arc<AtomicI32>,
+    exit_request: Arc<AtomicBool>,
+    exit_evt: EventFd,
     #[cfg(target_os = "macos")]
     map_sender: Option<Sender<WorkerMessage>>,
 }
@@ -58,7 +60,9 @@ impl Fs {
         fs_id: String,
         shared_dir: String,
         exit_code: Arc<AtomicI32>,
+        exit_request: Arc<AtomicBool>,
         allow_root_dir_delete: bool,
+        exit_evt: EventFd,
     ) -> super::Result<Fs> {
         let avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
 
@@ -83,6 +87,8 @@ impl Fs {
             worker_thread: None,
             worker_stopfd: EventFd::new(EFD_NONBLOCK).map_err(FsError::EventFd)?,
             exit_code,
+            exit_request,
+            exit_evt,
             #[cfg(target_os = "macos")]
             map_sender: None,
         })
@@ -185,6 +191,8 @@ impl VirtioDevice for Fs {
             self.passthrough_cfg.clone(),
             self.worker_stopfd.try_clone().unwrap(),
             self.exit_code.clone(),
+            self.exit_request.clone(),
+            self.exit_evt.try_clone().unwrap(),
             #[cfg(target_os = "macos")]
             self.map_sender.clone(),
         );

--- a/src/devices/src/virtio/fs/filesystem.rs
+++ b/src/devices/src/virtio/fs/filesystem.rs
@@ -13,7 +13,7 @@ use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
 use std::mem;
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::{AtomicBool, AtomicI32};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -1170,6 +1170,7 @@ pub trait FileSystem {
         in_size: u32,
         out_size: u32,
         exit_code: &Arc<AtomicI32>,
+        exit_request: &Arc<AtomicBool>,
     ) -> io::Result<Vec<u8>> {
         Err(io::Error::from_raw_os_error(bindings::LINUX_ENOSYS))
     }

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -2179,6 +2179,7 @@ impl FileSystem for PassthroughFs {
         _in_size: u32,
         out_size: u32,
         exit_code: &Arc<AtomicI32>,
+        exit_request: &Arc<AtomicBool>,
     ) -> io::Result<Vec<u8>> {
         const VIRTIO_IOC_MAGIC: u8 = b'v';
 
@@ -2197,6 +2198,10 @@ impl FileSystem for PassthroughFs {
         const VIRTIO_IOC_REMOVE_ROOT_DIR_CODE: u8 = 3;
         const VIRTIO_IOC_REMOVE_ROOT_DIR_REQ: u32 =
             request_code_none!(VIRTIO_IOC_MAGIC, VIRTIO_IOC_REMOVE_ROOT_DIR_CODE) as u32;
+
+        const VIRTIO_IOC_TYPE_EXIT_REQUEST: u8 = 4;
+        const VIRTIO_IOC_EXIT_REQUEST_REQ: u32 =
+            request_code_none!(VIRTIO_IOC_MAGIC, VIRTIO_IOC_TYPE_EXIT_REQUEST) as u32;
 
         match cmd {
             VIRTIO_IOC_EXPORT_FD_REQ => {
@@ -2229,7 +2234,13 @@ impl FileSystem for PassthroughFs {
                 Ok(ret)
             }
             VIRTIO_IOC_EXIT_CODE_REQ => {
+                debug!("virtiofs exit-code ioctl received: {}", arg as i32);
                 exit_code.store(arg as i32, Ordering::SeqCst);
+                Ok(Vec::new())
+            }
+            VIRTIO_IOC_EXIT_REQUEST_REQ => {
+                debug!("virtiofs explicit-exit ioctl received");
+                exit_request.store(true, Ordering::SeqCst);
                 Ok(Vec::new())
             }
             VIRTIO_IOC_REMOVE_ROOT_DIR_REQ if self.cfg.allow_root_dir_delete => {

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -2435,15 +2435,21 @@ impl FileSystem for PassthroughFs {
         _in_size: u32,
         _out_size: u32,
         exit_code: &Arc<AtomicI32>,
+        exit_request: &Arc<AtomicBool>,
     ) -> io::Result<Vec<u8>> {
         // We can't use nix::request_code_none here since it's system-dependent
         // and we need the value from Linux.
         const VIRTIO_IOC_EXIT_CODE_REQ: u32 = 0x7602;
         const VIRTIO_IOC_REMOVE_ROOT_DIR_REQ: u32 = 0x7603;
+        const VIRTIO_IOC_EXIT_REQUEST_REQ: u32 = 0x7604;
 
         match cmd {
             VIRTIO_IOC_EXIT_CODE_REQ => {
                 exit_code.store(arg as i32, Ordering::SeqCst);
+                Ok(Vec::new())
+            }
+            VIRTIO_IOC_EXIT_REQUEST_REQ => {
+                exit_request.store(true, Ordering::SeqCst);
                 Ok(Vec::new())
             }
             VIRTIO_IOC_REMOVE_ROOT_DIR_REQ if self.cfg.allow_root_dir_delete => {

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -12,7 +12,7 @@ use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::mem::size_of;
-use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
 use std::sync::Arc;
 
 use vm_memory::ByteValued;
@@ -85,6 +85,7 @@ impl<F: FileSystem + Sync> Server<F> {
         w: Writer,
         shm_region: &Option<VirtioShmRegion>,
         exit_code: &Arc<AtomicI32>,
+        exit_request: &Arc<AtomicBool>,
         #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
     ) -> Result<usize> {
         let in_header: InHeader = r.read_obj().map_err(Error::DecodeMessage)?;
@@ -134,7 +135,7 @@ impl<F: FileSystem + Sync> Server<F> {
             x if x == Opcode::Interrupt as u32 => self.interrupt(in_header),
             x if x == Opcode::Bmap as u32 => self.bmap(in_header, r, w),
             x if x == Opcode::Destroy as u32 => self.destroy(),
-            x if x == Opcode::Ioctl as u32 => self.ioctl(in_header, r, w, exit_code),
+            x if x == Opcode::Ioctl as u32 => self.ioctl(in_header, r, w, exit_code, exit_request),
             x if x == Opcode::Poll as u32 => self.poll(in_header, r, w),
             x if x == Opcode::NotifyReply as u32 => self.notify_reply(in_header, r, w),
             x if x == Opcode::BatchForget as u32 => self.batch_forget(in_header, r, w),
@@ -1185,6 +1186,7 @@ impl<F: FileSystem + Sync> Server<F> {
         mut r: Reader,
         w: Writer,
         exit_code: &Arc<AtomicI32>,
+        exit_request: &Arc<AtomicBool>,
     ) -> Result<usize> {
         let IoctlIn {
             fh,
@@ -1205,6 +1207,7 @@ impl<F: FileSystem + Sync> Server<F> {
             in_size,
             out_size,
             exit_code,
+            exit_request,
         ) {
             Ok(data) => {
                 let out = IoctlOut {

--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -4,7 +4,7 @@ use crossbeam_channel::Sender;
 use utils::worker_message::WorkerMessage;
 
 use std::os::fd::AsRawFd;
-use std::sync::atomic::AtomicI32;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::Arc;
 use std::thread;
 
@@ -28,6 +28,8 @@ pub struct FsWorker {
     server: Server<PassthroughFs>,
     stop_fd: EventFd,
     exit_code: Arc<AtomicI32>,
+    exit_request: Arc<AtomicBool>,
+    exit_evt: EventFd,
     #[cfg(target_os = "macos")]
     map_sender: Option<Sender<WorkerMessage>>,
 }
@@ -43,6 +45,8 @@ impl FsWorker {
         passthrough_cfg: passthrough::Config,
         stop_fd: EventFd,
         exit_code: Arc<AtomicI32>,
+        exit_request: Arc<AtomicBool>,
+        exit_evt: EventFd,
         #[cfg(target_os = "macos")] map_sender: Option<Sender<WorkerMessage>>,
     ) -> Self {
         Self {
@@ -54,6 +58,8 @@ impl FsWorker {
             server: Server::new(PassthroughFs::new(passthrough_cfg).unwrap()),
             stop_fd,
             exit_code,
+            exit_request,
+            exit_evt,
             #[cfg(target_os = "macos")]
             map_sender,
         }
@@ -160,6 +166,7 @@ impl FsWorker {
                 writer,
                 &self.shm_region,
                 &self.exit_code,
+                &self.exit_request,
                 #[cfg(target_os = "macos")]
                 &self.map_sender,
             ) {
@@ -172,6 +179,14 @@ impl FsWorker {
 
             if queue.needs_notification(&self.mem).unwrap() {
                 self.interrupt.signal_used_queue();
+            }
+
+            if self.exit_request.swap(false, Ordering::SeqCst) {
+                debug!("virtiofs explicit exit request received; signaling VMM exit event");
+                if let Err(e) = self.exit_evt.write(1) {
+                    error!("failed to signal VMM exit event: {e}");
+                }
+                return;
             }
         }
     }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -15,6 +15,8 @@ use std::io::{self, IsTerminal, Read};
 use std::os::fd::AsRawFd;
 use std::os::fd::{BorrowedFd, FromRawFd};
 use std::path::PathBuf;
+#[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
 
@@ -949,6 +951,8 @@ pub fn build_microvm(
 
     // We use this atomic to record the exit code set by init/init.c in the VM.
     let exit_code = Arc::new(AtomicI32::new(i32::MAX));
+    #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+    let exit_request = Arc::new(AtomicBool::new(false));
 
     let mut vmm = Vmm {
         guest_memory,
@@ -1031,6 +1035,13 @@ pub fn build_microvm(
     }
 
     #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+    let fs_exit_evt = vmm
+        .exit_evt
+        .try_clone()
+        .map_err(Error::EventFd)
+        .map_err(StartMicrovmError::Internal)?;
+
+    #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
     attach_fs_devices(
         &mut vmm,
         &vm_resources.fs,
@@ -1039,6 +1050,8 @@ pub fn build_microvm(
         export_table,
         intc.clone(),
         exit_code,
+        exit_request,
+        fs_exit_evt,
         #[cfg(target_os = "macos")]
         _sender,
     )?;
@@ -1873,6 +1886,7 @@ fn attach_mmio_device(
 }
 
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+#[allow(clippy::too_many_arguments)]
 fn attach_fs_devices(
     vmm: &mut Vmm,
     fs_devs: &[FsDeviceConfig],
@@ -1880,6 +1894,8 @@ fn attach_fs_devices(
     #[cfg(not(feature = "tee"))] export_table: Option<ExportTable>,
     intc: IrqChip,
     exit_code: Arc<AtomicI32>,
+    exit_request: Arc<AtomicBool>,
+    exit_evt: EventFd,
     #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
@@ -1890,7 +1906,12 @@ fn attach_fs_devices(
                 config.fs_id.clone(),
                 config.shared_dir.clone(),
                 exit_code.clone(),
+                exit_request.clone(),
                 config.allow_root_dir_delete,
+                exit_evt
+                    .try_clone()
+                    .map_err(Error::EventFd)
+                    .map_err(Internal)?,
             )
             .unwrap(),
         ));


### PR DESCRIPTION
Split guest exit-code reporting from VM-exit signaling in the virtio-fs path.

Guest exit status reporting and VM termination are different operations and
should not depend on reboot semantics.

Keep KRUN_EXIT_CODE_IOCTL for recording the guest exit status, and add
KRUN_EXIT_VM_IOCTL for explicitly requesting VM exit. Update init.krun to
call sync() and send the explicit VM-exit request instead of rebooting the
guest, and thread the exit request through the virtio-fs device/server/worker
path so the worker signals exit_evt only for the explicit VM-exit request.

This keeps the change focused on the virtio-fs exit protocol and avoids
mixing in unrelated init cleanups.
