### PR TITLE
virtiofs: support read-only mounts

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -323,6 +323,26 @@ int32_t krun_add_virtiofs2(uint32_t ctx_id,
                            const char *c_path,
                            uint64_t shm_size);
 
+/**
+ * Adds an independent virtio-fs device pointing to a host's directory with a tag. This
+ * variant allows specifying the size of the DAX window and a read-only flag.
+ *
+ * Arguments:
+ *  "ctx_id"         - the configuration context ID.
+ *  "c_tag"          - tag to identify the filesystem in the guest.
+ *  "c_path"         - full path to the directory in the host to be exposed to the guest.
+ *  "shm_size"       - size of the DAX SHM window in bytes.
+ *  "read_only"      - if true, the filesystem will be exposed as read-only to the guest.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_add_virtiofs3(uint32_t ctx_id,
+                           const char *c_tag,
+                           const char *c_path,
+                           uint64_t shm_size,
+                           bool read_only);
+
 /* Send the VFKIT magic after establishing the connection,
    as required by gvproxy in vfkit mode. */
 #define NET_FLAG_VFKIT 1 << 0

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -13,7 +13,8 @@ use virtio_bindings::{virtio_config::VIRTIO_F_VERSION_1, virtio_ring::VIRTIO_RIN
 use vm_memory::{ByteValued, GuestMemoryMmap};
 
 use super::super::{
-    ActivateResult, DeviceQueue, DeviceState, FsError, QueueConfig, VirtioDevice, VirtioShmRegion,
+    ActivateError, ActivateResult, DeviceQueue, DeviceState, FsError, QueueConfig, VirtioDevice,
+    VirtioShmRegion,
 };
 use super::passthrough;
 use super::worker::FsWorker;
@@ -46,6 +47,7 @@ pub struct Fs {
     config: VirtioFsConfig,
     shm_region: Option<VirtioShmRegion>,
     passthrough_cfg: passthrough::Config,
+    read_only: bool,
     worker_thread: Option<JoinHandle<()>>,
     worker_stopfd: EventFd,
     exit_code: Arc<AtomicI32>,
@@ -59,6 +61,7 @@ impl Fs {
         shared_dir: String,
         exit_code: Arc<AtomicI32>,
         allow_root_dir_delete: bool,
+        read_only: bool,
     ) -> super::Result<Fs> {
         let avail_features = (1u64 << VIRTIO_F_VERSION_1) | (1u64 << VIRTIO_RING_F_EVENT_IDX);
 
@@ -80,6 +83,7 @@ impl Fs {
             config,
             shm_region: None,
             passthrough_cfg: fs_cfg,
+            read_only,
             worker_thread: None,
             worker_stopfd: EventFd::new(EFD_NONBLOCK).map_err(FsError::EventFd)?,
             exit_code,
@@ -183,11 +187,16 @@ impl VirtioDevice for Fs {
             mem.clone(),
             self.shm_region.clone(),
             self.passthrough_cfg.clone(),
+            self.read_only,
             self.worker_stopfd.try_clone().unwrap(),
             self.exit_code.clone(),
             #[cfg(target_os = "macos")]
             self.map_sender.clone(),
-        );
+        )
+        .map_err(|e| {
+            error!("virtio_fs: failed to create worker: {}", e);
+            ActivateError::BadActivate
+        })?;
         self.worker_thread = Some(worker.run());
 
         self.device_state = DeviceState::Activated(mem, interrupt);

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use std::collections::btree_map;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
-use std::collections::btree_map;
 use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
@@ -16,13 +16,13 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
-use crossbeam_channel::{Sender, unbounded};
+use crossbeam_channel::{unbounded, Sender};
 use nix::errno::Errno;
 use utils::worker_message::WorkerMessage;
 
 use crate::virtio::fs::filesystem::SecContext;
 
-use super::super::super::linux_errno::{LINUX_ERANGE, linux_error};
+use super::super::super::linux_errno::{linux_error, LINUX_ERANGE};
 use super::super::bindings;
 use super::super::filesystem::{
     Context, DirEntry, Entry, ExportTable, Extensions, FileSystem, FsOptions, GetxattrReply,

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::collections::btree_map;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::btree_map;
 use std::ffi::{CStr, CString};
 use std::fs::File;
 use std::io;
@@ -16,13 +16,13 @@ use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 
-use crossbeam_channel::{unbounded, Sender};
+use crossbeam_channel::{Sender, unbounded};
 use nix::errno::Errno;
 use utils::worker_message::WorkerMessage;
 
 use crate::virtio::fs::filesystem::SecContext;
 
-use super::super::super::linux_errno::{linux_error, LINUX_ERANGE};
+use super::super::super::linux_errno::{LINUX_ERANGE, linux_error};
 use super::super::bindings;
 use super::super::filesystem::{
     Context, DirEntry, Entry, ExportTable, Extensions, FileSystem, FsOptions, GetxattrReply,
@@ -2313,6 +2313,12 @@ impl FileSystem for PassthroughFs {
             return Err(linux_error(io::Error::from_raw_os_error(libc::ENOSYS)));
         }
 
+        let open_flags = if (flags & fuse::SetupmappingFlags::WRITE.bits()) != 0 {
+            libc::O_RDWR
+        } else {
+            libc::O_RDONLY
+        };
+
         let prot_flags = if (flags & fuse::SetupmappingFlags::WRITE.bits()) != 0 {
             libc::PROT_READ | libc::PROT_WRITE
         } else {
@@ -2327,7 +2333,7 @@ impl FileSystem for PassthroughFs {
 
         debug!("setupmapping: ino {inode:?} guest_addr={guest_addr:x} len={len}");
 
-        let file = self.open_inode(inode, libc::O_RDWR)?;
+        let file = self.open_inode(inode, open_flags)?;
         let fd = file.as_raw_fd();
 
         let host_addr = unsafe {
@@ -2344,10 +2350,7 @@ impl FileSystem for PassthroughFs {
             return Err(linux_error(io::Error::last_os_error()));
         }
 
-        let ret = unsafe { libc::close(fd) };
-        if ret == -1 {
-            return Err(linux_error(io::Error::last_os_error()));
-        }
+        drop(file);
 
         // We've checked that map_sender is something above.
         let sender = map_sender.as_ref().unwrap();

--- a/src/devices/src/virtio/fs/mod.rs
+++ b/src/devices/src/virtio/fs/mod.rs
@@ -4,6 +4,7 @@ mod filesystem;
 pub mod fuse;
 #[allow(dead_code)]
 mod multikey;
+mod read_only;
 mod server;
 mod worker;
 

--- a/src/devices/src/virtio/fs/read_only.rs
+++ b/src/devices/src/virtio/fs/read_only.rs
@@ -1,0 +1,479 @@
+// Read-only wrapper for PassthroughFs.
+//
+// Delegates all read-only FUSE operations to the inner PassthroughFs and
+// rejects all mutating operations with EROFS (read-only filesystem).
+//
+// IMPORTANT: When adding new methods to the FileSystem trait, review this
+// wrapper to ensure mutating operations are explicitly blocked with EROFS.
+// Unoverridden methods fall back to the trait defaults (which return ENOSYS),
+// so the wrapper fails closed -- but new methods should still be explicitly
+// handled here for correct error semantics.
+
+#[cfg(target_os = "macos")]
+use crossbeam_channel::Sender;
+use std::ffi::CStr;
+use std::io;
+use std::sync::atomic::AtomicI32;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[cfg(target_os = "macos")]
+use utils::worker_message::WorkerMessage;
+
+use super::filesystem::{
+    Context, DirEntry, Entry, Extensions, FileSystem, FsOptions, GetxattrReply, ListxattrReply,
+    OpenOptions, SetattrValid, ZeroCopyReader, ZeroCopyWriter,
+};
+use super::fuse;
+use super::passthrough::{self, PassthroughFs};
+use crate::virtio::bindings;
+
+type Inode = u64;
+type Handle = u64;
+
+fn erofs() -> io::Error {
+    io::Error::from_raw_os_error(libc::EROFS)
+}
+
+pub struct PassthroughFsRo {
+    inner: PassthroughFs,
+}
+
+impl PassthroughFsRo {
+    pub fn new(cfg: passthrough::Config) -> io::Result<Self> {
+        Ok(Self {
+            inner: PassthroughFs::new(cfg)?,
+        })
+    }
+}
+
+impl FileSystem for PassthroughFsRo {
+    type Inode = Inode;
+    type Handle = Handle;
+
+    // --- Delegated read-only operations ---
+
+    fn init(&self, capable: FsOptions) -> io::Result<FsOptions> {
+        let opts = self.inner.init(capable)?;
+        // Strip WRITEBACK_CACHE to prevent the guest kernel from buffering writes.
+        Ok(opts & !FsOptions::WRITEBACK_CACHE)
+    }
+
+    fn destroy(&self) {
+        self.inner.destroy()
+    }
+
+    fn lookup(&self, ctx: Context, parent: Inode, name: &CStr) -> io::Result<Entry> {
+        self.inner.lookup(ctx, parent, name)
+    }
+
+    fn forget(&self, ctx: Context, inode: Inode, count: u64) {
+        self.inner.forget(ctx, inode, count)
+    }
+
+    fn batch_forget(&self, ctx: Context, requests: Vec<(Inode, u64)>) {
+        self.inner.batch_forget(ctx, requests)
+    }
+
+    fn getattr(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Option<Handle>,
+    ) -> io::Result<(bindings::stat64, Duration)> {
+        self.inner.getattr(ctx, inode, handle)
+    }
+
+    fn readlink(&self, ctx: Context, inode: Inode) -> io::Result<Vec<u8>> {
+        self.inner.readlink(ctx, inode)
+    }
+
+    fn open(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        kill_priv: bool,
+        flags: u32,
+    ) -> io::Result<(Option<Handle>, OpenOptions)> {
+        let f = flags as i32;
+        let accmode = f & libc::O_ACCMODE;
+        if accmode != libc::O_RDONLY {
+            return Err(erofs());
+        }
+        if f & libc::O_TRUNC != 0 || f & libc::O_APPEND != 0 {
+            return Err(erofs());
+        }
+        #[cfg(target_os = "linux")]
+        if f & libc::O_TMPFILE != 0 {
+            return Err(erofs());
+        }
+        // Force O_RDONLY on the underlying call.
+        let ro_flags = (flags & !(libc::O_ACCMODE as u32)) | (libc::O_RDONLY as u32);
+        self.inner.open(ctx, inode, kill_priv, ro_flags)
+    }
+
+    fn read<W: io::Write + ZeroCopyWriter>(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        w: W,
+        size: u32,
+        offset: u64,
+        lock_owner: Option<u64>,
+        flags: u32,
+    ) -> io::Result<usize> {
+        self.inner
+            .read(ctx, inode, handle, w, size, offset, lock_owner, flags)
+    }
+
+    fn flush(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        lock_owner: u64,
+    ) -> io::Result<()> {
+        self.inner.flush(ctx, inode, handle, lock_owner)
+    }
+
+    fn fsync(&self, ctx: Context, inode: Inode, datasync: bool, handle: Handle) -> io::Result<()> {
+        self.inner.fsync(ctx, inode, datasync, handle)
+    }
+
+    fn release(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        flags: u32,
+        handle: Handle,
+        flush: bool,
+        flock_release: bool,
+        lock_owner: Option<u64>,
+    ) -> io::Result<()> {
+        self.inner
+            .release(ctx, inode, flags, handle, flush, flock_release, lock_owner)
+    }
+
+    fn statfs(&self, ctx: Context, inode: Inode) -> io::Result<bindings::statvfs64> {
+        let mut st = self.inner.statfs(ctx, inode)?;
+        st.f_flag |= libc::ST_RDONLY;
+        Ok(st)
+    }
+
+    fn getxattr(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        name: &CStr,
+        size: u32,
+    ) -> io::Result<GetxattrReply> {
+        self.inner.getxattr(ctx, inode, name, size)
+    }
+
+    fn listxattr(&self, ctx: Context, inode: Inode, size: u32) -> io::Result<ListxattrReply> {
+        self.inner.listxattr(ctx, inode, size)
+    }
+
+    fn opendir(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        flags: u32,
+    ) -> io::Result<(Option<Handle>, OpenOptions)> {
+        let f = flags as i32;
+        let accmode = f & libc::O_ACCMODE;
+        if accmode != libc::O_RDONLY {
+            return Err(erofs());
+        }
+        // Force O_RDONLY on the underlying call.
+        let ro_flags = (flags & !(libc::O_ACCMODE as u32)) | (libc::O_RDONLY as u32);
+        self.inner.opendir(ctx, inode, ro_flags)
+    }
+
+    fn readdir<F>(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        size: u32,
+        offset: u64,
+        add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry) -> io::Result<usize>,
+    {
+        self.inner
+            .readdir(ctx, inode, handle, size, offset, add_entry)
+    }
+
+    fn readdirplus<F>(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        size: u32,
+        offset: u64,
+        add_entry: F,
+    ) -> io::Result<()>
+    where
+        F: FnMut(DirEntry, Entry) -> io::Result<usize>,
+    {
+        self.inner
+            .readdirplus(ctx, inode, handle, size, offset, add_entry)
+    }
+
+    fn fsyncdir(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        datasync: bool,
+        handle: Handle,
+    ) -> io::Result<()> {
+        self.inner.fsyncdir(ctx, inode, datasync, handle)
+    }
+
+    fn releasedir(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        flags: u32,
+        handle: Handle,
+    ) -> io::Result<()> {
+        self.inner.releasedir(ctx, inode, flags, handle)
+    }
+
+    fn access(&self, ctx: Context, inode: Inode, mask: u32) -> io::Result<()> {
+        if mask & (libc::W_OK as u32) != 0 {
+            return Err(erofs());
+        }
+        self.inner.access(ctx, inode, mask)
+    }
+
+    fn lseek(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        offset: u64,
+        whence: u32,
+    ) -> io::Result<u64> {
+        self.inner.lseek(ctx, inode, handle, offset, whence)
+    }
+
+    fn setupmapping(
+        &self,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        foffset: u64,
+        len: u64,
+        flags: u64,
+        moffset: u64,
+        host_shm_base: u64,
+        shm_size: u64,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
+    ) -> io::Result<()> {
+        // Reject writable mappings.
+        if (flags & fuse::SetupmappingFlags::WRITE.bits()) != 0 {
+            return Err(erofs());
+        }
+        self.inner.setupmapping(
+            ctx,
+            inode,
+            handle,
+            foffset,
+            len,
+            flags,
+            moffset,
+            host_shm_base,
+            shm_size,
+            #[cfg(target_os = "macos")]
+            map_sender,
+        )
+    }
+
+    fn removemapping(
+        &self,
+        ctx: Context,
+        requests: Vec<fuse::RemovemappingOne>,
+        host_shm_base: u64,
+        shm_size: u64,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
+    ) -> io::Result<()> {
+        self.inner.removemapping(
+            ctx,
+            requests,
+            host_shm_base,
+            shm_size,
+            #[cfg(target_os = "macos")]
+            map_sender,
+        )
+    }
+
+    fn ioctl(
+        &self,
+        _ctx: Context,
+        _inode: Inode,
+        _handle: Handle,
+        _flags: u32,
+        _cmd: u32,
+        _arg: u64,
+        _in_size: u32,
+        _out_size: u32,
+        _exit_code: &Arc<AtomicI32>,
+    ) -> io::Result<Vec<u8>> {
+        Err(erofs())
+    }
+
+    // --- Write operations rejected with EROFS ---
+
+    fn setattr(
+        &self,
+        _ctx: Context,
+        _inode: Inode,
+        _attr: bindings::stat64,
+        _handle: Option<Handle>,
+        _valid: SetattrValid,
+    ) -> io::Result<(bindings::stat64, Duration)> {
+        Err(erofs())
+    }
+
+    fn symlink(
+        &self,
+        _ctx: Context,
+        _linkname: &CStr,
+        _parent: Inode,
+        _name: &CStr,
+        _extensions: Extensions,
+    ) -> io::Result<Entry> {
+        Err(erofs())
+    }
+
+    fn mknod(
+        &self,
+        _ctx: Context,
+        _inode: Inode,
+        _name: &CStr,
+        _mode: u32,
+        _rdev: u32,
+        _umask: u32,
+        _extensions: Extensions,
+    ) -> io::Result<Entry> {
+        Err(erofs())
+    }
+
+    fn mkdir(
+        &self,
+        _ctx: Context,
+        _parent: Inode,
+        _name: &CStr,
+        _mode: u32,
+        _umask: u32,
+        _extensions: Extensions,
+    ) -> io::Result<Entry> {
+        Err(erofs())
+    }
+
+    fn unlink(&self, _ctx: Context, _parent: Inode, _name: &CStr) -> io::Result<()> {
+        Err(erofs())
+    }
+
+    fn rmdir(&self, _ctx: Context, _parent: Inode, _name: &CStr) -> io::Result<()> {
+        Err(erofs())
+    }
+
+    fn rename(
+        &self,
+        _ctx: Context,
+        _olddir: Inode,
+        _oldname: &CStr,
+        _newdir: Inode,
+        _newname: &CStr,
+        _flags: u32,
+    ) -> io::Result<()> {
+        Err(erofs())
+    }
+
+    fn link(
+        &self,
+        _ctx: Context,
+        _inode: Inode,
+        _newparent: Inode,
+        _newname: &CStr,
+    ) -> io::Result<Entry> {
+        Err(erofs())
+    }
+
+    fn create(
+        &self,
+        _ctx: Context,
+        _parent: Inode,
+        _name: &CStr,
+        _mode: u32,
+        _kill_priv: bool,
+        _flags: u32,
+        _umask: u32,
+        _extensions: Extensions,
+    ) -> io::Result<(Entry, Option<Handle>, OpenOptions)> {
+        Err(erofs())
+    }
+
+    fn write<R: io::Read + ZeroCopyReader>(
+        &self,
+        _ctx: Context,
+        _inode: Inode,
+        _handle: Handle,
+        _r: R,
+        _size: u32,
+        _offset: u64,
+        _lock_owner: Option<u64>,
+        _delayed_write: bool,
+        _kill_priv: bool,
+        _flags: u32,
+    ) -> io::Result<usize> {
+        Err(erofs())
+    }
+
+    fn fallocate(
+        &self,
+        _ctx: Context,
+        _inode: Inode,
+        _handle: Handle,
+        _mode: u32,
+        _offset: u64,
+        _length: u64,
+    ) -> io::Result<()> {
+        Err(erofs())
+    }
+
+    fn setxattr(
+        &self,
+        _ctx: Context,
+        _inode: Inode,
+        _name: &CStr,
+        _value: &[u8],
+        _flags: u32,
+    ) -> io::Result<()> {
+        Err(erofs())
+    }
+
+    fn removexattr(&self, _ctx: Context, _inode: Inode, _name: &CStr) -> io::Result<()> {
+        Err(erofs())
+    }
+
+    fn copyfilerange(
+        &self,
+        _ctx: Context,
+        _inode_in: Inode,
+        _handle_in: Handle,
+        _offset_in: u64,
+        _inode_out: Inode,
+        _handle_out: Handle,
+        _offset_out: u64,
+        _len: u64,
+        _flags: u64,
+    ) -> io::Result<usize> {
+        Err(erofs())
+    }
+}

--- a/src/devices/src/virtio/fs/read_only.rs
+++ b/src/devices/src/virtio/fs/read_only.rs
@@ -13,8 +13,8 @@
 use crossbeam_channel::Sender;
 use std::ffi::CStr;
 use std::io;
-use std::sync::Arc;
 use std::sync::atomic::AtomicI32;
+use std::sync::Arc;
 use std::time::Duration;
 
 #[cfg(target_os = "macos")]
@@ -34,6 +34,10 @@ type Handle = u64;
 fn erofs() -> io::Error {
     io::Error::from_raw_os_error(libc::EROFS)
 }
+
+// Keep the Linux ioctl number so read-only virtio-fs can still handle
+// non-mutating control ioctls while rejecting host-side root deletion.
+const VIRTIO_IOC_REMOVE_ROOT_DIR_REQ: u32 = 0x7603;
 
 fn read_only_open_flags(flags: u32) -> io::Result<u32> {
     let f = flags as i32;
@@ -304,17 +308,23 @@ impl FileSystem for PassthroughFsRo {
 
     fn ioctl(
         &self,
-        _ctx: Context,
-        _inode: Inode,
-        _handle: Handle,
-        _flags: u32,
-        _cmd: u32,
-        _arg: u64,
-        _in_size: u32,
-        _out_size: u32,
-        _exit_code: &Arc<AtomicI32>,
+        ctx: Context,
+        inode: Inode,
+        handle: Handle,
+        flags: u32,
+        cmd: u32,
+        arg: u64,
+        in_size: u32,
+        out_size: u32,
+        exit_code: &Arc<AtomicI32>,
     ) -> io::Result<Vec<u8>> {
-        Err(erofs())
+        if cmd == VIRTIO_IOC_REMOVE_ROOT_DIR_REQ {
+            return Err(erofs());
+        }
+
+        self.inner.ioctl(
+            ctx, inode, handle, flags, cmd, arg, in_size, out_size, exit_code,
+        )
     }
 
     // --- Write operations rejected with EROFS ---

--- a/src/devices/src/virtio/fs/read_only.rs
+++ b/src/devices/src/virtio/fs/read_only.rs
@@ -13,8 +13,8 @@
 use crossbeam_channel::Sender;
 use std::ffi::CStr;
 use std::io;
-use std::sync::atomic::AtomicI32;
 use std::sync::Arc;
+use std::sync::atomic::AtomicI32;
 use std::time::Duration;
 
 #[cfg(target_os = "macos")]
@@ -33,6 +33,22 @@ type Handle = u64;
 
 fn erofs() -> io::Error {
     io::Error::from_raw_os_error(libc::EROFS)
+}
+
+fn read_only_open_flags(flags: u32) -> io::Result<u32> {
+    let f = flags as i32;
+    if f & libc::O_ACCMODE != libc::O_RDONLY {
+        return Err(erofs());
+    }
+    if f & libc::O_TRUNC != 0 {
+        return Err(erofs());
+    }
+    #[cfg(target_os = "linux")]
+    if f & libc::O_TMPFILE != 0 {
+        return Err(erofs());
+    }
+
+    Ok((flags & !(libc::O_ACCMODE as u32)) | (libc::O_RDONLY as u32))
 }
 
 pub struct PassthroughFsRo {
@@ -95,20 +111,7 @@ impl FileSystem for PassthroughFsRo {
         kill_priv: bool,
         flags: u32,
     ) -> io::Result<(Option<Handle>, OpenOptions)> {
-        let f = flags as i32;
-        let accmode = f & libc::O_ACCMODE;
-        if accmode != libc::O_RDONLY {
-            return Err(erofs());
-        }
-        if f & libc::O_TRUNC != 0 || f & libc::O_APPEND != 0 {
-            return Err(erofs());
-        }
-        #[cfg(target_os = "linux")]
-        if f & libc::O_TMPFILE != 0 {
-            return Err(erofs());
-        }
-        // Force O_RDONLY on the underlying call.
-        let ro_flags = (flags & !(libc::O_ACCMODE as u32)) | (libc::O_RDONLY as u32);
+        let ro_flags = read_only_open_flags(flags)?;
         self.inner.open(ctx, inode, kill_priv, ro_flags)
     }
 
@@ -127,13 +130,7 @@ impl FileSystem for PassthroughFsRo {
             .read(ctx, inode, handle, w, size, offset, lock_owner, flags)
     }
 
-    fn flush(
-        &self,
-        ctx: Context,
-        inode: Inode,
-        handle: Handle,
-        lock_owner: u64,
-    ) -> io::Result<()> {
+    fn flush(&self, ctx: Context, inode: Inode, handle: Handle, lock_owner: u64) -> io::Result<()> {
         self.inner.flush(ctx, inode, handle, lock_owner)
     }
 
@@ -233,13 +230,7 @@ impl FileSystem for PassthroughFsRo {
         self.inner.fsyncdir(ctx, inode, datasync, handle)
     }
 
-    fn releasedir(
-        &self,
-        ctx: Context,
-        inode: Inode,
-        flags: u32,
-        handle: Handle,
-    ) -> io::Result<()> {
+    fn releasedir(&self, ctx: Context, inode: Inode, flags: u32, handle: Handle) -> io::Result<()> {
         self.inner.releasedir(ctx, inode, flags, handle)
     }
 
@@ -475,5 +466,33 @@ impl FileSystem for PassthroughFsRo {
         _flags: u64,
     ) -> io::Result<usize> {
         Err(erofs())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::read_only_open_flags;
+
+    #[test]
+    fn read_only_open_flags_allow_append() {
+        let flags = (libc::O_RDONLY | libc::O_APPEND) as u32;
+        let ro_flags = read_only_open_flags(flags).unwrap();
+
+        assert_eq!((ro_flags as i32) & libc::O_ACCMODE, libc::O_RDONLY);
+        assert_ne!((ro_flags as i32) & libc::O_APPEND, 0);
+    }
+
+    #[test]
+    fn read_only_open_flags_reject_write_access() {
+        let err = read_only_open_flags(libc::O_WRONLY as u32).unwrap_err();
+
+        assert_eq!(err.raw_os_error(), Some(libc::EROFS));
+    }
+
+    #[test]
+    fn read_only_open_flags_reject_truncate() {
+        let err = read_only_open_flags((libc::O_RDONLY | libc::O_TRUNC) as u32).unwrap_err();
+
+        assert_eq!(err.raw_os_error(), Some(libc::EROFS));
     }
 }

--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -3,6 +3,7 @@ use crossbeam_channel::Sender;
 #[cfg(target_os = "macos")]
 use utils::worker_message::WorkerMessage;
 
+use std::io;
 use std::os::fd::AsRawFd;
 use std::sync::atomic::AtomicI32;
 use std::sync::Arc;
@@ -16,8 +17,44 @@ use super::super::{FsError, Queue};
 use super::defs::{HPQ_INDEX, REQ_INDEX};
 use super::descriptor_utils::{Reader, Writer};
 use super::passthrough::{self, PassthroughFs};
+use super::read_only::PassthroughFsRo;
 use super::server::Server;
 use crate::virtio::{InterruptTransport, VirtioShmRegion};
+
+enum FsServer {
+    ReadWrite(Server<PassthroughFs>),
+    ReadOnly(Server<PassthroughFsRo>),
+}
+
+impl FsServer {
+    fn handle_message(
+        &self,
+        r: Reader,
+        w: Writer,
+        shm_region: &Option<VirtioShmRegion>,
+        exit_code: &Arc<AtomicI32>,
+        #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
+    ) -> super::Result<usize> {
+        match self {
+            FsServer::ReadWrite(s) => s.handle_message(
+                r,
+                w,
+                shm_region,
+                exit_code,
+                #[cfg(target_os = "macos")]
+                map_sender,
+            ),
+            FsServer::ReadOnly(s) => s.handle_message(
+                r,
+                w,
+                shm_region,
+                exit_code,
+                #[cfg(target_os = "macos")]
+                map_sender,
+            ),
+        }
+    }
+}
 
 pub struct FsWorker {
     queues: Vec<Queue>,
@@ -25,7 +62,7 @@ pub struct FsWorker {
     interrupt: InterruptTransport,
     mem: GuestMemoryMmap,
     shm_region: Option<VirtioShmRegion>,
-    server: Server<PassthroughFs>,
+    server: FsServer,
     stop_fd: EventFd,
     exit_code: Arc<AtomicI32>,
     #[cfg(target_os = "macos")]
@@ -41,22 +78,28 @@ impl FsWorker {
         mem: GuestMemoryMmap,
         shm_region: Option<VirtioShmRegion>,
         passthrough_cfg: passthrough::Config,
+        read_only: bool,
         stop_fd: EventFd,
         exit_code: Arc<AtomicI32>,
         #[cfg(target_os = "macos")] map_sender: Option<Sender<WorkerMessage>>,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, io::Error> {
+        let server = if read_only {
+            FsServer::ReadOnly(Server::new(PassthroughFsRo::new(passthrough_cfg)?))
+        } else {
+            FsServer::ReadWrite(Server::new(PassthroughFs::new(passthrough_cfg)?))
+        };
+        Ok(Self {
             queues,
             queue_evts,
             interrupt,
             mem,
             shm_region,
-            server: Server::new(PassthroughFs::new(passthrough_cfg).unwrap()),
+            server,
             stop_fd,
             exit_code,
             #[cfg(target_os = "macos")]
             map_sender,
-        }
+        })
     }
 
     pub fn run(self) -> thread::JoinHandle<()> {

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -595,6 +595,7 @@ pub unsafe extern "C" fn krun_set_root(ctx_id: u32, c_root_path: *const c_char) 
                 // Default to a conservative 512 MB window.
                 shm_size: Some(1 << 29),
                 allow_root_dir_delete: false,
+                read_only: false,
             });
         }
         Entry::Vacant(_) => return -libc::ENOENT,
@@ -611,29 +612,7 @@ pub unsafe extern "C" fn krun_add_virtiofs(
     c_tag: *const c_char,
     c_path: *const c_char,
 ) -> i32 {
-    let tag = match CStr::from_ptr(c_tag).to_str() {
-        Ok(tag) => tag,
-        Err(_) => return -libc::EINVAL,
-    };
-    let path = match CStr::from_ptr(c_path).to_str() {
-        Ok(path) => path,
-        Err(_) => return -libc::EINVAL,
-    };
-
-    match CTX_MAP.lock().unwrap().entry(ctx_id) {
-        Entry::Occupied(mut ctx_cfg) => {
-            let cfg = ctx_cfg.get_mut();
-            cfg.vmr.add_fs_device(FsDeviceConfig {
-                fs_id: tag.to_string(),
-                shared_dir: path.to_string(),
-                shm_size: None,
-                allow_root_dir_delete: false,
-            });
-        }
-        Entry::Vacant(_) => return -libc::ENOENT,
-    }
-
-    KRUN_SUCCESS
+    krun_add_virtiofs3(ctx_id, c_tag, c_path, 0, false)
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -645,6 +624,23 @@ pub unsafe extern "C" fn krun_add_virtiofs2(
     c_path: *const c_char,
     shm_size: u64,
 ) -> i32 {
+    krun_add_virtiofs3(ctx_id, c_tag, c_path, shm_size, false)
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[no_mangle]
+#[cfg(not(feature = "tee"))]
+pub unsafe extern "C" fn krun_add_virtiofs3(
+    ctx_id: u32,
+    c_tag: *const c_char,
+    c_path: *const c_char,
+    shm_size: u64,
+    read_only: bool,
+) -> i32 {
+    if c_tag.is_null() || c_path.is_null() {
+        return -libc::EINVAL;
+    }
+
     let tag = match CStr::from_ptr(c_tag).to_str() {
         Ok(tag) => tag,
         Err(_) => return -libc::EINVAL,
@@ -654,14 +650,24 @@ pub unsafe extern "C" fn krun_add_virtiofs2(
         Err(_) => return -libc::EINVAL,
     };
 
+    let shm = if shm_size > 0 {
+        match shm_size.try_into() {
+            Ok(s) => Some(s),
+            Err(_) => return -libc::EINVAL,
+        }
+    } else {
+        None
+    };
+
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
             cfg.vmr.add_fs_device(FsDeviceConfig {
                 fs_id: tag.to_string(),
                 shared_dir: path.to_string(),
-                shm_size: Some(shm_size.try_into().unwrap()),
+                shm_size: shm,
                 allow_root_dir_delete: false,
+                read_only,
             });
         }
         Entry::Vacant(_) => return -libc::ENOENT,
@@ -2294,6 +2300,7 @@ pub unsafe extern "C" fn krun_set_root_disk_remount(
                 // Default to a conservative 512 MB window.
                 shm_size: Some(1 << 29),
                 allow_root_dir_delete: true,
+                read_only: false,
             });
 
             ctx_cfg.set_block_root(device, fstype, options);

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1896,6 +1896,7 @@ fn attach_fs_devices(
                 config.shared_dir.clone(),
                 exit_code.clone(),
                 config.allow_root_dir_delete,
+                config.read_only,
             )
             .unwrap(),
         ));

--- a/src/vmm/src/vmm_config/fs.rs
+++ b/src/vmm/src/vmm_config/fs.rs
@@ -4,4 +4,5 @@ pub struct FsDeviceConfig {
     pub shared_dir: String,
     pub shm_size: Option<usize>,
     pub allow_root_dir_delete: bool,
+    pub read_only: bool,
 }


### PR DESCRIPTION
This PR adds a read-only virtio-fs mode to the public API and wires the new flag through the virtio-fs device configuration, worker setup, and VMM builder so callers can expose shared directories without allowing guest writes.

The implementation wraps the passthrough backend in a read-only filesystem layer that rejects mutating FUSE operations with `EROFS`, disables writeback cache, and still preserves the non-mutating control ioctls the guest uses. On macOS, `setupmapping` now opens the backing file with `O_RDONLY` for read-only mappings, which fixes read-only DAX mounts.

I also changed virtio-fs worker creation to return an activation error instead of panicking if the backend cannot be initialized.