### PR TITLE
init: fix FreeBSD build by guarding tmpfs mount with __linux__

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -1460,6 +1460,7 @@ int main(int argc, char **argv)
     }
 #endif
 
+#if __linux__
     if (config_tmpfs) {
         /* TODO: Honour mount flags from the config file. Most notably,
          * tmpcopyup is set by Podman by default, requesting copying the files
@@ -1470,6 +1471,7 @@ int main(int argc, char **argv)
             exit(-1);
         }
     }
+#endif
 
     krun_home = getenv("KRUN_HOME");
     if (krun_home) {


### PR DESCRIPTION
- The tmpfs mount added in 536360aa (`init: Mount a tmpfs if requested`) uses Linux-specific `MS_NOEXEC`/`MS_NOSUID`/`MS_NODEV`/`MS_RELATIME` flags and the Linux `mount()` signature, which don't exist on FreeBSD.
- Guard the block with `#if __linux__` to fix the FreeBSD cross-compilation that's currently breaking CI.

Fixes the `init/init-freebsd` build error:
```
init/init.c:1468:19: error: use of undeclared identifier 'MS_NOEXEC'
init/init.c:1468:31: error: use of undeclared identifier 'MS_NOSUID'
init/init.c:1468:43: error: use of undeclared identifier 'MS_NODEV'
init/init.c:1468:54: error: use of undeclared identifier 'MS_RELATIME'
```