### PR TITLE
lib: remove deprecated APIs and implicit resource creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This is a novel technique called **Transparent Socket Impersonation** which allo
 
 #### Enabling TSI
 
-TSI for AF_INET and AF_INET6 is automatically enabled when no network interface is added to the VM. TSI for AF_UNIX is enabled when, in addition to the previous condition, `krun_set_root` has been used to set `/` as root filesystem.
+TSI for AF_INET and AF_INET6 is automatically enabled when no network interface is added to the VM. TSI for AF_UNIX is enabled when, in addition to the previous condition, the root filesystem has been configured with `/` as the shared directory.
 
 #### Known limitations
 
@@ -92,7 +92,7 @@ While most virtio devices allow the guest to access resources from the host, two
 
 ### virtio-fs
 
-When exposing a directory in a filesystem from the host to the guest through virtio-fs devices configured with `krun_set_root` and/or `krun_add_virtiofs`, libkrun **does not** provide any protection against the guest attempting to access other directories in the same filesystem, or even other filesystems in the host.
+When exposing a directory in a filesystem from the host to the guest through virtio-fs devices configured with `krun_add_virtiofs*`, libkrun **does not** provide any protection against the guest attempting to access other directories in the same filesystem, or even other filesystems in the host.
 
 A mount point isolation mechanism from the host should be used in combination with virtio-fs.
 

