### PR TITLE
README: add security email section

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on submitting changes.
 
 ## Getting in contact
 
+If you think you've identified a security issue in the project, please DO NOT report the issue publicly via the GitHub issue tracker or Matrix. Instead, send an email with as many details as possible to `libkrun-security@redhat.com`. This is a private mailing list for the core maintainers.
+
 The main communication channel is the [libkrun Matrix channel](https://matrix.to/#/#libkrun:matrix.org).
 
 ## Acknowledgments


### PR DESCRIPTION
Add a section telling users to report security issues to libkrun-security@redhat.com instead of the GH issue tracker or Matrix.

The email is configured such that only the core maintainers are able to see messages and mailing list members. Outside parties can **only** send messages.