### PR TITLE
Queue Rng device events only when active

### DIFF
--- a/src/devices/src/virtio/rng/event_handler.rs
+++ b/src/devices/src/virtio/rng/event_handler.rs
@@ -56,16 +56,15 @@ impl Rng {
 impl Subscriber for Rng {
     fn process(&mut self, event: &EpollEvent, event_manager: &mut EventManager) {
         let source = event.fd();
-        let req = self.queue_event(REQ_INDEX).as_raw_fd();
         let activate_evt = self.activate_evt.as_raw_fd();
-
-        if self.is_activated() {
-            match source {
-                _ if source == req => self.handle_req_event(event),
-                _ if source == activate_evt => {
-                    self.handle_activate_event(event_manager);
-                }
-                _ => warn!("Unexpected rng event received: {source:?}"),
+        if source == activate_evt {
+            self.handle_activate_event(event_manager);
+        } else if self.is_activated() {
+            let req = self.queue_event(REQ_INDEX).as_raw_fd();
+            if source == req {
+                self.handle_req_event(event);
+            } else {
+                warn!("Unexpected rng event received: {source:?}")
             }
         } else {
             warn!("rng: The device is not yet activated. Spurious event received: {source:?}");


### PR DESCRIPTION
When an Rng virtio device is deactivated, its event queues are set to None.

However, Subscribers may still attempt to queue events to the device, resulting in a panic.

This pull request addresses the issue by simply moving the event queueing logic only if the device is active, otherwise warns about a spurious event.

This happens when launching a FreeBSD guest with krunkit*, which results in ~80% of boots failing. I may have had a similar issue with alpine 3.23.3 once, but my memory is a bit fuzzy.

Updated the code to allow the device to be re-activated.

*to get FreeBSD to boot in krunkit at all, legacy console needs to be used (wip), and the GPU needs to be explicitly disabled. Came across this when looking into that.