### PR TITLE
devices/mmio: Read QueueSizeMax from queue_config instead of actual queues

### DIFF
--- a/src/devices/src/virtio/mmio.rs
+++ b/src/devices/src/virtio/mmio.rs
@@ -391,7 +391,10 @@ impl BusDevice for MmioTransport {
                         }
                         features
                     }
-                    0x34 => self.with_queue(0, |q| u32::from(q.get_max_size())),
+                    0x34 => self
+                        .queue_config
+                        .get(self.queue_select as usize)
+                        .map_or(0, |c| c.size as u32),
                     0x44 => self.with_queue(0, |q| q.ready as u32),
                     0x60 => self.interrupt.status().load(Ordering::SeqCst) as u32,
                     0x70 => self.device_status,


### PR DESCRIPTION
Commit c87386cc refactored queue ownership so transport queues are
moved to the device backend on activation (self.queues = None).
This caused QueueSizeMax to return 0 if device state prevented
recreating the queues (e.g. failed reset), making FreeBSD give up.
 
This change restores the previous behavior where QueueSizeMax can always be reported regardless of device status. 

Note: there is still an underlying problem - the lack of proper device reset support in the net device which would have probably fixed this too (but we need to implement reset for every device).

Fixes: #626
