### PR TITLE
Add `KRUN_FS_ROOT_TAG` define and document `krun_set_root` alternative

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -98,7 +98,16 @@ int32_t krun_free_ctx(uint32_t ctx_id);
 int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib);
 
 /**
+ * The virtiofs tag used for the root filesystem. Can be used with krun_add_virtiofs*
+ * for more control over root filesystem parameters (e.g. read-only, DAX window size).
+ */
+#define KRUN_FS_ROOT_TAG "/dev/root"
+
+/**
  * Sets the path to be use as root for the microVM. Not available in libkrun-SEV.
+ *
+ * For more control over the root filesystem (e.g. read-only, DAX window size),
+ * use krun_add_virtiofs3() with KRUN_FS_ROOT_TAG instead.
  *
  * Arguments:
  *  "ctx_id"    - the configuration context ID.


### PR DESCRIPTION
Pull request #623 added support for read-only mounts. It seems only consequent to also provide users with the ability to set read-only state for the root file system.
Introduce `krun_set_root2()`, which extends `krun_set_root()` with a read_only parameter to allow exposing the root filesystem as read-only to the guest. The original `krun_set_root()` now delegates to the new function with `read_only=false`, preserving the previous behavior.