--- a/examples/boot_efi.c
+++ b/examples/boot_efi.c
@@ -197,7 +197,7 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
-    if (err = krun_set_root_disk(ctx_id, cmdline.disk_image)) {
+    if (err = krun_add_disk(ctx_id, "root", cmdline.disk_image, false)) {
         errno = -err;
         perror("Error configuring disk image");
         return -1;

--- a/examples/boot_efi.c
+++ b/examples/boot_efi.c
@@ -169,7 +169,7 @@ int main(int argc, char *const argv[])
     }
 
     // Set the log level to "off".
-    err = krun_set_log_level(0);
+    err = krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_OFF, KRUN_LOG_STYLE_AUTO, 0);
     if (err) {
         errno = -err;
         perror("Error configuring log level");

--- a/examples/boot_efi.c
+++ b/examples/boot_efi.c
@@ -191,6 +191,12 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    if (err = krun_add_virtio_console_default(ctx_id, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO)) {
+        errno = -err;
+        perror("Error configuring console");
+        return -1;
+    }
+
     if (err = krun_set_firmware(ctx_id, cmdline.efi_fw)) {
         errno = -err;
         perror("Error configuring EFI FW path");

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -363,14 +363,8 @@ int main(int argc, char *const argv[])
         printf("Using vhost-user sound backend at %s\n", cmdline.vhost_user_snd_socket);
     }
 
-    // Configure vhost-user vsock if requested
+    // Configure vsock: either vhost-user or built-in with TSI
     if (cmdline.vhost_user_vsock_socket != NULL) {
-        // Disable the implicit vsock device to avoid conflict
-        if (!check_krun_error(krun_disable_implicit_vsock(ctx_id),
-                              "Error disabling implicit vsock")) {
-            return -1;
-        }
-
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_VSOCK,
                                                           cmdline.vhost_user_vsock_socket, NULL,
                                                           KRUN_VHOST_USER_VSOCK_NUM_QUEUES,
@@ -425,8 +419,16 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    // Add built-in vsock with TSI when not using vhost-user-vsock
+    if (cmdline.vhost_user_vsock_socket == NULL) {
+        if (err = krun_add_vsock(ctx_id, KRUN_TSI_HIJACK_INET | KRUN_TSI_HIJACK_UNIX)) {
+            errno = -err;
+            perror("Error configuring vsock");
+            return -1;
+        }
+    }
+
     // Map port 18000 in the host to 8000 in the guest (if networking uses TSI)
-    // Skip port mapping when using vhost-user-vsock (TSI requires built-in vsock)
     if (cmdline.net_mode == NET_MODE_TSI && cmdline.vhost_user_vsock_socket == NULL) {
         if (err = krun_set_port_map(ctx_id, &port_map[0])) {
             errno = -err;

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -405,7 +405,7 @@ int main(int argc, char *const argv[])
     rlim.rlim_cur = rlim.rlim_max;
     setrlimit(RLIMIT_NOFILE, &rlim);
 
-    if (err = krun_set_root(ctx_id, cmdline.new_root)) {
+    if (err = krun_add_virtiofs3(ctx_id, KRUN_FS_ROOT_TAG, cmdline.new_root, 0, false)) {
         errno = -err;
         perror("Error configuring root path");
         return -1;

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -308,6 +308,12 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    if (err = krun_add_virtio_console_default(ctx_id, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO)) {
+        errno = -err;
+        perror("Error configuring console");
+        return -1;
+    }
+
     // Configure vhost-user RNG if requested
     if (cmdline.vhost_user_rng_socket != NULL) {
         // Test sentinel-terminated array: auto-detect queue count, use custom size

--- a/examples/consoles.c
+++ b/examples/consoles.c
@@ -119,7 +119,7 @@ int main(int argc, char *const argv[])
     const char *const *command_args = (argc > 3) ? (const char *const *)&argv[3] : NULL;
     const char *const envp[] = { 0 };
 
-    krun_set_log_level(KRUN_LOG_LEVEL_WARN);
+    krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_WARN, KRUN_LOG_STYLE_AUTO, 0);
 
     int err;
     int ctx_id = krun_create_ctx();

--- a/examples/consoles.c
+++ b/examples/consoles.c
@@ -125,12 +125,6 @@ int main(int argc, char *const argv[])
     int ctx_id = krun_create_ctx();
     if (ctx_id < 0) { errno = -ctx_id; perror("krun_create_ctx"); return 1; }
 
-    if ((err = krun_disable_implicit_console(ctx_id))) {
-        errno = -err;
-        perror("krun_disable_implicit_console");
-        return 1;
-    }
-
     int console_id = krun_add_virtio_console_multiport(ctx_id);
     if (console_id < 0) {
         errno = -console_id;

--- a/examples/consoles.c
+++ b/examples/consoles.c
@@ -189,9 +189,9 @@ int main(int argc, char *const argv[])
         return 1;
     }
 
-    if ((err = krun_set_root(ctx_id, root_dir))) {
+    if ((err = krun_add_virtiofs3(ctx_id, KRUN_FS_ROOT_TAG, root_dir, 0, false))) {
         errno = -err;
-        perror("krun_set_root");
+        perror("krun_add_virtiofs3");
         return 1;
     }
 

--- a/examples/external_kernel.c
+++ b/examples/external_kernel.c
@@ -218,7 +218,7 @@ int main(int argc, char *const argv[])
     }
 
     // Set the log level to "off".
-    err = krun_set_log_level(0);
+    err = krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_OFF, KRUN_LOG_STYLE_AUTO, 0);
     if (err)
     {
         errno = -err;

--- a/examples/external_kernel.c
+++ b/examples/external_kernel.c
@@ -243,6 +243,13 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    if (err = krun_add_virtio_console_default(ctx_id, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO))
+    {
+        errno = -err;
+        perror("Error configuring console");
+        return -1;
+    }
+
     if (cmdline.boot_disk)
     {
         if (err = krun_add_disk(ctx_id, "boot", cmdline.boot_disk, 0))

--- a/examples/gui_vm/src/main.rs
+++ b/examples/gui_vm/src/main.rs
@@ -9,9 +9,9 @@ use krun_sys::{
     KRUN_LOG_LEVEL_TRACE, KRUN_LOG_LEVEL_WARN, KRUN_LOG_STYLE_ALWAYS, KRUN_LOG_TARGET_DEFAULT,
     VIRGLRENDERER_RENDER_SERVER, VIRGLRENDERER_THREAD_SYNC, VIRGLRENDERER_USE_ASYNC_FENCE_CB,
     VIRGLRENDERER_USE_EGL, VIRGLRENDERER_VENUS, krun_add_display, krun_add_input_device,
-    krun_add_input_device_fd, krun_add_virtio_console_default, krun_create_ctx,
+    krun_add_input_device_fd, krun_add_virtio_console_default, krun_add_virtiofs3, krun_create_ctx,
     krun_display_set_dpi, krun_display_set_physical_size, krun_display_set_refresh_rate,
-    krun_init_log, krun_set_display_backend, krun_set_exec, krun_set_gpu_options2, krun_set_root,
+    krun_init_log, krun_set_display_backend, krun_set_exec, krun_set_gpu_options2,
     krun_set_vm_config, krun_start_enter,
 };
 use log::LevelFilter;
@@ -167,7 +167,13 @@ fn krun_thread(
             4096
         ))?;
 
-        krun_call!(krun_set_root(ctx, args.root_dir.as_ptr()))?;
+        krun_call!(krun_add_virtiofs3(
+            ctx,
+            c"/dev/root".as_ptr(),
+            args.root_dir.as_ptr(),
+            0,
+            false
+        ))?;
 
         let executable = args.executable.as_ref().unwrap().as_ptr();
         let argv: Vec<_> = args.argv.iter().map(|a| a.as_ptr()).collect();

--- a/examples/gui_vm/src/main.rs
+++ b/examples/gui_vm/src/main.rs
@@ -9,9 +9,9 @@ use krun_sys::{
     KRUN_LOG_LEVEL_TRACE, KRUN_LOG_LEVEL_WARN, KRUN_LOG_STYLE_ALWAYS, KRUN_LOG_TARGET_DEFAULT,
     VIRGLRENDERER_RENDER_SERVER, VIRGLRENDERER_THREAD_SYNC, VIRGLRENDERER_USE_ASYNC_FENCE_CB,
     VIRGLRENDERER_USE_EGL, VIRGLRENDERER_VENUS, krun_add_display, krun_add_input_device,
-    krun_add_input_device_fd, krun_create_ctx, krun_display_set_dpi,
-    krun_display_set_physical_size, krun_display_set_refresh_rate, krun_init_log,
-    krun_set_display_backend, krun_set_exec, krun_set_gpu_options2, krun_set_root,
+    krun_add_input_device_fd, krun_add_virtio_console_default, krun_create_ctx,
+    krun_display_set_dpi, krun_display_set_physical_size, krun_display_set_refresh_rate,
+    krun_init_log, krun_set_display_backend, krun_set_exec, krun_set_gpu_options2, krun_set_root,
     krun_set_vm_config, krun_start_enter,
 };
 use log::LevelFilter;
@@ -22,7 +22,7 @@ use std::fs::{File, OpenOptions};
 use std::mem::size_of_val;
 
 use anyhow::Context;
-use std::os::fd::IntoRawFd;
+use std::os::fd::{AsRawFd, IntoRawFd};
 use std::path::PathBuf;
 use std::process::exit;
 use std::ptr::null;
@@ -149,6 +149,13 @@ fn krun_thread(
         let ctx = krun_call_u32!(krun_create_ctx())?;
 
         krun_call!(krun_set_vm_config(ctx, 4, 4096))?;
+
+        krun_call!(krun_add_virtio_console_default(
+            ctx,
+            std::io::stdin().as_raw_fd(),
+            std::io::stdout().as_raw_fd(),
+            std::io::stderr().as_raw_fd(),
+        ))?;
 
         krun_call!(krun_set_gpu_options2(
             ctx,

--- a/examples/launch-tee.c
+++ b/examples/launch-tee.c
@@ -68,7 +68,7 @@ int main(int argc, char *const argv[])
     }
 
     // Use the first command line argument as the disk image containing the root fs.
-    if (err = krun_set_root_disk(ctx_id, argv[1])) {
+    if (err = krun_add_disk(ctx_id, "root", argv[1], false)) {
         errno = -err;
         perror("Error configuring root disk image");
         return -1;
@@ -114,7 +114,7 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
-    if (err = krun_set_data_disk(ctx_id, argv[3])) {
+    if (err = krun_add_disk(ctx_id, "data", argv[3], false)) {
         errno = -err;
         perror("Error configuring the TEE config data disk");
         return -1;

--- a/examples/launch-tee.c
+++ b/examples/launch-tee.c
@@ -45,7 +45,7 @@ int main(int argc, char *const argv[])
     }
 
     // Set the log level to "error".
-    err = krun_set_log_level(1);
+    err = krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_ERROR, KRUN_LOG_STYLE_AUTO, 0);
     if (err) {
         errno = -err;
         perror("Error configuring log level");

--- a/examples/launch-tee.c
+++ b/examples/launch-tee.c
@@ -67,6 +67,12 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    if (err = krun_add_virtio_console_default(ctx_id, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO)) {
+        errno = -err;
+        perror("Error configuring console");
+        return -1;
+    }
+
     // Use the first command line argument as the disk image containing the root fs.
     if (err = krun_add_disk(ctx_id, "root", argv[1], false)) {
         errno = -err;

--- a/examples/nitro.c
+++ b/examples/nitro.c
@@ -180,7 +180,7 @@ int main(int argc, char *const argv[])
 
     // Enable debug output if configured.
     log_level = (cmdline.debug) ? KRUN_LOG_LEVEL_DEBUG : KRUN_LOG_LEVEL_OFF;
-    err = krun_set_log_level(log_level);
+    err = krun_init_log(KRUN_LOG_TARGET_DEFAULT, log_level, KRUN_LOG_STYLE_AUTO, 0);
     if (err) {
         errno = -err;
         perror("Error configuring log level");

--- a/examples/nitro.c
+++ b/examples/nitro.c
@@ -203,9 +203,9 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
-    if (err = krun_set_console_output(ctx_id, "/dev/stdout")) {
+    if (err = krun_add_virtio_console_default(ctx_id, -1, STDOUT_FILENO, -1)) {
         errno = -err;
-        perror("Error configuring the console output");
+        perror("Error configuring the console");
         return -1;
     }
 

--- a/examples/nitro.c
+++ b/examples/nitro.c
@@ -210,7 +210,7 @@ int main(int argc, char *const argv[])
     }
 
     // Configure the enclave's rootfs.
-    if (err = krun_set_root(ctx_id, cmdline.new_root)) {
+    if (err = krun_add_virtiofs3(ctx_id, KRUN_FS_ROOT_TAG, cmdline.new_root, 0, false)) {
         errno = -err;
         perror("Error configuring enclave rootfs");
         return -1;

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -882,10 +882,6 @@ int32_t krun_add_vsock_port2(uint32_t ctx_id,
 /**
  * Add a vsock device with specified TSI features.
  *
- * By default, libkrun creates a vsock device implicitly with TSI hijacking
- * enabled based on heuristics. To use this function, you must first call
- * krun_disable_implicit_vsock() to disable the implicit vsock device.
- *
  * Currently only one vsock device is supported. Calling this function
  * multiple times will return an error.
  *
@@ -1127,20 +1123,6 @@ int32_t krun_fs_add_overlay_file(uint32_t ctx_id, const char *fs_tag,
  */
 int32_t krun_fs_add_overlay_dir(uint32_t ctx_id, const char *fs_tag,
                                 const char *path, uint32_t mode);
-
-/**
- * Disable the implicit vsock device.
- *
- * By default, libkrun creates a vsock device automatically. This function
- * disables that behavior entirely - no vsock device will be created.
- *
- * Arguments:
- *  "ctx_id" - the configuration context ID.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_disable_implicit_vsock(uint32_t ctx_id);
 
 /*
  * Specify the value of `console=` in the kernel commandline.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -10,24 +10,6 @@ extern "C" {
 #include <stdbool.h>
 #include <unistd.h>
 
-/**
- * Sets the log level for the library.
- *
- * Arguments:
- *  "level" can be one of the following values:
- *    0: Off
- *    1: Error
- *    2: Warn
- *    3: Info
- *    4: Debug
- *    5: Trace
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_log_level(uint32_t level);
-
-
 #define KRUN_LOG_TARGET_DEFAULT -1
 
 #define KRUN_LOG_LEVEL_OFF 0

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -227,22 +227,6 @@ int32_t krun_add_disk2(uint32_t ctx_id,
                        uint32_t sync_mode);
 
 /**
- * NO LONGER SUPPORTED. DO NOT USE.
- *
- * Configures the mapped volumes for the microVM. Only supported on macOS, on Linux use
- * user_namespaces and bind-mounts instead. Not available in libkrun-SEV.
- *
- * Arguments:
- *  "ctx_id"         - the configuration context ID.
- *  "mapped_volumes" - an array of string pointers with format "host_path:guest_path" representing
- *                     the volumes to be mapped inside the microVM
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_mapped_volumes(uint32_t ctx_id, const char *const mapped_volumes[]);
-
-/**
  * Adds an independent virtio-fs device pointing to a host's directory with a tag.
  *
  * Arguments:

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -912,18 +912,16 @@ int32_t krun_add_vsock(uint32_t ctx_id, uint32_t tsi_features);
 int32_t krun_get_shutdown_eventfd(uint32_t ctx_id);
 
 /**
- * Configures the console device to ignore stdin and write the output to "c_filepath".
+ * Configures the console device to write its output to "c_filepath".
+ * Only available when built with AWS Nitro support.
  *
  * Arguments:
  *  "ctx_id"    - the configuration context ID.
  *  "filepath"  - a null-terminated string representing the path of the file to write the
  *                console output.
  *
- * Notes:
- *  This API only applies to the implicitly created console. If the implicit console is
- *  disabled via `krun_disable_implicit_console` the operation is a NOOP. Additionally,
- *  this API does not have any effect on consoles created via the `krun_add_*_console_default`
- *  APIs.
+ * Returns:
+ *  Zero on success or a negative error number on failure.
  */
 int32_t krun_set_console_output(uint32_t ctx_id, const char *c_filepath);
 
@@ -1037,20 +1035,6 @@ int32_t krun_split_irqchip(uint32_t ctx_id, bool enable);
  * any implicit resources. Callers should start using the
  * krun_disable_implicit_* functions now to ease migration.
  */
-
-/*
- * Do not create an implicit console device in the guest. By using this API,
- * libkrun will create zero console devices on behalf of the user. Any
- * console devices needed by the user must be added manually via other API
- * calls.
- *
- * Arguments:
- *  "ctx_id" - the configuration context ID.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_disable_implicit_console(uint32_t ctx_id);
 
 /**
  * Do not inject the default init binary (/init.krun) into the root
@@ -1175,9 +1159,7 @@ int32_t krun_set_kernel_console(uint32_t ctx_id, const char *console_id);
  *
  * The function can be called multiple times for adding multiple virtio-console devices.
  * In the guest, the consoles will appear in the same order as they are added (that is,
- * the first added console will be "hvc0", the second "hvc1", ...). However, if the
- * implicit console is not disabled via `krun_disable_implicit_console`, the first
- * console created with the function will occupy the "hvc1" ID.
+ * the first added console will be "hvc0", the second "hvc1", ...).
  *
  * This function attaches a multi port virtio-console to the guest. If the input, output and error
  * file descriptors are TTYs, the device will be created with just a single console port (`err_fd`
@@ -1215,9 +1197,7 @@ int32_t krun_add_virtio_console_default(uint32_t ctx_id,
  *
  * The function can be called multiple times for adding multiple serial devices.
  * In the guest, the consoles will appear in the same order as they are added (that is,
- * the first added console will be "ttyS0", the second "ttyS1", ...). However, if the
- * implicit console is not disabled via `krun_disable_implicit_console` on aarch64 or macOS,
- * the first console created with the function will occupy the "ttyS1" ID.
+ * the first added console will be "ttyS0", the second "ttyS1", ...).
  *
  * Arguments:
  *  "ctx_id"       - the configuration context ID.
@@ -1248,8 +1228,7 @@ int32_t krun_add_serial_console_default(uint32_t ctx_id,
  *
  * The function can be called multiple times for adding multiple virtio-console devices.
  * Each device appears in the guest with port 0 accessible as /dev/hvcN (hvc0, hvc1, etc.) in the order
- * devices are added. If the implicit console is not disabled via `krun_disable_implicit_console`,
- * the first explicitly added device will occupy the "hvc1" ID. Additional ports within each device
+ * devices are added. Additional ports within each device
  * (port 1, 2, ...) appear as /dev/vportNpM character devices.
  *
  * Arguments:

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -118,44 +118,11 @@ int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib)
  */
 int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
 
-/**
- * DEPRECATED. Use krun_add_disk instead.
- *
- * Sets the path to the disk image that contains the file-system to be used as root for the microVM.
- * The only supported image format is "raw".
- *
- * Arguments:
- *  "ctx_id"    - the configuration context ID.
- *  "disk_path" - a null-terminated string representing the path leading to the disk image that
- *                contains the root file-system.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_root_disk(uint32_t ctx_id, const char *disk_path);
 
-/**
- * DEPRECATED. Use krun_add_disk instead.
- *
- * Sets the path to the disk image that contains the file-system to be used as
- * a data partition for the microVM.  The only supported image format is "raw".
- *
- * Arguments:
- *  "ctx_id"    - the configuration context ID.
- *  "disk_path" - a null-terminated string representing the path leading to the disk image that
- *                contains the root file-system.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_data_disk(uint32_t ctx_id, const char *disk_path);
 
 /**
  * Adds a disk image to be used as a general partition for the microVM. The only supported image
  * format is "raw".
- *
- * This API is mutually exclusive with the deprecated krun_set_root_disk and
- * krun_set_data_disk methods and must not be used together.
  *
  * This function deliberately only handles images in the Raw format, because it doesn't allow
  * specifying an image format, and probing an image's format is dangerous. For more information,
@@ -182,9 +149,6 @@ int32_t krun_add_disk(uint32_t ctx_id, const char *block_id, const char *disk_pa
 /**
  * Adds a disk image to be used as a general partition for the microVM. The supported
  * image formats are: "raw" and "qcow2".
- *
- * This API is mutually exclusive with the deprecated krun_set_root_disk and
- * krun_set_data_disk methods and must not be used together.
  *
  * SECURITY NOTE:
  * Non-Raw images can reference other files, which libkrun will automatically open, and to which the
@@ -253,9 +217,6 @@ int32_t krun_add_disk2(uint32_t ctx_id,
 
 /**
  * Adds a disk image to be used as a general partition for the microVM.
- *
- * This API is mutually exclusive with the deprecated krun_set_root_disk and
- * krun_set_data_disk methods and must not be used together.
  *
  * SECURITY NOTE:
  * See the security note for `krun_add_disk2`.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -332,7 +332,7 @@ int32_t krun_add_virtiofs3(uint32_t ctx_id,
 #define NET_FEATURE_HOST_TSO6 1 << 12
 #define NET_FEATURE_HOST_UFO 1 << 14
 
-/* These are the features enabled by krun_set_passt_fd and krun_set_gvproxy_path. */
+/* These are the default features used by krun_add_net_unixstream and krun_add_net_unixgram. */
 #define COMPAT_NET_FEATURES NET_FEATURE_CSUM | NET_FEATURE_GUEST_CSUM | \
                             NET_FEATURE_GUEST_TSO4 | NET_FEATURE_GUEST_UFO | \
                             NET_FEATURE_HOST_TSO4 | NET_FEATURE_HOST_UFO
@@ -454,57 +454,6 @@ int32_t krun_add_net_tap(uint32_t ctx_id,
                          uint32_t flags);
 
 /**
- * DEPRECATED. Use krun_add_net_unixstream instead.
- *
- * Configures the networking to use passt.
- * Call to this function disables TSI backend to use passt instead.
- *
- * Arguments:
- *  "ctx_id"         - the configuration context ID.
- *  "fd"             - a file descriptor to communicate with passt
- *
- * Notes:
- * If you never call this function, networking uses the TSI backend.
- * This function should be called before krun_set_port_map.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_passt_fd(uint32_t ctx_id, int fd);
-
-/**
- * DEPRECATED. Use krun_add_net_unixgram instead.
- *
- * Configures the networking to use gvproxy in vfkit mode.
- * Call to this function disables TSI backend to use gvproxy instead.
- *
- * Arguments:
- *  "ctx_id"  - the configuration context ID.
- *  "c_path"  - a null-terminated string representing the path for
- *              gvproxy's listen-vfkit unixdgram socket.
- *
- * Notes:
- * If you never call this function, networking uses the TSI backend.
- * This function should be called before krun_set_port_map.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_gvproxy_path(uint32_t ctx_id, char *c_path);
-
-/**
- * Sets the MAC address for the virtio-net device when using the passt backend.
- *
- * Arguments:
- *  "ctx_id"         - the configuration context ID.
- *  "mac"            - MAC address as an array of 6 uint8_t entries.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_net_mac(uint32_t ctx_id, uint8_t *const c_mac);
-
-/**
  * Configures a map of host to guest TCP ports for the microVM.
  *
  * Arguments:
@@ -526,8 +475,9 @@ int32_t krun_set_net_mac(uint32_t ctx_id, uint8_t *const c_mac);
  *  means that for a map such as "8080:80", applications running inside the guest will also
  *  need to access the service through the "8080" port.
  *
- * If past networking mode is used (krun_set_passt_fd was called), port mapping is not supported
- * as an API of libkrun (but you can still do port mapping using command line arguments of passt)
+ * If passt networking mode is used, port mapping is not supported as an API
+ * of libkrun (but you can still do port mapping using command line arguments
+ * of passt)
  */
 int32_t krun_set_port_map(uint32_t ctx_id, const char *const port_map[]);
 

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -85,21 +85,6 @@ int32_t krun_set_vm_config(uint32_t ctx_id, uint8_t num_vcpus, uint32_t ram_mib)
  */
 #define KRUN_FS_ROOT_TAG "/dev/root"
 
-/**
- * Sets the path to be use as root for the microVM. Not available in libkrun-SEV.
- *
- * For more control over the root filesystem (e.g. read-only, DAX window size),
- * use krun_add_virtiofs3() with KRUN_FS_ROOT_TAG instead.
- *
- * Arguments:
- *  "ctx_id"    - the configuration context ID.
- *  "root_path" - a null-terminated string representing the path to be used as root.
- *
- * Returns:
- *  Zero on success or a negative error number on failure.
- */
-int32_t krun_set_root(uint32_t ctx_id, const char *root_path);
-
 
 
 /**
@@ -758,8 +743,7 @@ int32_t krun_set_smbios_oem_strings(uint32_t ctx_id, const char *const oem_strin
  *
  * Arguments:
  *  "ctx_id"        - the configuration context ID.
- *  "workdir_path"  - the path to the working directory, relative to the root configured with
- *                    "krun_set_root".
+ *  "workdir_path"  - the path to the working directory, relative to the root filesystem.
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
@@ -773,7 +757,7 @@ int32_t krun_set_workdir(uint32_t ctx_id,
  *
  * Arguments:
  *  "ctx_id"    - the configuration context ID.
- *  "exec_path" - the path to the executable, relative to the root configured with "krun_set_root".
+ *  "exec_path" - the path to the executable, relative to the root filesystem.
  *  "argv"      - an array of string pointers to be passed as arguments.
  *  "envp"      - an array of string pointers to be injected as environment variables into the
  *                context of the executable. If NULL, it will auto-generate an array collecting the
@@ -1027,7 +1011,7 @@ int32_t krun_split_irqchip(uint32_t ctx_id, bool enable);
 
 /**
  * Do not inject the default init binary (/init.krun) into the root
- * filesystem. Must be called before krun_set_root().
+ * filesystem. Must be called before configuring the root filesystem.
  *
  * No-op when libkrun is built without the "init-blob" feature (there is no
  * implicit init to disable).

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -1025,13 +1025,6 @@ int32_t krun_get_max_vcpus(void);
 */
 int32_t krun_split_irqchip(uint32_t ctx_id, bool enable);
 
-/*
- * NOTE: Implicit resource creation is a legacy convenience. The 2.0 API
- * (see https://github.com/containers/libkrun/issues/634) will not create
- * any implicit resources. Callers should start using the
- * krun_disable_implicit_* functions now to ease migration.
- */
-
 /**
  * Do not inject the default init binary (/init.krun) into the root
  * filesystem. Must be called before krun_set_root().

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -181,10 +181,6 @@ struct ContextConfig {
     #[cfg(feature = "blk")]
     block_cfgs: Vec<BlockDeviceConfig>,
     #[cfg(feature = "blk")]
-    root_block_cfg: Option<BlockDeviceConfig>,
-    #[cfg(feature = "blk")]
-    data_block_cfg: Option<BlockDeviceConfig>,
-    #[cfg(feature = "blk")]
     block_root: Option<BlockRootConfig>,
     #[cfg(feature = "tee")]
     tee_config_file: Option<PathBuf>,
@@ -292,30 +288,8 @@ impl ContextConfig {
     }
 
     #[cfg(feature = "blk")]
-    fn set_root_block_cfg(&mut self, block_cfg: BlockDeviceConfig) {
-        self.root_block_cfg = Some(block_cfg);
-    }
-
-    #[cfg(feature = "blk")]
-    fn set_data_block_cfg(&mut self, block_cfg: BlockDeviceConfig) {
-        self.data_block_cfg = Some(block_cfg);
-    }
-
-    #[cfg(feature = "blk")]
     fn get_block_cfg(&self) -> Vec<BlockDeviceConfig> {
-        // For backwards compat, when cfgs is empty (the new API is not used), this needs to be
-        // root and then data, in that order. Also for backwards compat, root/data are setters and
-        // need to discard redundant calls. So we have simple setters above and fix up here.
-        //
-        // When the new API is used, this is simpler.
-        if self.block_cfgs.is_empty() {
-            [&self.root_block_cfg, &self.data_block_cfg]
-                .into_iter()
-                .filter_map(|cfg| cfg.clone())
-                .collect()
-        } else {
-            self.block_cfgs.clone()
-        }
+        self.block_cfgs.clone()
     }
 
     #[cfg(feature = "net")]
@@ -888,74 +862,6 @@ pub unsafe extern "C" fn krun_add_disk3(
                     sync_mode,
                 };
                 cfg.add_block_cfg(block_device_config);
-            }
-            Entry::Vacant(_) => return -libc::ENOENT,
-        }
-
-        KRUN_SUCCESS
-    }
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-#[cfg(feature = "blk")]
-pub unsafe extern "C" fn krun_set_root_disk(ctx_id: u32, c_disk_path: *const c_char) -> i32 {
-    unsafe {
-        let disk_path = match CStr::from_ptr(c_disk_path).to_str() {
-            Ok(disk) => disk,
-            Err(_) => return -libc::EINVAL,
-        };
-
-        match CTX_MAP.lock().unwrap().entry(ctx_id) {
-            Entry::Occupied(mut ctx_cfg) => {
-                let cfg = ctx_cfg.get_mut();
-                let block_device_config = BlockDeviceConfig {
-                    block_id: "root".to_string(),
-                    cache_type: CacheType::auto(disk_path),
-                    disk_image_path: disk_path.to_string(),
-                    disk_image_format: ImageType::Raw,
-                    is_disk_read_only: false,
-                    direct_io: false,
-                    #[cfg(not(target_os = "macos"))]
-                    sync_mode: SyncMode::Full,
-                    #[cfg(target_os = "macos")]
-                    sync_mode: SyncMode::Relaxed,
-                };
-                cfg.set_root_block_cfg(block_device_config);
-            }
-            Entry::Vacant(_) => return -libc::ENOENT,
-        }
-
-        KRUN_SUCCESS
-    }
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-#[cfg(feature = "blk")]
-pub unsafe extern "C" fn krun_set_data_disk(ctx_id: u32, c_disk_path: *const c_char) -> i32 {
-    unsafe {
-        let disk_path = match CStr::from_ptr(c_disk_path).to_str() {
-            Ok(disk) => disk,
-            Err(_) => return -libc::EINVAL,
-        };
-
-        match CTX_MAP.lock().unwrap().entry(ctx_id) {
-            Entry::Occupied(mut ctx_cfg) => {
-                let cfg = ctx_cfg.get_mut();
-                let block_device_config = BlockDeviceConfig {
-                    block_id: "data".to_string(),
-                    cache_type: CacheType::auto(disk_path),
-                    disk_image_path: disk_path.to_string(),
-                    disk_image_format: ImageType::Raw,
-                    is_disk_read_only: false,
-                    direct_io: false,
-                    #[cfg(not(target_os = "macos"))]
-                    sync_mode: SyncMode::Full,
-                    #[cfg(target_os = "macos")]
-                    sync_mode: SyncMode::Relaxed,
-                };
-                cfg.set_data_block_cfg(block_device_config);
             }
             Entry::Vacant(_) => return -libc::ENOENT,
         }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -177,7 +177,9 @@ struct ContextConfig {
     shutdown_efd: Option<EventFd>,
     gpu_virgl_flags: Option<u32>,
     gpu_shm_size: Option<usize>,
-    console_output: Option<PathBuf>,
+    /// Console output path, only used by the aws-nitro TryFrom path.
+    #[cfg(feature = "aws-nitro")]
+    nitro_console_output: Option<PathBuf>,
     vmm_uid: Option<libc::uid_t>,
     vmm_gid: Option<libc::gid_t>,
     #[cfg(all(
@@ -391,7 +393,7 @@ impl TryFrom<ContextConfig> for NitroEnclave {
             }
         };
 
-        let Some(output_path) = ctx.console_output else {
+        let Some(output_path) = ctx.nitro_console_output else {
             error!("console output path not specified");
             return Err(-libc::EINVAL);
         };
@@ -1752,6 +1754,34 @@ pub unsafe extern "C" fn krun_add_vhost_user_device(
     -libc::ENOTSUP
 }
 
+// FIXME: aws-nitro builds its own NitroEnclave from ContextConfig and needs
+// the console output path directly. This should be replaced with a proper
+// console configuration in the nitro path.
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+#[cfg(feature = "aws-nitro")]
+pub unsafe extern "C" fn krun_set_console_output(ctx_id: u32, c_filepath: *const c_char) -> i32 {
+    unsafe {
+        let filepath = match CStr::from_ptr(c_filepath).to_str() {
+            Ok(f) => f,
+            Err(_) => return -libc::EINVAL,
+        };
+
+        match CTX_MAP.lock().unwrap().entry(ctx_id) {
+            Entry::Occupied(mut ctx_cfg) => {
+                let cfg = ctx_cfg.get_mut();
+                if cfg.nitro_console_output.is_some() {
+                    -libc::EINVAL
+                } else {
+                    cfg.nitro_console_output = Some(PathBuf::from(filepath.to_string()));
+                    KRUN_SUCCESS
+                }
+            }
+            Entry::Vacant(_) => -libc::ENOENT,
+        }
+    }
+}
+
 #[allow(unused_assignments)]
 #[unsafe(no_mangle)]
 pub extern "C" fn krun_get_shutdown_eventfd(ctx_id: u32) -> i32 {
@@ -1768,30 +1798,6 @@ pub extern "C" fn krun_get_shutdown_eventfd(ctx_id: u32) -> i32 {
             }
         }
         Entry::Vacant(_) => -libc::ENOENT,
-    }
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn krun_set_console_output(ctx_id: u32, c_filepath: *const c_char) -> i32 {
-    unsafe {
-        let filepath = match CStr::from_ptr(c_filepath).to_str() {
-            Ok(f) => f,
-            Err(_) => return -libc::EINVAL,
-        };
-
-        match CTX_MAP.lock().unwrap().entry(ctx_id) {
-            Entry::Occupied(mut ctx_cfg) => {
-                let cfg = ctx_cfg.get_mut();
-                if cfg.console_output.is_some() {
-                    -libc::EINVAL
-                } else {
-                    cfg.console_output = Some(PathBuf::from(filepath.to_string()));
-                    KRUN_SUCCESS
-                }
-            }
-            Entry::Vacant(_) => -libc::ENOENT,
-        }
     }
 }
 
@@ -2510,19 +2516,6 @@ pub unsafe extern "C" fn krun_get_default_init(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn krun_disable_implicit_console(ctx_id: u32) -> i32 {
-    match CTX_MAP.lock().unwrap().entry(ctx_id) {
-        Entry::Occupied(mut ctx_cfg) => {
-            let cfg = ctx_cfg.get_mut();
-            cfg.vmr.disable_implicit_console = true;
-        }
-        Entry::Vacant(_) => return -libc::ENOENT,
-    }
-
-    KRUN_SUCCESS
-}
-
-#[unsafe(no_mangle)]
 pub extern "C" fn krun_disable_implicit_vsock(ctx_id: u32) -> i32 {
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
@@ -3008,10 +3001,6 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     }
     if let Some(shm_size) = ctx_cfg.gpu_shm_size {
         ctx_cfg.vmr.set_gpu_shm_size(shm_size);
-    }
-
-    if let Some(console_output) = ctx_cfg.console_output {
-        ctx_cfg.vmr.set_console_output(console_output);
     }
 
     if let Some(gid) = ctx_cfg.vmm_gid

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2516,19 +2516,6 @@ pub unsafe extern "C" fn krun_get_default_init(
 }
 
 #[unsafe(no_mangle)]
-pub extern "C" fn krun_disable_implicit_vsock(ctx_id: u32) -> i32 {
-    match CTX_MAP.lock().unwrap().entry(ctx_id) {
-        Entry::Occupied(mut ctx_cfg) => {
-            let cfg = ctx_cfg.get_mut();
-            cfg.vsock_config = VsockConfig::Disabled;
-        }
-        Entry::Vacant(_) => return -libc::ENOENT,
-    }
-
-    KRUN_SUCCESS
-}
-
-#[unsafe(no_mangle)]
 pub extern "C" fn krun_add_vsock(ctx_id: u32, tsi_features: u32) -> i32 {
     let tsi_flags = match TsiFlags::from_bits(tsi_features) {
         Some(flags) => flags,
@@ -2966,33 +2953,6 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
                 tsi_flags: *tsi_flags,
             };
             ctx_cfg.vmr.set_vsock_device(vsock_device_config).unwrap();
-        }
-        VsockConfig::Implicit => {
-            // Implicit vsock configuration - use heuristics
-            // Check if TSI should be enabled based on network configuration
-            #[cfg(feature = "net")]
-            let enable_tsi = ctx_cfg.vmr.net.list.is_empty();
-            #[cfg(not(feature = "net"))]
-            let enable_tsi = true;
-
-            let has_ipc_map = ctx_cfg.unix_ipc_port_map.is_some();
-
-            if enable_tsi || has_ipc_map {
-                let (tsi_flags, host_port_map) = if enable_tsi {
-                    (TsiFlags::HIJACK_INET, ctx_cfg.tsi_port_map)
-                } else {
-                    (TsiFlags::empty(), None)
-                };
-
-                let vsock_device_config = VsockDeviceConfig {
-                    vsock_id: "vsock0".to_string(),
-                    guest_cid: 3,
-                    host_port_map,
-                    unix_ipc_port_map: ctx_cfg.unix_ipc_port_map.clone(),
-                    tsi_flags,
-                };
-                ctx_cfg.vmr.set_vsock_device(vsock_device_config).unwrap();
-            }
         }
     }
 

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -563,46 +563,6 @@ pub extern "C" fn krun_set_vm_config(ctx_id: u32, num_vcpus: u8, ram_mib: u32) -
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
-pub unsafe extern "C" fn krun_set_root(ctx_id: u32, c_root_path: *const c_char) -> i32 {
-    unsafe {
-        let root_path = match CStr::from_ptr(c_root_path).to_str() {
-            Ok(root) => root,
-            Err(_) => return -libc::EINVAL,
-        };
-
-        let fs_id = "/dev/root".to_string();
-        let shared_dir = root_path.to_string();
-
-        match CTX_MAP.lock().unwrap().entry(ctx_id) {
-            Entry::Occupied(mut ctx_cfg) => {
-                let cfg = ctx_cfg.get_mut();
-                cfg.vmr.add_fs_device(FsDeviceConfig {
-                    fs_id,
-                    shared_dir: Some(shared_dir),
-                    // Default to a conservative 512 MB window.
-                    shm_size: Some(1 << 29),
-                    read_only: false,
-                    virtual_entries: {
-                        #[allow(unused_mut)]
-                        let mut v = Vec::new();
-                        #[cfg(feature = "init-blob")]
-                        if !cfg.disable_implicit_init {
-                            v.push(init_virtual_entry());
-                        }
-                        v
-                    },
-                });
-            }
-            Entry::Vacant(_) => return -libc::ENOENT,
-        }
-
-        KRUN_SUCCESS
-    }
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-#[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 pub unsafe extern "C" fn krun_add_virtiofs(
     ctx_id: u32,
     c_tag: *const c_char,

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -155,13 +155,6 @@ impl KrunfwBindings {
     }
 }
 
-#[derive(Clone)]
-#[cfg(feature = "net")]
-enum LegacyNetworkConfig {
-    VirtioNetPasst(RawFd),
-    VirtioNetGvproxy(PathBuf),
-}
-
 #[derive(Default)]
 struct ContextConfig {
     krunfw: Option<KrunfwBindings>,
@@ -171,10 +164,6 @@ struct ContextConfig {
     env: Option<String>,
     args: Option<String>,
     rlimits: Option<String>,
-    #[cfg(feature = "net")]
-    legacy_net_cfg: Option<LegacyNetworkConfig>,
-    #[cfg(feature = "net")]
-    legacy_mac: Option<[u8; 6]>,
     net_index: u8,
     tsi_port_map: Option<HashMap<u16, u16>>,
     vsock_config: VsockConfig,
@@ -290,11 +279,6 @@ impl ContextConfig {
     #[cfg(feature = "blk")]
     fn get_block_cfg(&self) -> Vec<BlockDeviceConfig> {
         self.block_cfgs.clone()
-    }
-
-    #[cfg(feature = "net")]
-    fn set_net_mac(&mut self, mac: [u8; 6]) {
-        self.legacy_mac = Some(mac);
     }
 
     fn set_port_map(&mut self, new_port_map: HashMap<u16, u16>) -> Result<(), ()> {
@@ -898,19 +882,7 @@ const NET_FEATURE_HOST_TSO4: u32 = 1 << 11;
 const NET_FEATURE_HOST_TSO6: u32 = 1 << 12;
 #[cfg(feature = "net")]
 const NET_FEATURE_HOST_UFO: u32 = 1 << 14;
-/*
- * These are the flags enabled by default on each virtio-net instance
- * before the introduction of "krun_add_net_*". They are now used in
- * the legacy API ("krun_set_passt_fd" and "krun_set_gvproxy_path")
- * for compatiblity reasons.
- */
-#[cfg(feature = "net")]
-const NET_COMPAT_FEATURES: u32 = NET_FEATURE_CSUM
-    | NET_FEATURE_GUEST_CSUM
-    | NET_FEATURE_GUEST_TSO4
-    | NET_FEATURE_GUEST_UFO
-    | NET_FEATURE_HOST_TSO4
-    | NET_FEATURE_HOST_UFO;
+
 #[cfg(feature = "net")]
 const NET_ALL_FEATURES: u32 = NET_FEATURE_CSUM
     | NET_FEATURE_GUEST_CSUM
@@ -1112,79 +1084,6 @@ pub unsafe extern "C" fn krun_add_net_tap(
     _flags: u32,
 ) -> i32 {
     -libc::EINVAL
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-#[cfg(feature = "net")]
-pub unsafe extern "C" fn krun_set_passt_fd(ctx_id: u32, fd: c_int) -> i32 {
-    if fd < 0 {
-        return -libc::EINVAL;
-    }
-
-    match CTX_MAP.lock().unwrap().entry(ctx_id) {
-        Entry::Occupied(mut ctx_cfg) => {
-            let cfg = ctx_cfg.get_mut();
-            // The legacy interface only supports a single network interface.
-            if cfg.net_index != 0 {
-                return -libc::EINVAL;
-            }
-            cfg.legacy_net_cfg = Some(LegacyNetworkConfig::VirtioNetPasst(fd));
-        }
-        Entry::Vacant(_) => return -libc::ENOENT,
-    }
-    KRUN_SUCCESS
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-#[cfg(feature = "net")]
-pub unsafe extern "C" fn krun_set_gvproxy_path(ctx_id: u32, c_path: *const c_char) -> i32 {
-    unsafe {
-        let path_str = match CStr::from_ptr(c_path).to_str() {
-            Ok(path) => path,
-            Err(e) => {
-                debug!("Error parsing gvproxy_path: {e:?}");
-                return -libc::EINVAL;
-            }
-        };
-
-        let path = PathBuf::from(path_str);
-
-        match CTX_MAP.lock().unwrap().entry(ctx_id) {
-            Entry::Occupied(mut ctx_cfg) => {
-                let cfg = ctx_cfg.get_mut();
-                // The legacy interface only supports a single network interface.
-                if cfg.net_index != 0 {
-                    return -libc::EINVAL;
-                }
-                cfg.legacy_net_cfg = Some(LegacyNetworkConfig::VirtioNetGvproxy(path));
-            }
-            Entry::Vacant(_) => return -libc::ENOENT,
-        }
-        KRUN_SUCCESS
-    }
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
-#[cfg(feature = "net")]
-pub unsafe extern "C" fn krun_set_net_mac(ctx_id: u32, c_mac: *const u8) -> i32 {
-    unsafe {
-        let mac: [u8; 6] = match slice::from_raw_parts(c_mac, 6).try_into() {
-            Ok(m) => m,
-            Err(_) => return -libc::EINVAL,
-        };
-
-        match CTX_MAP.lock().unwrap().entry(ctx_id) {
-            Entry::Occupied(mut ctx_cfg) => {
-                let cfg = ctx_cfg.get_mut();
-                cfg.set_net_mac(mac);
-            }
-            Entry::Vacant(_) => return -libc::ENOENT,
-        }
-        KRUN_SUCCESS
-    }
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -3085,22 +2984,6 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         return -libc::EINVAL;
     }
 
-    #[cfg(feature = "net")]
-    {
-        if let Some(legacy_net_cfg) = ctx_cfg.legacy_net_cfg.clone() {
-            let backend = match legacy_net_cfg {
-                LegacyNetworkConfig::VirtioNetGvproxy(path) => {
-                    VirtioNetBackend::UnixgramPath(path, true)
-                }
-                LegacyNetworkConfig::VirtioNetPasst(fd) => VirtioNetBackend::UnixstreamFd(fd),
-            };
-            let mac = ctx_cfg
-                .legacy_mac
-                .unwrap_or([0x5a, 0x94, 0xef, 0xe4, 0x0c, 0xee]);
-            create_virtio_net(&mut ctx_cfg, backend, mac, NET_COMPAT_FEATURES);
-        }
-    }
-
     match &ctx_cfg.vsock_config {
         VsockConfig::Disabled => (),
         VsockConfig::Explicit { tsi_flags } => {
@@ -3117,7 +3000,7 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
             // Implicit vsock configuration - use heuristics
             // Check if TSI should be enabled based on network configuration
             #[cfg(feature = "net")]
-            let enable_tsi = ctx_cfg.vmr.net.list.is_empty() && ctx_cfg.legacy_net_cfg.is_none();
+            let enable_tsi = ctx_cfg.vmr.net.list.is_empty();
             #[cfg(not(feature = "net"))]
             let enable_tsi = true;
 

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -686,16 +686,6 @@ pub unsafe extern "C" fn krun_add_virtiofs3(
 
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
-#[cfg(not(feature = "tee"))]
-pub unsafe extern "C" fn krun_set_mapped_volumes(
-    _ctx_id: u32,
-    _c_mapped_volumes: *const *const c_char,
-) -> i32 {
-    -libc::EINVAL
-}
-
-#[allow(clippy::missing_safety_doc)]
-#[unsafe(no_mangle)]
 #[cfg(feature = "blk")]
 pub unsafe extern "C" fn krun_add_disk(
     ctx_id: u32,

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -435,26 +435,6 @@ fn log_level_to_filter_str(level: u32) -> &'static str {
     }
 }
 
-#[unsafe(no_mangle)]
-pub extern "C" fn krun_set_log_level(level: u32) -> i32 {
-    let filter = log_level_to_filter_str(level);
-    env_logger::Builder::from_env(Env::default().default_filter_or(filter))
-        .format_timestamp_micros()
-        .init();
-
-    #[cfg(feature = "aws-nitro")]
-    {
-        // Notify krun-awsnitro to enable debug for log level.
-        if level == 4 {
-            let mut debug = KRUN_NITRO_DEBUG.lock().unwrap();
-
-            *debug = true;
-        }
-    }
-
-    KRUN_SUCCESS
-}
-
 mod log_defs {
     pub const KRUN_LOG_STYLE_AUTO: u32 = 0;
     pub const KRUN_LOG_STYLE_ALWAYS: u32 = 1;
@@ -502,6 +482,14 @@ pub unsafe extern "C" fn krun_init_log(target: RawFd, level: u32, style: u32, op
             builder
         };
         builder.format_timestamp_micros().target(target).init();
+
+        #[cfg(feature = "aws-nitro")]
+        {
+            // Notify krun-awsnitro to enable debug for log level.
+            if level >= 4 {
+                *KRUN_NITRO_DEBUG.lock().unwrap() = true;
+            }
+        }
 
         KRUN_SUCCESS
     }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -3047,7 +3047,7 @@ mod test_disable_implicit_init {
         let ctx = unsafe { krun_create_ctx() } as u32;
         unsafe {
             krun_disable_implicit_init(ctx);
-            krun_set_root(ctx, c"/tmp".as_ptr());
+            krun_add_virtiofs3(ctx, c"/dev/root".as_ptr(), c"/tmp".as_ptr(), 0, false);
         }
 
         let ctx_map = CTX_MAP.lock().unwrap();

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -18,6 +18,7 @@ use std::os::fd::AsRawFd;
 use std::os::fd::{BorrowedFd, FromRawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawHandle, BorrowedHandle, FromRawHandle};
+#[cfg(windows)]
 use std::path::PathBuf;
 use std::sync::atomic::AtomicI32;
 use std::sync::{Arc, Mutex};
@@ -745,17 +746,6 @@ pub fn build_microvm(
 
     let mut serial_devices = Vec::new();
 
-    // Create the legacy serial device if we're booting from a firmware
-    if vm_resources.firmware_config.is_some() && !vm_resources.disable_implicit_console {
-        serial_devices.push(setup_serial_device(
-            event_manager,
-            None,
-            None,
-            // Uncomment this to get EFI output when debugging EDK2.
-            //Some(Box::new(io::stdout())),
-        )?);
-    };
-
     // We can't call to `setup_terminal_raw_mode` until `Vmm` is created,
     // so let's keep track of FDs connected to legacy serial devices here
     // and set raw mode on them later.
@@ -1041,29 +1031,15 @@ pub fn build_microvm(
             attach_rng_device(&mut vmm, event_manager, intc.clone())?;
         }
     }
-    let mut console_id = 0;
-    if !vm_resources.disable_implicit_console {
-        attach_console_devices(
-            &mut vmm,
-            event_manager,
-            intc.clone(),
-            vm_resources,
-            None,
-            console_id,
-        )?;
-        console_id += 1;
-    }
-
-    for console_cfg in vm_resources.virtio_consoles.iter() {
+    for (console_id, console_cfg) in vm_resources.virtio_consoles.iter().enumerate() {
         attach_console_devices(
             &mut vmm,
             event_manager,
             intc.clone(),
             vm_resources,
             Some(console_cfg),
-            console_id,
+            console_id as u32,
         )?;
-        console_id += 1;
     }
 
     #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
@@ -2176,40 +2152,14 @@ fn attach_fs_devices(
 #[cfg(unix)]
 fn autoconfigure_console_ports(
     vmm: &mut Vmm,
-    vm_resources: &VmResources,
+    _vm_resources: &VmResources,
     cfg: Option<&DefaultVirtioConsoleConfig>,
-    creating_implicit_console: bool,
 ) -> std::result::Result<Vec<PortDescription>, StartMicrovmError> {
-    use self::StartMicrovmError::*;
-
-    let mut console_output_path: Option<PathBuf> = None;
-    if let Some(path) = vm_resources.console_output.clone()
-        && !vm_resources.disable_implicit_console
-        && creating_implicit_console
+    let (input_fd, output_fd, err_fd) = match cfg {
+        Some(c) => (c.input_fd, c.output_fd, c.err_fd),
+        None => (STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO),
+    };
     {
-        console_output_path = Some(path)
-    }
-
-    if let Some(console_output_path) = console_output_path {
-        let file = File::create(console_output_path).map_err(OpenConsoleFile)?;
-        // Manually emulate our Legacy behavior: In the case of output_path we have always used the
-        // stdin to determine the console size
-        let stdin_fd = unsafe { BorrowedFd::borrow_raw(STDIN_FILENO) };
-        let term_fd = if isatty(stdin_fd).is_ok_and(|v| v) {
-            port_io::term_fd(stdin_fd.as_raw_fd()).unwrap()
-        } else {
-            port_io::term_fixed_size(0, 0)
-        };
-        Ok(vec![PortDescription::console(
-            Some(port_io::input_empty().unwrap()),
-            Some(port_io::output_file(file).unwrap()),
-            term_fd,
-        )])
-    } else {
-        let (input_fd, output_fd, err_fd) = match cfg {
-            Some(c) => (c.input_fd, c.output_fd, c.err_fd),
-            None => (STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO),
-        };
         let input_is_terminal =
             input_fd >= 0 && isatty(unsafe { BorrowedFd::borrow_raw(input_fd) }).unwrap_or(false);
         let output_is_terminal =
@@ -2237,7 +2187,8 @@ fn autoconfigure_console_ports(
                 forwarding_sigint = true;
                 let sigint_input = port_io::PortInputSigInt::new();
                 let sigint_input_fd = sigint_input.sigint_evt().as_raw_fd();
-                register_sigint_handler(sigint_input_fd).map_err(RegisterFsSigwinch)?;
+                register_sigint_handler(sigint_input_fd)
+                    .map_err(StartMicrovmError::RegisterFsSigwinch)?;
                 Some(Box::new(sigint_input) as _)
             }
             #[cfg(not(target_os = "linux"))]
@@ -2561,16 +2512,11 @@ fn attach_console_devices(
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
 
-    let creating_implicit_console = cfg.is_none();
-
     let ports = match cfg {
-        None => autoconfigure_console_ports(vmm, vm_resources, None, creating_implicit_console)?,
-        Some(VirtioConsoleConfigMode::Autoconfigure(autocfg)) => autoconfigure_console_ports(
-            vmm,
-            vm_resources,
-            Some(autocfg),
-            creating_implicit_console,
-        )?,
+        None => autoconfigure_console_ports(vmm, vm_resources, None)?,
+        Some(VirtioConsoleConfigMode::Autoconfigure(autocfg)) => {
+            autoconfigure_console_ports(vmm, vm_resources, Some(autocfg))?
+        }
         Some(VirtioConsoleConfigMode::Explicit(ports)) => create_explicit_ports(vmm, ports)?,
     };
 

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -164,13 +164,11 @@ pub enum PortConfig {
 /// Configuration for the vsock device
 #[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub enum VsockConfig {
-    /// Default behavior - vsock created implicitly with heuristics-based TSI
+    /// No vsock device
     #[default]
-    Implicit,
+    Disabled,
     /// Explicit configuration with specified TSI features
     Explicit { tsi_flags: TsiFlags },
-    /// Vsock device disabled
-    Disabled,
 }
 
 /// A data structure that encapsulates the device configurations

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -9,6 +9,7 @@ use std::fs::File;
 use std::io::BufReader;
 #[cfg(unix)]
 use std::os::fd::RawFd;
+#[cfg(feature = "tee")]
 use std::path::PathBuf;
 #[cfg(target_os = "windows")]
 use utils::windows::SendHandle;
@@ -221,16 +222,12 @@ pub struct VmResources {
     #[cfg(feature = "vhost-user")]
     /// Vhost-user device configurations
     pub vhost_user_devices: Vec<VhostUserDeviceConfig>,
-    /// File to send console output.
-    pub console_output: Option<PathBuf>,
     /// SMBIOS OEM Strings
     pub smbios_oem_strings: Option<Vec<String>>,
     /// Whether to enable nested virtualization.
     pub nested_enabled: bool,
     /// Whether to enable split irqchip
     pub split_irqchip: bool,
-    /// Do not create an implicit console device in the guest
-    pub disable_implicit_console: bool,
     /// The console id to use for console= in the kernel cmdline
     pub kernel_console: Option<String>,
     /// Serial consoles to attach to the guest
@@ -390,10 +387,6 @@ impl VmResources {
         self.gpu_shm_size = Some(shm_size);
     }
 
-    pub fn set_console_output(&mut self, console_output: PathBuf) {
-        self.console_output = Some(console_output);
-    }
-
     /// Sets a network device to be attached when the VM starts.
     #[cfg(feature = "net")]
     pub fn add_network_interface(
@@ -432,8 +425,6 @@ impl VmResources {
 
 #[cfg(test)]
 mod tests {
-    #[cfg(feature = "gpu")]
-    use crate::resources::DisplayBackendConfig;
     use crate::resources::VmResources;
     use crate::vmm_config::kernel_cmdline::KernelCmdlineConfig;
     use crate::vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
@@ -472,11 +463,9 @@ mod tests {
             input_backends: Vec::new(),
             #[cfg(feature = "vhost-user")]
             vhost_user_devices: Vec::new(),
-            console_output: None,
             smbios_oem_strings: None,
             nested_enabled: false,
             split_irqchip: false,
-            disable_implicit_console: false,
             serial_consoles: Vec::new(),
             virtio_consoles: Vec::new(),
             kernel_console: None,

--- a/tests/test_cases/src/common.rs
+++ b/tests/test_cases/src/common.rs
@@ -52,7 +52,13 @@ pub fn setup_fs_and_enter_with_env(
         .collect();
     envp.push(null());
     unsafe {
-        krun_call!(krun_set_root(ctx, path_str.as_ptr()))?;
+        krun_call!(krun_add_virtiofs3(
+            ctx,
+            c"/dev/root".as_ptr(),
+            path_str.as_ptr(),
+            0,
+            false,
+        ))?;
         krun_call!(krun_set_workdir(ctx, c"/".as_ptr()))?;
         let test_case_cstr = CString::new(test_setup.test_case).context("CString::new")?;
         let argv = [test_case_cstr.as_ptr(), null()];

--- a/tests/test_cases/src/common_freebsd.rs
+++ b/tests/test_cases/src/common_freebsd.rs
@@ -209,7 +209,6 @@ unsafe fn do_setup_and_enter(
             CString::new(config_iso.as_os_str().as_bytes()).context("CString::new")?;
 
         // FreeBSD requires a serial console; virtio console is not supported.
-        krun_call!(krun_disable_implicit_console(ctx))?;
         krun_call!(krun_add_serial_console_default(ctx, serial_read_fd, 1))?;
 
         // Kernel cmdline: mount vtbd0 as root via cd9660 and hand off to init-freebsd.

--- a/tests/test_cases/src/test_augmentfs.rs
+++ b/tests/test_cases/src/test_augmentfs.rs
@@ -48,7 +48,7 @@ mod host {
             let marker: &'static [u8] = b"virtual-file-marker-content-12345";
 
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
 

--- a/tests/test_cases/src/test_augmentfs.rs
+++ b/tests/test_cases/src/test_augmentfs.rs
@@ -21,6 +21,7 @@ mod host {
     use crate::{krun_call, krun_call_u32};
     use krun_sys::*;
     use std::ffi::CString;
+    use std::os::fd::AsRawFd;
     use std::ptr::null_mut;
 
     impl Test for TestAugmentFs {
@@ -48,9 +49,20 @@ mod host {
             let marker: &'static [u8] = b"virtual-file-marker-content-12345";
 
             unsafe {
-                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
 
                 // Disable the implicit init — we'll inject it ourselves.
                 krun_call!(krun_disable_implicit_init(ctx))?;

--- a/tests/test_cases/src/test_freebsd_boot.rs
+++ b/tests/test_cases/src/test_freebsd_boot.rs
@@ -26,7 +26,12 @@ mod host {
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
             let assets = freebsd_assets().expect("FreeBSD assets must be present when test runs");
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
                 setup_kernel_and_enter(ctx, test_setup, assets)?;

--- a/tests/test_cases/src/test_freebsd_gvproxy_tcp_guest_connect.rs
+++ b/tests/test_cases/src/test_freebsd_gvproxy_tcp_guest_connect.rs
@@ -52,7 +52,12 @@ mod host {
             thread::spawn(move || self.tcp_tester.run_server(listener));
 
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
                 setup_gvproxy_backend(ctx, &test_setup)?;

--- a/tests/test_cases/src/test_freebsd_gvproxy_tcp_guest_listen.rs
+++ b/tests/test_cases/src/test_freebsd_gvproxy_tcp_guest_listen.rs
@@ -50,7 +50,12 @@ mod host {
             let assets = freebsd_assets().expect("freebsd assets must be available");
 
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
                 let net_sock = setup_gvproxy_backend(ctx, &test_setup)?;

--- a/tests/test_cases/src/test_multiport_console.rs
+++ b/tests/test_cases/src/test_multiport_console.rs
@@ -58,8 +58,6 @@ mod host {
                 ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
 
-                krun_call!(krun_disable_implicit_console(ctx))?;
-
                 // Add a default console (as with other tests this uses stdout for writing "OK")
                 krun_call!(krun_add_virtio_console_default(
                     ctx,

--- a/tests/test_cases/src/test_multiport_console.rs
+++ b/tests/test_cases/src/test_multiport_console.rs
@@ -50,7 +50,12 @@ mod host {
     impl Test for TestMultiportConsole {
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
 
                 krun_call!(krun_disable_implicit_console(ctx))?;

--- a/tests/test_cases/src/test_net/mod.rs
+++ b/tests/test_cases/src/test_net/mod.rs
@@ -136,7 +136,7 @@ mod host {
             thread::spawn(move || tcp_tester.run_server(listener));
 
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
 

--- a/tests/test_cases/src/test_net/mod.rs
+++ b/tests/test_cases/src/test_net/mod.rs
@@ -106,6 +106,7 @@ mod host {
     use crate::common::setup_fs_and_enter;
     use crate::{Test, TestOutcome, TestSetup, krun_call, krun_call_u32};
     use krun_sys::*;
+    use std::os::fd::AsRawFd;
     use std::thread;
 
     impl Test for TestNet {
@@ -136,13 +137,24 @@ mod host {
             thread::spawn(move || tcp_tester.run_server(listener));
 
             unsafe {
-                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
 
                 // Backend-specific setup
                 (self.setup_backend)(ctx, &test_setup)?;
 
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter(ctx, test_setup)?;
             }
             Ok(())

--- a/tests/test_cases/src/test_net_perf.rs
+++ b/tests/test_cases/src/test_net_perf.rs
@@ -155,6 +155,7 @@ mod host {
     use crate::common::setup_fs_and_enter;
     use crate::{Test, TestOutcome, TestSetup, krun_call, krun_call_u32};
     use krun_sys::*;
+    use std::os::fd::AsRawFd;
     use std::process::{Child, Command, Stdio};
 
     const CONTAINERFILE: &str = "\
@@ -360,6 +361,12 @@ RUN dnf install -y iperf3 && dnf clean all
                 // Backend-specific setup
                 (self.setup_backend)(ctx, &test_setup)?;
 
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter(ctx, test_setup)?;
             }
             Ok(())

--- a/tests/test_cases/src/test_pjdfstest.rs
+++ b/tests/test_cases/src/test_pjdfstest.rs
@@ -9,6 +9,7 @@ mod host {
     use crate::{ShouldRun, Test, TestOutcome, TestSetup, krun_call, krun_call_u32};
     use krun_sys::*;
     use std::ffi::CString;
+    use std::os::fd::AsRawFd;
 
     use macros::env_or_default;
 
@@ -54,6 +55,12 @@ mod host {
             unsafe {
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 2, 1024))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter_with_env(ctx, test_setup, &[host_os_env.as_c_str()])?;
             }
             Ok(())

--- a/tests/test_cases/src/test_root_disk_remount.rs
+++ b/tests/test_cases/src/test_root_disk_remount.rs
@@ -98,7 +98,12 @@ mod host {
             let test_case = CString::new(test_setup.test_case)?;
 
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
 

--- a/tests/test_cases/src/test_root_disk_remount.rs
+++ b/tests/test_cases/src/test_root_disk_remount.rs
@@ -18,6 +18,7 @@ mod host {
     use krun_sys::*;
     use nix::libc;
     use std::ffi::CString;
+    use std::os::fd::AsRawFd;
     use std::process::Command;
     use std::ptr::null;
 
@@ -106,6 +107,12 @@ mod host {
                 ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
 
                 let argv = [test_case.as_ptr(), null()];
                 let envp = [null()];

--- a/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
@@ -31,7 +31,7 @@ mod host {
             let listener = self.tcp_tester.create_server_socket();
             thread::spawn(move || self.tcp_tester.run_server(listener));
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
                 setup_fs_and_enter(ctx, test_setup)?;

--- a/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
@@ -39,6 +39,7 @@ mod host {
                     0
                 ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_add_vsock(ctx, KRUN_TSI_HIJACK_INET))?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
                 krun_call!(krun_add_virtio_console_default(
                     ctx,

--- a/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_connect.rs
@@ -24,6 +24,7 @@ mod host {
     use crate::{Test, TestSetup};
     use crate::{krun_call, krun_call_u32};
     use krun_sys::*;
+    use std::os::fd::AsRawFd;
     use std::thread;
 
     impl Test for TestTsiTcpGuestConnect {
@@ -31,9 +32,20 @@ mod host {
             let listener = self.tcp_tester.create_server_socket();
             thread::spawn(move || self.tcp_tester.run_server(listener));
             unsafe {
-                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter(ctx, test_setup)?;
             }
             Ok(())

--- a/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
@@ -33,7 +33,7 @@ mod host {
                     self.tcp_tester.run_client();
                 });
 
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 let port_mapping = format!("{PORT}:{PORT}");
                 let port_mapping = CString::new(port_mapping).unwrap();

--- a/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
@@ -45,6 +45,7 @@ mod host {
                 let port_mapping = CString::new(port_mapping).unwrap();
                 let port_map = [port_mapping.as_ptr(), null()];
 
+                krun_call!(krun_add_vsock(ctx, KRUN_TSI_HIJACK_INET))?;
                 krun_call!(krun_set_port_map(ctx, port_map.as_ptr()))?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
                 krun_call!(krun_add_virtio_console_default(

--- a/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
+++ b/tests/test_cases/src/test_tsi_tcp_guest_listen.rs
@@ -23,6 +23,7 @@ mod host {
     use crate::{Test, TestSetup, krun_call, krun_call_u32};
     use krun_sys::*;
     use std::ffi::CString;
+    use std::os::fd::AsRawFd;
     use std::ptr::null;
     use std::thread;
 
@@ -33,7 +34,12 @@ mod host {
                     self.tcp_tester.run_client();
                 });
 
-                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 let port_mapping = format!("{PORT}:{PORT}");
                 let port_mapping = CString::new(port_mapping).unwrap();
@@ -41,6 +47,12 @@ mod host {
 
                 krun_call!(krun_set_port_map(ctx, port_map.as_ptr()))?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter(ctx, test_setup)?;
                 println!("OK");
             }

--- a/tests/test_cases/src/test_virtiofs_misc.rs
+++ b/tests/test_cases/src/test_virtiofs_misc.rs
@@ -17,7 +17,7 @@ mod host {
     impl Test for TestVirtioFsMisc {
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 1024))?;
                 setup_fs_and_enter(ctx, test_setup)?;

--- a/tests/test_cases/src/test_virtiofs_misc.rs
+++ b/tests/test_cases/src/test_virtiofs_misc.rs
@@ -13,13 +13,25 @@ mod host {
     use crate::{krun_call, krun_call_u32};
     use krun_sys::*;
     use std::io::Read;
+    use std::os::fd::AsRawFd;
 
     impl Test for TestVirtioFsMisc {
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
             unsafe {
-                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 1024))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter(ctx, test_setup)?;
             }
             Ok(())

--- a/tests/test_cases/src/test_virtiofs_root_ro.rs
+++ b/tests/test_cases/src/test_virtiofs_root_ro.rs
@@ -42,7 +42,12 @@ mod host {
             let envp = [null()];
 
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
 

--- a/tests/test_cases/src/test_virtiofs_root_ro.rs
+++ b/tests/test_cases/src/test_virtiofs_root_ro.rs
@@ -22,6 +22,7 @@ mod host {
     use krun_sys::*;
     use std::ffi::CString;
     use std::fs;
+    use std::os::fd::AsRawFd;
     use std::os::unix::ffi::OsStrExt;
     use std::ptr::null;
 
@@ -50,6 +51,12 @@ mod host {
                 ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
 
                 // Use "/dev/root" tag (KRUN_FS_ROOT_TAG) with read_only=true
                 krun_call!(krun_add_virtiofs3(

--- a/tests/test_cases/src/test_vm_config.rs
+++ b/tests/test_cases/src/test_vm_config.rs
@@ -17,7 +17,7 @@ mod host {
     impl Test for TestVmConfig {
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, self.num_cpus, self.ram_mib))?;
                 setup_fs_and_enter(ctx, test_setup)?;

--- a/tests/test_cases/src/test_vm_config.rs
+++ b/tests/test_cases/src/test_vm_config.rs
@@ -13,13 +13,25 @@ mod host {
     use crate::{Test, TestSetup};
     use crate::{krun_call, krun_call_u32};
     use krun_sys::*;
+    use std::os::fd::AsRawFd;
 
     impl Test for TestVmConfig {
         fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
             unsafe {
-                krun_call!(krun_init_log(KRUN_LOG_TARGET_DEFAULT, KRUN_LOG_LEVEL_TRACE, KRUN_LOG_STYLE_AUTO, 0))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_set_vm_config(ctx, self.num_cpus, self.ram_mib))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter(ctx, test_setup)?;
             }
             Ok(())

--- a/tests/test_cases/src/test_vsock_guest_connect.rs
+++ b/tests/test_cases/src/test_vsock_guest_connect.rs
@@ -73,6 +73,7 @@ mod host {
                     0
                 ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_add_vsock(ctx, 0))?;
                 krun_call!(krun_add_vsock_port(
                     ctx,
                     VSOCK_PORT,

--- a/tests/test_cases/src/test_vsock_guest_connect.rs
+++ b/tests/test_cases/src/test_vsock_guest_connect.rs
@@ -65,7 +65,12 @@ mod host {
 
             thread::spawn(move || server(listener));
             unsafe {
-                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
                 let ctx = krun_call_u32!(krun_create_ctx())?;
                 krun_call!(krun_add_vsock_port(
                     ctx,

--- a/tests/test_cases/src/test_vsock_guest_connect.rs
+++ b/tests/test_cases/src/test_vsock_guest_connect.rs
@@ -41,6 +41,7 @@ mod host {
     use krun_sys::*;
     use std::ffi::CString;
     use std::io::Write;
+    use std::os::fd::AsRawFd;
     use std::os::unix::net::UnixListener;
     use std::os::unix::prelude::OsStrExt;
     use std::{mem, thread};
@@ -78,6 +79,12 @@ mod host {
                     sock_path_cstr.as_ptr()
                 ))?;
                 krun_call!(krun_set_vm_config(ctx, 1, 1024))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
                 setup_fs_and_enter(ctx, test_setup)?;
             }
             Ok(())


### PR DESCRIPTION
This PR removes deprecated and superseded API functions, preparing for the 2.0 API (https://github.com/containers/libkrun/issues/634).

The init-blob integration (`krun_inject_init`, `krun_set_oci_config_json`, init config delivery changes) has been split into a separate PR built on top of this one.

### Deprecated functions removed
- `krun_set_log_level` → `krun_init_log`
- `krun_set_root_disk` → `krun_add_disk3`
- `krun_set_data_disk` → `krun_add_disk3`
- `krun_set_passt_fd` → `krun_add_net_unixstream`
- `krun_set_gvproxy_path` → `krun_add_net_unixgram`
- `krun_set_net_mac` → mac parameter on `krun_add_net_*`
- `krun_set_mapped_volumes` — was already returning `-EINVAL`
- `krun_set_root` → `krun_add_virtiofs3` with `"/dev/root"` tag
- `krun_set_console_output` → `krun_add_virtio_console_default`

### Implicit resource creation removed
- `krun_disable_implicit_console` → this is now the default behavior
- `krun_disable_implicit_vsock` →  this is now the default behavior

Tests and examples have been updated to use the current API equivalents.