### PR TITLE
init: fix unescape_string() not advancing past escape characters

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -641,27 +641,35 @@ static void unescape_string(char *string, int len)
         switch (*++val) {
         case 'n':
             string[i++] = '\n';
+            val++;
             break;
         case 't':
             string[i++] = '\t';
+            val++;
             break;
         case 'r':
             string[i++] = '\r';
+            val++;
             break;
         case 'b':
             string[i++] = '\b';
+            val++;
             break;
         case 'f':
             string[i++] = '\f';
+            val++;
             break;
         case '\\':
             string[i++] = '\\';
+            val++;
             break;
         case '\"':
             string[i++] = '\"';
+            val++;
             break;
         case '/':
             string[i++] = '/';
+            val++;
             break;
         case 'u': {
             const char *unescaped = "?";


### PR DESCRIPTION
The unescape_string() function in init.c, which handles JSON escape sequences when parsing environment variables from .krun_config.json, had a bug where the pointer 'val' was not advanced past the escape character after processing it.

When encountering a two-character JSON escape sequence like \n or \", the switch statement pre-increments val to point at the escape character (e.g., 'n' or '"') and writes the unescaped byte to the output. However, it never advances val past that character. On the next loop iteration, the character is not a backslash, so it gets copied again as a literal character.

This causes:
 - \n (JSON-escaped newline) to produce a newline followed by a literal 'n'
 - \" (JSON-escaped double quote) to produce two double quotes

For example, an environment variable set to a JSON string like:

  {\"key\": \"value\"}

would be rendered inside the krun VM as:

  {""key"": ""value""}

Fix this by adding val++ after writing the unescaped character in each case of the switch statement. The 'u' (unicode) case already handles its own pointer arithmetic and is not affected.

Fixes: https://github.com/containers/libkrun/issues/678
Assisted-by: <anthropic/claude-opus-4.6>