### PR TITLE
Add virtio-fs integration tests (pjdfstest suite, custom fallocate test)

### DIFF
--- a/tests/macros/src/lib.rs
+++ b/tests/macros/src/lib.rs
@@ -2,7 +2,7 @@ extern crate proc_macro;
 extern crate quote;
 extern crate syn;
 
-use proc_macro::TokenStream;
+use proc_macro::{Literal, TokenStream, TokenTree};
 use quote::quote;
 
 #[proc_macro_attribute]
@@ -25,4 +25,39 @@ pub fn host(_args: TokenStream, input: TokenStream) -> TokenStream {
 
     prefix.extend(input);
     prefix
+}
+
+/// Compile-time env var with default. Expands to a string literal, usable in `concat!()`.
+///
+/// ```ignore
+/// const X: &str = concat!("prefix ", env_or_default!("MY_VAR", "fallback"), " suffix");
+/// ```
+#[proc_macro]
+pub fn env_or_default(input: TokenStream) -> TokenStream {
+    let tokens: Vec<TokenTree> = input.into_iter().collect();
+
+    // Parse: "ENV_VAR_NAME" , "default_value"
+    let key = match tokens.first() {
+        Some(TokenTree::Literal(lit)) => strip_string_literal(&lit.to_string())
+            .unwrap_or_else(|| panic!("first argument must be a string literal")),
+        _ => panic!("first argument must be a string literal"),
+    };
+
+    match tokens.get(1) {
+        Some(TokenTree::Punct(p)) if p.as_char() == ',' => {}
+        _ => panic!("expected `,` after first argument"),
+    }
+
+    let default_tokens: TokenStream = tokens[2..].iter().cloned().collect();
+
+    match std::env::var(&key) {
+        Ok(value) => TokenStream::from(TokenTree::Literal(Literal::string(&value))),
+        Err(_) => default_tokens,
+    }
+}
+
+fn strip_string_literal(s: &str) -> Option<String> {
+    s.strip_prefix('"')
+        .and_then(|s| s.strip_suffix('"'))
+        .map(|s| s.to_owned())
 }

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -203,9 +203,14 @@ fn run_single_test(
     let stdout = fs::read(&stdout_path).unwrap_or_default();
 
     let test_name = test_case.name.to_string();
+    let test_dir_clone = test_dir.clone();
     let outcome = match catch_unwind(|| {
         let test = get_test(&test_name).unwrap();
-        test.check(stdout)
+        let test_setup = TestSetup {
+            test_case: test_name,
+            tmp_dir: test_dir_clone,
+        };
+        test.check(stdout, test_setup)
     }) {
         Ok(outcome) => outcome,
         Err(_) => TestOutcome::Fail("test.check() panicked".to_string()),

--- a/tests/test_cases/src/common.rs
+++ b/tests/test_cases/src/common.rs
@@ -1,7 +1,7 @@
 //! Common utilities used by multiple test
 
 use anyhow::Context;
-use std::ffi::CString;
+use std::ffi::{c_char, CStr, CString};
 use std::fs;
 use std::fs::create_dir;
 use std::os::unix::ffi::OsStrExt;
@@ -35,16 +35,27 @@ pub fn setup_rootfs(test_setup: &TestSetup) -> anyhow::Result<PathBuf> {
 
 /// Sets up the root filesystem, copies the guest agent into it, and enters the VM.
 pub fn setup_fs_and_enter(ctx: u32, test_setup: TestSetup) -> anyhow::Result<()> {
+    setup_fs_and_enter_with_env(ctx, test_setup, &[])
+}
+
+pub fn setup_fs_and_enter_with_env(
+    ctx: u32,
+    test_setup: TestSetup,
+    guest_env: &[&CStr],
+) -> anyhow::Result<()> {
     let root_dir = setup_rootfs(&test_setup)?;
 
     let path_str = CString::new(root_dir.as_os_str().as_bytes()).context("CString::new")?;
+    let mut envp: Vec<*const c_char> = guest_env
+        .iter()
+        .map(|entry| entry.as_ptr().cast())
+        .collect();
+    envp.push(null());
     unsafe {
         krun_call!(krun_set_root(ctx, path_str.as_ptr()))?;
         krun_call!(krun_set_workdir(ctx, c"/".as_ptr()))?;
         let test_case_cstr = CString::new(test_setup.test_case).context("CString::new")?;
         let argv = [test_case_cstr.as_ptr(), null()];
-        //let envp = [c"RUST_BACKTRACE=1".as_ptr(), null()];
-        let envp = [null()];
         krun_call!(krun_set_exec(
             ctx,
             c"/guest-agent".as_ptr(),

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -25,6 +25,9 @@ use test_virtiofs_root_ro::TestVirtiofsRootRo;
 mod test_pjdfstest;
 use test_pjdfstest::TestPjdfstest;
 
+mod test_virtiofs_misc;
+use test_virtiofs_misc::TestVirtioFsMisc;
+
 pub enum TestOutcome {
     Pass,
     Fail(String),
@@ -81,6 +84,7 @@ pub fn test_cases() -> Vec<TestCase> {
         TestCase::new("net-vmnet-helper", Box::new(TestNet::new_vmnet_helper())),
         TestCase::new("multiport-console", Box::new(TestMultiportConsole)),
         TestCase::new("virtiofs-root-ro", Box::new(TestVirtiofsRootRo)),
+        TestCase::new("virtiofs-misc", Box::new(TestVirtioFsMisc)),
         TestCase::new("pjdfstest", Box::new(TestPjdfstest)),
         TestCase::new("perf-net-passt-tx", Box::new(TestNetPerf::new_passt_tx())),
         TestCase::new("perf-net-passt-rx", Box::new(TestNetPerf::new_passt_rx())),

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -192,7 +192,7 @@ pub trait Test {
     fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()>;
 
     /// Checks the output of the (host) process which started the VM
-    fn check(self: Box<Self>, stdout: Vec<u8>) -> TestOutcome {
+    fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
         let output = String::from_utf8(stdout).unwrap();
         if output == "OK\n" {
             TestOutcome::Pass

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -22,6 +22,9 @@ use test_multiport_console::TestMultiportConsole;
 mod test_virtiofs_root_ro;
 use test_virtiofs_root_ro::TestVirtiofsRootRo;
 
+mod test_pjdfstest;
+use test_pjdfstest::TestPjdfstest;
+
 pub enum TestOutcome {
     Pass,
     Fail(String),
@@ -78,6 +81,7 @@ pub fn test_cases() -> Vec<TestCase> {
         TestCase::new("net-vmnet-helper", Box::new(TestNet::new_vmnet_helper())),
         TestCase::new("multiport-console", Box::new(TestMultiportConsole)),
         TestCase::new("virtiofs-root-ro", Box::new(TestVirtiofsRootRo)),
+        TestCase::new("pjdfstest", Box::new(TestPjdfstest)),
         TestCase::new("perf-net-passt-tx", Box::new(TestNetPerf::new_passt_tx())),
         TestCase::new("perf-net-passt-rx", Box::new(TestNetPerf::new_passt_rx())),
         TestCase::new("perf-net-tap-tx", Box::new(TestNetPerf::new_tap_tx())),

--- a/tests/test_cases/src/test_net/mod.rs
+++ b/tests/test_cases/src/test_net/mod.rs
@@ -97,7 +97,7 @@ mod host {
             (self.should_run)()
         }
 
-        fn check(self: Box<Self>, stdout: Vec<u8>) -> TestOutcome {
+        fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
             if let Some(cleanup) = self.cleanup {
                 cleanup();
             }

--- a/tests/test_cases/src/test_net_perf.rs
+++ b/tests/test_cases/src/test_net_perf.rs
@@ -365,7 +365,7 @@ RUN dnf install -y iperf3 && dnf clean all
             Ok(())
         }
 
-        fn check(self: Box<Self>, stdout: Vec<u8>) -> TestOutcome {
+        fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
             if let Some(cleanup) = self.cleanup {
                 cleanup();
             }

--- a/tests/test_cases/src/test_pjdfstest.rs
+++ b/tests/test_cases/src/test_pjdfstest.rs
@@ -1,0 +1,101 @@
+use macros::{guest, host};
+
+pub struct TestPjdfstest;
+
+#[host]
+mod host {
+    use super::*;
+    use crate::common::setup_fs_and_enter_with_env;
+    use crate::{krun_call, krun_call_u32, ShouldRun, Test, TestOutcome, TestSetup};
+    use krun_sys::*;
+    use std::ffi::CString;
+
+    use macros::env_or_default;
+
+    // Set PJDFSTEST_REPO and PJDFSTEST_COMMIT at build time to enable this test.
+    const CONTAINERFILE: &str = concat!(
+        "FROM fedora:43\n",
+        "RUN dnf install -y autoconf automake gcc make perl-Test-Harness git openssl && dnf clean all\n",
+        "RUN git init /pjdfstest \\\n",
+        " && git -C /pjdfstest fetch --depth 1 ",
+        env_or_default!("PJDFSTEST_REPO", ""),
+        " ",
+        env_or_default!("PJDFSTEST_COMMIT", ""),
+        " \\\n",
+        " && git -C /pjdfstest checkout FETCH_HEAD\n",
+        "WORKDIR /pjdfstest\n",
+        "RUN autoreconf -ifs && ./configure && make pjdfstest\n",
+    );
+
+    impl Test for TestPjdfstest {
+        fn should_run(&self) -> ShouldRun {
+            if option_env!("PJDFSTEST_REPO").is_none() || option_env!("PJDFSTEST_COMMIT").is_none()
+            {
+                return ShouldRun::No("PJDFSTEST_REPO/PJDFSTEST_COMMIT not set");
+            }
+            ShouldRun::Yes
+        }
+
+        fn rootfs_image(&self) -> Option<&'static str> {
+            Some(CONTAINERFILE)
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            1800
+        }
+
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let host_os = if cfg!(target_os = "macos") {
+                "Darwin"
+            } else {
+                "Linux"
+            };
+            let host_os_env = CString::new(format!("PJDFSTEST_HOST_OS={host_os}"))?;
+            unsafe {
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_set_vm_config(ctx, 2, 1024))?;
+                setup_fs_and_enter_with_env(ctx, test_setup, &[host_os_env.as_c_str()])?;
+            }
+            Ok(())
+        }
+
+        fn check(self: Box<Self>, stdout: Vec<u8>) -> TestOutcome {
+            let stdout = String::from_utf8_lossy(&stdout);
+
+            if stdout.contains("Result: PASS") {
+                TestOutcome::Pass
+            } else if stdout.contains("Result: FAIL") || stdout.contains("Result: NOTESTS") {
+                TestOutcome::Fail(stdout.to_string())
+            } else if stdout.trim() == "OK" {
+                TestOutcome::Pass
+            } else {
+                TestOutcome::Fail(stdout.to_string())
+            }
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+    use std::process::Command;
+
+    impl Test for TestPjdfstest {
+        fn in_guest(self: Box<Self>) {
+            // Create a test directory on the filesystem under test
+            std::fs::create_dir_all("/tmp/pjdfstest-work").expect("Failed to create test dir");
+
+            let status = Command::new("/usr/bin/prove")
+                .arg("-rv")
+                .arg("/pjdfstest/tests")
+                .current_dir("/tmp/pjdfstest-work")
+                .status()
+                .expect("Failed to run prove");
+
+            if !status.success() {
+                panic!("prove exited with status: {}", status.code().unwrap_or(-1));
+            }
+        }
+    }
+}

--- a/tests/test_cases/src/test_pjdfstest.rs
+++ b/tests/test_cases/src/test_pjdfstest.rs
@@ -59,7 +59,7 @@ mod host {
             Ok(())
         }
 
-        fn check(self: Box<Self>, stdout: Vec<u8>) -> TestOutcome {
+        fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
             let stdout = String::from_utf8_lossy(&stdout);
 
             if stdout.contains("Result: PASS") {

--- a/tests/test_cases/src/test_virtiofs_misc.rs
+++ b/tests/test_cases/src/test_virtiofs_misc.rs
@@ -1,0 +1,207 @@
+use macros::{guest, host};
+
+pub struct TestVirtioFsMisc;
+
+#[host]
+mod host {
+    use super::*;
+
+    use crate::common::setup_fs_and_enter;
+    use crate::{krun_call, krun_call_u32};
+    use crate::{Test, TestOutcome, TestSetup};
+    use krun_sys::*;
+    use std::io::Read;
+
+    impl Test for TestVirtioFsMisc {
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            unsafe {
+                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_set_vm_config(ctx, 1, 1024))?;
+                setup_fs_and_enter(ctx, test_setup)?;
+            }
+            Ok(())
+        }
+
+        fn check(self: Box<Self>, stdout: Vec<u8>, test_setup: TestSetup) -> TestOutcome {
+            let output = String::from_utf8(stdout).unwrap();
+            if output != "OK\n" {
+                return TestOutcome::Fail(format!(
+                    "expected exactly {:?}, got {:?}",
+                    "OK\n", output
+                ));
+            }
+
+            let root = test_setup.tmp_dir.join("rootfs");
+
+            // Verify fallocate basic: file should be at least 4096 bytes
+            let meta = std::fs::metadata(root.join("test_fallocate_basic")).unwrap();
+            assert!(
+                meta.len() >= 4096,
+                "host: file size after allocate: {} (expected >= 4096)",
+                meta.len()
+            );
+
+            // Verify punch hole: read the file and check the hole is zeroed
+            let mut f = std::fs::File::open(root.join("test_fallocate_punch_hole")).unwrap();
+            let mut contents = Vec::new();
+            f.read_to_end(&mut contents).unwrap();
+
+            assert_eq!(contents.len(), 16384, "host: punch hole file should be 16K");
+            assert!(
+                contents[..4096].iter().all(|&b| b == 0xAA),
+                "host: data before hole should be 0xAA"
+            );
+            assert!(
+                contents[4096..8192].iter().all(|&b| b == 0),
+                "host: punched hole region should be zeroed"
+            );
+            assert!(
+                contents[8192..].iter().all(|&b| b == 0xAA),
+                "host: data after hole should be 0xAA"
+            );
+
+            TestOutcome::Pass
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+
+    use std::fs;
+    use std::io::{Read, Seek, SeekFrom, Write};
+    use std::os::unix::fs::MetadataExt;
+    use std::os::unix::io::AsRawFd;
+
+    use nix::fcntl::{fallocate, FallocateFlags};
+
+    fn test_fallocate_basic() {
+        let path = "/test_fallocate_basic";
+        let f = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+
+        fallocate(f.as_raw_fd(), FallocateFlags::empty(), 0, 4096)
+            .expect("fallocate(ALLOCATE_RANGE) failed");
+
+        let meta = f.metadata().unwrap();
+        assert!(
+            meta.len() >= 4096,
+            "file size after allocate: {} (expected >= 4096)",
+            meta.len()
+        );
+    }
+
+    fn test_fallocate_keep_size() {
+        let path = "/test_fallocate_keep_size";
+        let f = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+
+        fallocate(f.as_raw_fd(), FallocateFlags::FALLOC_FL_KEEP_SIZE, 0, 65536)
+            .expect("fallocate(KEEP_SIZE) failed");
+
+        let meta = f.metadata().unwrap();
+        assert_eq!(meta.len(), 0, "file size should remain 0 with KEEP_SIZE");
+        assert!(
+            meta.blocks() > 0,
+            "blocks should be allocated with KEEP_SIZE"
+        );
+    }
+
+    fn test_fallocate_punch_hole() {
+        let path = "/test_fallocate_punch_hole";
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+
+        // Write 16K of non-zero data
+        let data = vec![0xAAu8; 16384];
+        f.write_all(&data).unwrap();
+        f.sync_all().unwrap();
+
+        let size_before = f.metadata().unwrap().len();
+
+        // Punch a 4K hole in the middle (offset 4096, length 4096)
+        fallocate(
+            f.as_raw_fd(),
+            FallocateFlags::FALLOC_FL_PUNCH_HOLE | FallocateFlags::FALLOC_FL_KEEP_SIZE,
+            4096,
+            4096,
+        )
+        .expect("fallocate(PUNCH_HOLE) failed");
+
+        let meta = f.metadata().unwrap();
+        assert_eq!(
+            meta.len(),
+            size_before,
+            "file size should not change after PUNCH_HOLE"
+        );
+
+        // Verify the hole is zeroed
+        f.seek(SeekFrom::Start(4096)).unwrap();
+        let mut hole_data = vec![0u8; 4096];
+        f.read_exact(&mut hole_data).unwrap();
+        assert!(
+            hole_data.iter().all(|&b| b == 0),
+            "punched region should be zeroed"
+        );
+
+        // Verify data around the hole is intact
+        f.seek(SeekFrom::Start(0)).unwrap();
+        let mut before_hole = vec![0u8; 4096];
+        f.read_exact(&mut before_hole).unwrap();
+        assert!(
+            before_hole.iter().all(|&b| b == 0xAA),
+            "data before hole should be intact"
+        );
+
+        f.seek(SeekFrom::Start(8192)).unwrap();
+        let mut after_hole = vec![0u8; 4096];
+        f.read_exact(&mut after_hole).unwrap();
+        assert!(
+            after_hole.iter().all(|&b| b == 0xAA),
+            "data after hole should be intact"
+        );
+    }
+
+    fn test_fallocate_punch_hole_requires_keep_size() {
+        let path = "/test_fallocate_punch_no_keepsize";
+        let f = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .read(true)
+            .write(true)
+            .open(path)
+            .unwrap();
+
+        let ret = fallocate(f.as_raw_fd(), FallocateFlags::FALLOC_FL_PUNCH_HOLE, 0, 4096);
+        assert!(ret.is_err(), "PUNCH_HOLE without KEEP_SIZE should fail");
+    }
+
+    impl Test for TestVirtioFsMisc {
+        fn in_guest(self: Box<Self>) {
+            test_fallocate_basic();
+            test_fallocate_keep_size();
+            test_fallocate_punch_hole();
+            test_fallocate_punch_hole_requires_keep_size();
+
+            println!("OK");
+        }
+    }
+}


### PR DESCRIPTION
Note I decided NOT to run the pjdfstest suite on the CI:
- in the `aarch64` runnre we have some problem with using podman (rootless namespaces are not setup? subuid mapping for the user is not setup? something like that)
- in the `x86` runner it works, but it is too slow - it takes >30 minutes in the CI (I haven't tried to bump the timeout futher). This seems too long for nice development.

The upstream pjdfstest suite has failures on macOS host, so @slp has their fork for macOS here: https://github.com/slp/pjdfstest/tree/libkrun-macos

But there are also failures when running on Linux. Specifically it wants to try calls such as mknod which we don't work under podman (even vanilla podman without krun).
I have made my own fork here https://github.com/mtjhrc/pjdfstest/tree/libkrun which adapts which tests are skipped based on the host system which we are running the test on. 
Also note on Linux it is best to run this under tmpfs (this is the default, assuming your /tmp is tmpfs). It should supposedly also work under ext4, but notably some tests fail on btrfs. 