### PR TITLE
init/aws-nitro: Continue if module already loaded

### DIFF
--- a/init/aws-nitro/mod.c
+++ b/init/aws-nitro/mod.c
@@ -35,7 +35,7 @@ static int mod_load(const char *path)
     }
 
     ret = finit_module(fd, "", 0);
-    if (ret < 0) {
+    if (ret < 0 && errno != EEXIST) {
         close(fd);
         fprintf(stderr, "init module %s (errno %d)\n", path, errno);
         return -errno;


### PR DESCRIPTION
If a module is already loaded, then the initramfs can continue on loading other modules. Although returning an error, this does not require failure of the initramfs.