### PR TITLE
virtio/vsock: use device's peer_buf_alloc

### DIFF
--- a/src/devices/src/virtio/vsock/tsi_stream.rs
+++ b/src/devices/src/virtio/vsock/tsi_stream.rs
@@ -613,9 +613,7 @@ impl Proxy for TsiStreamProxy {
             -libc::EINVAL
         };
 
-        if ret > 0
-            && (self.tx_cnt - self.last_tx_cnt_sent).0 as usize >= (defs::CONN_TX_BUF_SIZE / 2)
-        {
+        if ret > 0 && (self.tx_cnt - self.last_tx_cnt_sent).0 >= self.peer_buf_alloc / 2 {
             debug!(
                 "sending credit update: id={}, tx_cnt={}, last_tx_cnt={}",
                 self.id, self.tx_cnt, self.last_tx_cnt_sent

--- a/src/devices/src/virtio/vsock/unix.rs
+++ b/src/devices/src/virtio/vsock/unix.rs
@@ -418,9 +418,7 @@ impl Proxy for UnixProxy {
             -libc::EINVAL
         };
 
-        if ret > 0
-            && (self.tx_cnt - self.last_tx_cnt_sent).0 as usize >= (defs::CONN_TX_BUF_SIZE / 2)
-        {
+        if ret > 0 && (self.tx_cnt - self.last_tx_cnt_sent).0 >= self.peer_buf_alloc / 2 {
             debug!(
                 "sending credit update: id={}, tx_cnt={}, last_tx_cnt={}",
                 self.id, self.tx_cnt, self.last_tx_cnt_sent


### PR DESCRIPTION
In commit c0e42fb0e0 ("vsock/virtio: cap TX credit to local buffer size") the kernel stopped honoring our peer_buf_alloc value, capping it to its own.

Use the kernel's peer_buf_alloc instead of CONN_TX_BUF_SIZE as a hint of when we need to send a credit update.