### PR TITLE
Implement support for nested virt on Linux

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -954,9 +954,6 @@ int32_t krun_setgid(uint32_t ctx_id, gid_t gid);
  *  "ctx_id"  - the configuration context ID.
  *  "enabled" - true to enable Nested Virtualization in the microVM.
  *
- * Notes:
- *  This feature is only supported on macOS.
- *
  * Returns:
  *  Zero on success or a negative error number on failure. Success doesn't imply that
  *  Nested Virtualization is supported on the system, only that it's going to be requested

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -964,9 +964,6 @@ int32_t krun_set_nested_virt(uint32_t ctx_id, bool enabled);
 /**
  * Check the system if Nested Virtualization is supported
  *
- * Notes:
- *  This feature is only supported on macOS.
- *
  * Returns:
  *  - 1 : Success and Nested Virtualization is supported
  *  - 0 : Success and Nested Virtualization is not supported

--- a/src/cpuid/src/cpu_leaf.rs
+++ b/src/cpuid/src/cpu_leaf.rs
@@ -34,7 +34,8 @@ pub mod leaf_0x1 {
         pub const MONITOR_BITINDEX: u32 = 3;
         // CPL Qualified Debug Store
         pub const DS_CPL_SHIFT: u32 = 4;
-        // 5 = VMX (Virtual Machine Extensions)
+        // VMX = Virtual Machine Extensions (Intel nested virtualization)
+        pub const VMX_BITINDEX: u32 = 5;
         // 6 = SMX (Safer Mode Extensions)
         // 7 = EIST (Enhanced Intel SpeedStep® technology)
         // TM2 = Thermal Monitor 2
@@ -268,6 +269,8 @@ pub mod leaf_0x80000001 {
     pub const LEAF_NUM: u32 = 0x8000_0001;
 
     pub mod ecx {
+        // SVM = Secure Virtual Machine (AMD nested virtualization)
+        pub const SVM_BITINDEX: u32 = 2;
         pub const TOPOEXT_INDEX: u32 = 22;
         pub const PREFETCH_BITINDEX: u32 = 8; // 3DNow! PREFETCH/PREFETCHW instructions
         pub const LZCNT_BITINDEX: u32 = 5; // advanced bit manipulation

--- a/src/cpuid/src/lib.rs
+++ b/src/cpuid/src/lib.rs
@@ -46,7 +46,7 @@ mod brand_string;
 /// let kvm = Kvm::new().unwrap();
 /// let mut kvm_cpuid: CpuId = kvm.get_supported_cpuid(KVM_MAX_CPUID_ENTRIES).unwrap();
 ///
-/// let vm_spec = VmSpec::new(0, 1, true).unwrap();
+/// let vm_spec = VmSpec::new(0, 1, true, false).unwrap();
 ///
 /// filter_cpuid(&mut kvm_cpuid, &vm_spec).unwrap();
 ///

--- a/src/cpuid/src/transformer/amd.rs
+++ b/src/cpuid/src/transformer/amd.rs
@@ -51,12 +51,18 @@ pub fn update_largest_extended_fn_entry(
 
 pub fn update_extended_feature_info_entry(
     entry: &mut kvm_cpuid_entry2,
-    _vm_spec: &VmSpec,
+    vm_spec: &VmSpec,
 ) -> Result<(), Error> {
     use crate::cpu_leaf::leaf_0x80000001::*;
 
     // set the Topology Extension bit since we use the Extended Cache Topology leaf
     entry.ecx.write_bit(ecx::TOPOEXT_INDEX, true);
+
+    // Advertise SVM only when nested virtualization is enabled AND the host supports it.
+    entry.ecx.write_bit(
+        ecx::SVM_BITINDEX,
+        vm_spec.nested_enabled() && entry.ecx.read_bit(ecx::SVM_BITINDEX),
+    );
 
     Ok(())
 }
@@ -159,7 +165,7 @@ mod tests {
         use crate::cpu_leaf::leaf_0x7::index0::*;
 
         // Check that if index == 0 the entry is processed
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: leaf_0x7::LEAF_NUM,
             index: 0,
@@ -184,7 +190,7 @@ mod tests {
     fn test_update_largest_extended_fn_entry() {
         use crate::cpu_leaf::leaf_0x80000000::*;
 
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -210,7 +216,7 @@ mod tests {
     fn test_update_extended_feature_info_entry() {
         use crate::cpu_leaf::leaf_0x80000001::*;
 
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -230,7 +236,7 @@ mod tests {
     fn check_update_amd_features_entry(cpu_count: u8, ht_enabled: bool) {
         use crate::cpu_leaf::leaf_0x80000008::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -263,7 +269,8 @@ mod tests {
     ) {
         use crate::cpu_leaf::leaf_0x8000001e::*;
 
-        let vm_spec = VmSpec::new(cpu_id, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec =
+            VmSpec::new(cpu_id, cpu_count, ht_enabled, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: LEAF_NUM,
             index: 0,
@@ -306,7 +313,7 @@ mod tests {
 
     #[test]
     fn test_update_extended_cache_topology_entry() {
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: leaf_0x8000001d::LEAF_NUM,
             index: 0,

--- a/src/cpuid/src/transformer/common.rs
+++ b/src/cpuid/src/transformer/common.rs
@@ -151,7 +151,7 @@ mod tests {
     fn check_update_feature_info_entry(cpu_count: u8, expected_htt: bool) {
         use crate::cpu_leaf::leaf_0x1::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, false, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,
@@ -176,7 +176,7 @@ mod tests {
     ) {
         use crate::cpu_leaf::leaf_cache_parameters::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,

--- a/src/cpuid/src/transformer/intel.rs
+++ b/src/cpuid/src/transformer/intel.rs
@@ -17,6 +17,12 @@ pub fn update_feature_info_entry(
 
     common::update_feature_info_entry(entry, vm_spec)?;
 
+    // Advertise VMX only when nested virtualization is enabled AND the host supports it.
+    entry.ecx.write_bit(
+        ecx::VMX_BITINDEX,
+        vm_spec.nested_enabled() && entry.ecx.read_bit(ecx::VMX_BITINDEX),
+    );
+
     // enable X2APIC bit
     #[cfg(feature = "tdx")]
     if entry.index == 0x1 {
@@ -219,7 +225,7 @@ mod tests {
     fn test_update_feature_info_entry() {
         use crate::cpu_leaf::leaf_0x1::*;
 
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: leaf_0x1::LEAF_NUM,
             index: 0,
@@ -238,7 +244,7 @@ mod tests {
 
     #[test]
     fn test_update_perf_mon_entry() {
-        let vm_spec = VmSpec::new(0, 1, false).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, 1, false, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: leaf_0xa::LEAF_NUM,
             index: 0,
@@ -266,7 +272,7 @@ mod tests {
     ) {
         use crate::cpu_leaf::leaf_0x4::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: 0x0,
             index: 0,
@@ -298,7 +304,7 @@ mod tests {
     ) {
         use crate::cpu_leaf::leaf_0xb::*;
 
-        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled).expect("Error creating vm_spec");
+        let vm_spec = VmSpec::new(0, cpu_count, ht_enabled, false).expect("Error creating vm_spec");
         let mut entry = kvm_cpuid_entry2 {
             function: 0x0,
             index,

--- a/src/cpuid/src/transformer/mod.rs
+++ b/src/cpuid/src/transformer/mod.rs
@@ -21,6 +21,8 @@ pub struct VmSpec {
     cpu_count: u8,
     /// Specifies whether hyper-threading is enabled.
     ht_enabled: bool,
+    /// Specifies whether nested virtualization is enabled.
+    nested_enabled: bool,
     /// The desired brand string for the guest.
     brand_string: BrandString,
 }
@@ -28,7 +30,12 @@ pub struct VmSpec {
 impl VmSpec {
     /// Creates a new instance of VmSpec with the specified parameters
     /// The brand string is deduced from the vendor_id
-    pub fn new(cpu_id: u8, cpu_count: u8, ht_enabled: bool) -> Result<VmSpec, Error> {
+    pub fn new(
+        cpu_id: u8,
+        cpu_count: u8,
+        ht_enabled: bool,
+        nested_enabled: bool,
+    ) -> Result<VmSpec, Error> {
         let cpu_vendor_id = get_vendor_id().map_err(Error::InternalError)?;
 
         Ok(VmSpec {
@@ -36,6 +43,7 @@ impl VmSpec {
             cpu_id,
             cpu_count,
             ht_enabled,
+            nested_enabled,
             brand_string: BrandString::from_vendor_id(&cpu_vendor_id),
         })
     }
@@ -43,6 +51,11 @@ impl VmSpec {
     /// Returns an immutable reference to cpu_vendor_id
     pub fn cpu_vendor_id(&self) -> &[u8; 12] {
         &self.cpu_vendor_id
+    }
+
+    /// Returns whether nested virtualization is enabled
+    pub fn nested_enabled(&self) -> bool {
+        self.nested_enabled
     }
 }
 
@@ -117,7 +130,7 @@ mod tests {
         let num_entries = 5;
 
         let mut cpuid = CpuId::new(num_entries).unwrap();
-        let vm_spec = VmSpec::new(0, 1, false);
+        let vm_spec = VmSpec::new(0, 1, false, false);
         cpuid.as_mut_slice()[0].function = PROCESSED_FN;
         assert!(MockCpuidTransformer {}
             .process_cpuid(&mut cpuid, &vm_spec.unwrap())

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1822,10 +1822,6 @@ pub unsafe extern "C" fn krun_set_console_output(ctx_id: u32, c_filepath: *const
 #[allow(clippy::missing_safety_doc)]
 #[no_mangle]
 pub unsafe extern "C" fn krun_set_nested_virt(ctx_id: u32, enabled: bool) -> i32 {
-    if enabled && !cfg!(target_os = "macos") {
-        return -libc::EINVAL;
-    }
-
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1841,7 +1841,25 @@ pub unsafe extern "C" fn krun_check_nested_virt() -> i32 {
         Err(_) => -libc::EINVAL,
     }
 
-    #[cfg(not(target_os = "macos"))]
+    #[cfg(target_os = "linux")]
+    {
+        let paths = [
+            "/sys/module/kvm_intel/parameters/nested",
+            "/sys/module/kvm_amd/parameters/nested",
+        ];
+        if paths.iter().any(|path| {
+            std::fs::read_to_string(path).is_ok_and(|contents| {
+                let val = contents.trim();
+                val == "1" || val.eq_ignore_ascii_case("Y")
+            })
+        }) {
+            1
+        } else {
+            0
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
     -libc::EOPNOTSUPP
 }
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -2368,6 +2368,7 @@ pub mod tests {
             vcpu_count,
             ht_enabled: false,
             cpu_template: None,
+            nested_enabled: false,
         };
 
         let (guest_memory, _arch_memory_info, _shm_manager, _payload_config) =
@@ -2403,6 +2404,7 @@ pub mod tests {
             vcpu_count,
             ht_enabled: false,
             cpu_template: None,
+            nested_enabled: false,
         };
 
         // Dummy entry_addr, vcpus will not boot.

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -912,6 +912,8 @@ pub struct VcpuConfig {
     pub ht_enabled: bool,
     /// CPUID template to use.
     pub cpu_template: Option<CpuFeaturesTemplate>,
+    /// Enable nested virtualization in the CPUID configuration.
+    pub nested_enabled: bool,
 }
 
 // Using this for easier explicit type-casting to help IDEs interpret the code.
@@ -1173,7 +1175,7 @@ impl Vcpu {
             self.id,
             vcpu_config.vcpu_count,
             vcpu_config.ht_enabled,
-            false,
+            vcpu_config.nested_enabled,
         )
         .map_err(Error::CpuId)?;
 
@@ -1898,6 +1900,7 @@ mod tests {
             vcpu_count: 1,
             ht_enabled: false,
             cpu_template: None,
+            nested_enabled: false,
         };
 
         assert!(vcpu

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -1169,8 +1169,13 @@ impl Vcpu {
         vcpu_config: &VcpuConfig,
         kernel_boot: bool,
     ) -> Result<()> {
-        let cpuid_vm_spec = VmSpec::new(self.id, vcpu_config.vcpu_count, vcpu_config.ht_enabled)
-            .map_err(Error::CpuId)?;
+        let cpuid_vm_spec = VmSpec::new(
+            self.id,
+            vcpu_config.vcpu_count,
+            vcpu_config.ht_enabled,
+            false,
+        )
+        .map_err(Error::CpuId)?;
 
         filter_cpuid(&mut self.cpuid, &cpuid_vm_spec).map_err(|e| {
             error!("Failure in configuring CPUID for vcpu {}: {:?}", self.id, e);

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -200,6 +200,8 @@ impl VmResources {
             vcpu_count: self.vm_config().vcpu_count.unwrap(),
             ht_enabled: self.vm_config().ht_enabled.unwrap(),
             cpu_template: self.vm_config().cpu_template,
+            #[cfg(target_os = "linux")]
+            nested_enabled: self.nested_enabled,
         }
     }
 
@@ -441,6 +443,7 @@ mod tests {
             vcpu_count: vm_resources.vm_config().vcpu_count.unwrap(),
             ht_enabled: vm_resources.vm_config().ht_enabled.unwrap(),
             cpu_template: vm_resources.vm_config().cpu_template,
+            nested_enabled: vm_resources.nested_enabled,
         };
 
         let vcpu_config = vm_resources.vcpu_config();


### PR DESCRIPTION
So far, we supported enabling nested virt on macOS but not on Linux. Let's do that now.

Fixes: #625 