### PR TITLE
virtio/console: Fixed libkrun panic caused by console resizing during VM startup

### DIFF
--- a/src/devices/src/virtio/console/event_handler.rs
+++ b/src/devices/src/virtio/console/event_handler.rs
@@ -112,14 +112,19 @@ impl Subscriber for Console {
     fn process(&mut self, event: &EpollEvent, event_manager: &mut EventManager) {
         let source = event.fd();
 
-        let control_rxq = self.queue_events[CONTROL_RXQ_INDEX].as_raw_fd();
-        let control_txq = self.queue_events[CONTROL_TXQ_INDEX].as_raw_fd();
-        let control_rxq_control = self.control.queue_evt().as_raw_fd();
-
         let activate_evt = self.activate_evt.as_raw_fd();
         let sigwinch_evt = self.sigwinch_evt.as_raw_fd();
 
         if self.is_activated() {
+            // interest_list() registers sigwinch_evt and control.queue_evt() with
+            // epoll at creation time, but queue_events is only populated later in
+            // activate(). If a spurious event arrives before activation, indexing
+            // into the empty queue_events would panic — so these must stay inside
+            // the is_activated() guard.
+            let control_rxq = self.queue_events[CONTROL_RXQ_INDEX].as_raw_fd();
+            let control_txq = self.queue_events[CONTROL_TXQ_INDEX].as_raw_fd();
+            let control_rxq_control = self.control.queue_evt().as_raw_fd();
+
             let mut raise_irq = false;
 
             if source == control_txq {


### PR DESCRIPTION
when vm booting, and console resize happened, libkrun crash immediately:
```
thread '<unnamed>' (2610281) panicked at src/devices/src/virtio/console/event_handler.rs:115:44:index out of bounds: the len is 0 but the index is 2
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
Before this fix, `process()` read `self.queue_events[CONTROL_RXQ_INDEX]` and `self.queue_events[CONTROL_TXQ_INDEX]` before checking `self.is_activated()`. 

If a spurious pre-activation event arrived(says console resize), `queue_events` was still empty and the handler could panic with an out-of-bounds index.