### PR TITLE
tests: create /dev /proc /sys in temporary rootfs before boot

### DIFF
--- a/src/vmm/src/vmm_config/kernel_cmdline.rs
+++ b/src/vmm/src/vmm_config/kernel_cmdline.rs
@@ -5,10 +5,10 @@ use std::fmt::{Display, Formatter, Result};
 
 #[cfg(target_os = "linux")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
-                                          rootfstype=virtiofs rw quiet no-kvmapf";
+                                          root=/dev/root rootfstype=virtiofs rw quiet no-kvmapf";
 #[cfg(target_os = "macos")]
 pub const DEFAULT_KERNEL_CMDLINE: &str = "reboot=k panic=-1 panic_print=0 nomodule console=hvc0 \
-                                          rootfstype=virtiofs rw quiet no-kvmapf";
+                                          root=/dev/root rootfstype=virtiofs rw quiet no-kvmapf";
 
 /// Strongly typed data structure used to configure the boot source of the
 /// microvm.

--- a/tests/test_cases/src/common.rs
+++ b/tests/test_cases/src/common.rs
@@ -3,7 +3,7 @@
 use anyhow::Context;
 use std::ffi::CString;
 use std::fs;
-use std::fs::create_dir;
+use std::fs::{create_dir, create_dir_all};
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::ptr::null;
@@ -30,6 +30,9 @@ fn copy_guest_agent(dir: &Path) -> anyhow::Result<()> {
 pub fn setup_fs_and_enter(ctx: u32, test_setup: TestSetup) -> anyhow::Result<()> {
     let root_dir = test_setup.tmp_dir.join("root");
     create_dir(&root_dir).context("Failed to create root directory")?;
+    create_dir_all(root_dir.join("dev")).context("Failed to create /dev in rootfs")?;
+    create_dir_all(root_dir.join("proc")).context("Failed to create /proc in rootfs")?;
+    create_dir_all(root_dir.join("sys")).context("Failed to create /sys in rootfs")?;
 
     let path_str = CString::new(root_dir.as_os_str().as_bytes()).context("CString::new")?;
     copy_guest_agent(&root_dir)?;


### PR DESCRIPTION
Create mountpoint directories in test rootfs setup so early init mounts (devtmpfs/proc/sysfs) do not fail with ENOENT.

This avoids boot-time errors such as:
`devtmpfs: error mounting -2`.