### PR TITLE
vmm: Fix bzip2 magic header detection

### DIFF
--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1183,7 +1183,7 @@ fn load_external_kernel(
             let data: Vec<u8> = std::fs::read(external_kernel.path.clone())
                 .map_err(StartMicrovmError::ImageBz2OpenKernel)?;
             if let Some(magic) = data
-                .windows(4)
+                .windows(3)
                 .position(|window| window == [b'B', b'Z', b'h'])
             {
                 debug!("Found BZIP2 header on Image file at: 0x{magic:x}");


### PR DESCRIPTION
The bzip2 magic byte search uses `.windows(4)` to produce 4-byte slices, but compares them against the 3-byte pattern `[b'B', b'Z', b'h']`. As a result, we will never see a match. Thus, the bzip2 header is never found, and loading always fails with ImageBz2Invalid (surfacing as EINVAL to callers).
Fix the issue by using `.windows(3)`, matching how the `gzip` path handles its 3-byte magic.