### PR TITLE
init: explictly issue sync+reboot

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -29,7 +29,9 @@
 #include <sys/wait.h>
 
 #if __linux__
+#include <linux/reboot.h>
 #include <linux/vm_sockets.h>
+#include <sys/reboot.h>
 #endif
 
 #include "dhcp.h"
@@ -1439,6 +1441,11 @@ int main(int argc, char **argv)
         } else if (WIFSIGNALED(status)) {
             set_exit_code(WTERMSIG(status) + 128);
         }
+
+        sync();
+#if __linux__
+        reboot(LINUX_REBOOT_CMD_RESTART);
+#endif
     }
 
     return 0;


### PR DESCRIPTION
So far, we were relying on the kernel to automatically shut down the VM after init exits. This works fine with the libkrunfw kernel, but gives a pretty ugly (though harmless) panic on upstream kernels.

This can easily be avoiding by actually using the reboot() syscall to tell the kernel this is actually what we want to do. Do it after recording the exit code.