### PR TITLE
Bump version to 1.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "krun-arch"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "krun-arch-gen",
  "krun-smbios",
@@ -729,11 +729,11 @@ dependencies = [
 
 [[package]]
 name = "krun-arch-gen"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 
 [[package]]
 name = "krun-aws-nitro"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "krun-devices",
  "libc",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "krun-cpuid"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -756,7 +756,7 @@ dependencies = [
 
 [[package]]
 name = "krun-devices"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "bitflags 1.3.2",
  "caps",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "krun-hvf"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "crossbeam-channel",
  "krun-arch",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "krun-kernel"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "krun-utils",
  "vm-memory",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "krun-polly"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "krun-utils",
  "libc",
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "krun-rutabaga-gfx"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -853,14 +853,14 @@ dependencies = [
 
 [[package]]
 name = "krun-smbios"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "krun-utils"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -873,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "krun-vmm"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "bitfield",
  "bitflags 2.11.0",
@@ -947,7 +947,7 @@ checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libkrun"
-version = "1.17.3"
+version = "1.18.0"
 dependencies = [
  "crossbeam-channel",
  "env_logger",

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LIBRARY_HEADER_DISPLAY = include/libkrun_display.h
 LIBRARY_HEADER_INPUT = include/libkrun_input.h
 
 ABI_VERSION=1
-FULL_VERSION=1.17.3
+FULL_VERSION=1.18.0
 
 AWS_NITRO_INIT_SRC = \
 		init/aws-nitro/include/*        	  	\

--- a/examples/Cargo.lock
+++ b/examples/Cargo.lock
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "krun-utils"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-arch"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Architecture-specific VM support for libkrun"
@@ -18,9 +18,9 @@ libc = ">=0.2.39"
 vm-memory = { version = "0.17", features = ["backend-mmap"] }
 vmm-sys-util = "0.14"
 
-arch_gen = { package = "krun-arch-gen", version = "=0.1.0-1.17.3", path = "../arch_gen" }
-smbios = { package = "krun-smbios", version = "=0.1.0-1.17.3", path = "../smbios" }
-utils = { package = "krun-utils", version = "=0.1.0-1.17.3", path = "../utils" }
+arch_gen = { package = "krun-arch-gen", version = "=0.1.0-1.18.0", path = "../arch_gen" }
+smbios = { package = "krun-smbios", version = "=0.1.0-1.18.0", path = "../smbios" }
+utils = { package = "krun-utils", version = "=0.1.0-1.18.0", path = "../utils" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = "0.12", features = ["fam-wrappers"] }
@@ -28,4 +28,4 @@ kvm-ioctls = "0.22"
 tdx = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
-utils = { package = "krun-utils", version = "=0.1.0-1.17.3", path = "../utils" }
+utils = { package = "krun-utils", version = "=0.1.0-1.18.0", path = "../utils" }

--- a/src/arch_gen/Cargo.toml
+++ b/src/arch_gen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-arch-gen"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Generated architecture-specific definitions for libkrun"

--- a/src/aws_nitro/Cargo.toml
+++ b/src/aws_nitro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-aws-nitro"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 edition = "2021"
 description = "AWS Nitro Enclaves support for libkrun"
 license = "Apache-2.0"
@@ -15,7 +15,7 @@ nix = { version = "0.30", features = ["poll"] }
 tar = "0.4"
 vsock = "0.5"
 
-devices = { package = "krun-devices", version = "=0.1.0-1.17.3", path = "../devices" }
+devices = { package = "krun-devices", version = "=0.1.0-1.18.0", path = "../devices" }
 log = "0.4"
 signal-hook = "0.3"
 

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-cpuid"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "CPUID handling for libkrun"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-devices"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 build = "build.rs"
@@ -38,18 +38,18 @@ zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", features = ["bindgen_clang_runtime"], optional = true }
 
-arch = { package = "krun-arch", version = "=0.1.0-1.17.3", path = "../arch" }
-utils = { package = "krun-utils", version = "=0.1.0-1.17.3", path = "../utils" }
-polly = { package = "krun-polly", version = "=0.1.0-1.17.3", path = "../polly" }
-rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-1.17.3", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
+arch = { package = "krun-arch", version = "=0.1.0-1.18.0", path = "../arch" }
+utils = { package = "krun-utils", version = "=0.1.0-1.18.0", path = "../utils" }
+polly = { package = "krun-polly", version = "=0.1.0-1.18.0", path = "../polly" }
+rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-1.18.0", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
 imago = { version = "0.2.2", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "krun-hvf", version = "=0.1.0-1.17.3", path = "../hvf" }
+hvf = { package = "krun-hvf", version = "=0.1.0-1.18.0", path = "../hvf" }
 lru = ">=0.9"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-1.17.3", path = "../rutabaga_gfx", features = ["x"], optional = true }
+rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-1.18.0", path = "../rutabaga_gfx", features = ["x"], optional = true }
 caps = "0.5.5"
 kvm-bindings = { version = "0.12", features = ["fam-wrappers"] }
 kvm-ioctls = "0.22"

--- a/src/hvf/Cargo.toml
+++ b/src/hvf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-hvf"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Apple Hypervisor.framework backend for libkrun"
@@ -12,4 +12,4 @@ crossbeam-channel = ">=0.5.15"
 libloading = "0.8"
 log = "0.4.0"
 
-arch = { package = "krun-arch", version = "=0.1.0-1.17.3", path = "../arch" }
+arch = { package = "krun-arch", version = "=0.1.0-1.18.0", path = "../arch" }

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-kernel"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 edition = "2021"
 description = "Kernel loading support for libkrun"
 license = "Apache-2.0"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 [dependencies]
 vm-memory = { version = "0.17", features = ["backend-mmap"] }
 
-utils = { package = "krun-utils", version = "=0.1.0-1.17.3", path = "../utils" }
+utils = { package = "krun-utils", version = "=0.1.0-1.18.0", path = "../utils" }

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libkrun"
-version = "1.17.3"
+version = "1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "A dynamic library providing Virtualization-based process isolation capabilities"
@@ -31,19 +31,19 @@ once_cell = "1.4.1"
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", optional = true, features = ["bindgen_clang_runtime"] }
 
-devices = { package = "krun-devices", version = "=0.1.0-1.17.3", path = "../devices" }
-polly = { package = "krun-polly", version = "=0.1.0-1.17.3", path = "../polly" }
-utils = { package = "krun-utils", version = "=0.1.0-1.17.3", path = "../utils" }
-vmm = { package = "krun-vmm", version = "=0.1.0-1.17.3", path = "../vmm" }
+devices = { package = "krun-devices", version = "=0.1.0-1.18.0", path = "../devices" }
+polly = { package = "krun-polly", version = "=0.1.0-1.18.0", path = "../polly" }
+utils = { package = "krun-utils", version = "=0.1.0-1.18.0", path = "../utils" }
+vmm = { package = "krun-vmm", version = "=0.1.0-1.18.0", path = "../vmm" }
 rand = "0.9.2"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "krun-hvf", version = "=0.1.0-1.17.3", path = "../hvf" }
+hvf = { package = "krun-hvf", version = "=0.1.0-1.18.0", path = "../hvf" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = "0.12", features = ["fam-wrappers"] }
 kvm-ioctls = "0.22"
-aws-nitro = { package = "krun-aws-nitro", version = "=0.1.0-1.17.3", path = "../aws_nitro", optional = true }
+aws-nitro = { package = "krun-aws-nitro", version = "=0.1.0-1.18.0", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.5.0", optional = true }
 vm-memory = { version = "0.17", features = ["backend-mmap"] }
 

--- a/src/polly/Cargo.toml
+++ b/src/polly/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-polly"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Event-driven I/O polling for libkrun"
@@ -9,4 +9,4 @@ repository = "https://github.com/containers/libkrun"
 
 [dependencies]
 libc = ">=0.2.39"
-utils = { package = "krun-utils", version = "=0.1.0-1.17.3", path="../utils" }
+utils = { package = "krun-utils", version = "=0.1.0-1.18.0", path="../utils" }

--- a/src/rutabaga_gfx/Cargo.toml
+++ b/src/rutabaga_gfx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-rutabaga-gfx"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "[highly unstable] Handling virtio-gpu protocols"

--- a/src/rutabaga_gfx/ffi/Cargo.toml
+++ b/src/rutabaga_gfx/ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-rutabaga-gfx-ffi"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Handling virtio-gpu protocols with C API"
@@ -12,7 +12,7 @@ name = "rutabaga_gfx_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-rutabaga_gfx = { package = "krun-rutabaga-gfx", path = "../", version = "=0.1.0-1.17.3"}
+rutabaga_gfx = { package = "krun-rutabaga-gfx", path = "../", version = "=0.1.0-1.18.0"}
 libc = "0.2.93"
 log = "0.4"
 once_cell = "1.7"

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-smbios"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 edition = "2021"
 description = "SMBIOS table generation for libkrun"
 license = "Apache-2.0"

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-utils"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 description = "Utility helpers for libkrun"

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krun-vmm"
-version = "0.1.0-1.17.3"
+version = "0.1.0-1.18.0"
 authors = ["The libkrun Authors"]
 edition = "2021"
 build = "build.rs"
@@ -32,12 +32,12 @@ vmm-sys-util = "0.14"
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", optional = true, features = ["bindgen_clang_runtime"] }
 
-arch = { package = "krun-arch", version = "=0.1.0-1.17.3", path = "../arch" }
-arch_gen = { package = "krun-arch-gen", version = "=0.1.0-1.17.3", path = "../arch_gen" }
-devices = { package = "krun-devices", version = "=0.1.0-1.17.3", path = "../devices" }
-kernel = { package = "krun-kernel", version = "=0.1.0-1.17.3", path = "../kernel" }
-utils = { package = "krun-utils", version = "=0.1.0-1.17.3", path = "../utils" }
-polly = { package = "krun-polly", version = "=0.1.0-1.17.3", path = "../polly" }
+arch = { package = "krun-arch", version = "=0.1.0-1.18.0", path = "../arch" }
+arch_gen = { package = "krun-arch-gen", version = "=0.1.0-1.18.0", path = "../arch_gen" }
+devices = { package = "krun-devices", version = "=0.1.0-1.18.0", path = "../devices" }
+kernel = { package = "krun-kernel", version = "=0.1.0-1.18.0", path = "../kernel" }
+utils = { package = "krun-utils", version = "=0.1.0-1.18.0", path = "../utils" }
+polly = { package = "krun-polly", version = "=0.1.0-1.18.0", path = "../polly" }
 
 # Dependencies for amd-sev
 kbs-types = { version = "0.13.0", optional = true }
@@ -49,7 +49,7 @@ bitflags = { version = "2.10.0", optional = true }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 bzip2 = "0.5"
-cpuid = { package = "krun-cpuid", version = "=0.1.0-1.17.3", path = "../cpuid" }
+cpuid = { package = "krun-cpuid", version = "=0.1.0-1.18.0", path = "../cpuid" }
 zstd = "0.13"
 
 [target.'cfg(target_os = "linux")'.dependencies]
@@ -58,7 +58,7 @@ kvm-bindings = { version = "0.12", features = ["fam-wrappers"] }
 kvm-ioctls = "0.22"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-hvf = { package = "krun-hvf", version = "=0.1.0-1.17.3", path = "../hvf" }
+hvf = { package = "krun-hvf", version = "=0.1.0-1.18.0", path = "../hvf" }
 
 [dev-dependencies]
-devices = { package = "krun-devices", version = "=0.1.0-1.17.3", path = "../devices", features = ["test_utils"] }
+devices = { package = "krun-devices", version = "=0.1.0-1.18.0", path = "../devices", features = ["test_utils"] }


### PR DESCRIPTION
Set up the stage for a new release by bumping the version to 1.18.0 in both src/libkrun and every crate with pinned-to-main versions.