### PR TITLE
Tsi: handle protocol field to make DGRAM+ICMP ping work 

### DIFF
--- a/init/init-binary/src/env.rs
+++ b/init/init-binary/src/env.rs
@@ -174,6 +174,17 @@ pub fn enable_dummy_interface() {
     }
 }
 
+/// Allow all GIDs to create ICMP ping sockets (SOCK_DGRAM + IPPROTO_ICMP).
+/// Without this the guest kernel rejects them with EACCES, preventing TSI
+/// from hijacking ping sockets.
+#[cfg(target_os = "linux")]
+pub fn enable_ping_sockets() {
+    use std::fs;
+    if let Err(e) = fs::write("/proc/sys/net/ipv4/ping_group_range", "0 2147483647") {
+        eprintln!("Warning: failed to set ping_group_range: {e}");
+    }
+}
+
 pub fn apply_hostname() {
     let hostname = env::var("HOSTNAME").unwrap_or_else(|_| "localhost".into());
     let _ = nix::unistd::sethostname(&hostname);

--- a/init/init-binary/src/main.rs
+++ b/init/init-binary/src/main.rs
@@ -96,6 +96,7 @@ fn main() -> anyhow::Result<()> {
     #[cfg(target_os = "linux")]
     if env::tsi_enabled() {
         env::enable_dummy_interface();
+        env::enable_ping_sockets();
     }
 
     #[cfg(target_os = "freebsd")]

--- a/init/init.c
+++ b/init/init.c
@@ -1552,6 +1552,14 @@ int main(int argc, char **argv)
         if (enable_dummy_interface() < 0) {
             printf("Warning: Couldn't enable dummy interface\n");
         }
+
+        /* Allow unprivileged ICMP ping sockets (SOCK_DGRAM + IPPROTO_ICMP)
+         * for all GIDs so that TSI can hijack and proxy them to the host. */
+        int ping_fd = open("/proc/sys/net/ipv4/ping_group_range", O_WRONLY);
+        if (ping_fd >= 0) {
+            write(ping_fd, "0 2147483647\n", 13);
+            close(ping_fd);
+        }
     }
 #endif
 

--- a/src/devices/src/virtio/vsock/muxer.rs
+++ b/src/devices/src/virtio/vsock/muxer.rs
@@ -316,7 +316,7 @@ impl VsockMuxer {
                     }
                 }
                 defs::SOCK_DGRAM => {
-                    debug!("proxy create dgram");
+                    debug!("proxy create dgram (protocol={})", req.protocol);
                     let id = ((req.peer_port as u64) << 32) | (defs::TSI_PROXY_PORT as u64);
                     if req.family as i32 == libc::AF_UNIX
                         && !self.tsi_flags.contains(TsiFlags::HIJACK_UNIX)
@@ -335,6 +335,7 @@ impl VsockMuxer {
                         self.cid,
                         req.family,
                         req.peer_port,
+                        req.protocol,
                         mem.clone(),
                         queue.clone(),
                         self.rxq.clone(),

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -103,6 +103,7 @@ pub struct TsiProxyCreate {
     pub peer_port: u32,
     pub family: u16,
     pub _type: u16,
+    pub protocol: u16,
 }
 
 #[repr(C)]
@@ -625,19 +626,28 @@ impl VsockPacket {
     }
 
     pub fn read_proxy_create(&self) -> Option<TsiProxyCreate> {
-        if self.buf_size >= 6 {
-            let peer_port: u32 = byte_order::read_le_u32(&self.buf().unwrap()[0..]);
-            let family: u16 = byte_order::read_le_u16(&self.buf().unwrap()[4..]);
-            let _type: u16 = byte_order::read_le_u16(&self.buf().unwrap()[6..]);
-
-            Some(TsiProxyCreate {
-                peer_port,
-                family,
-                _type,
-            })
-        } else {
-            None
+        let buf = self.buf()?;
+        if buf.len() < 8 {
+            return None;
         }
+
+        let peer_port: u32 = byte_order::read_le_u32(&buf[0..]);
+        let family: u16 = byte_order::read_le_u16(&buf[4..]);
+        let _type: u16 = byte_order::read_le_u16(&buf[6..]);
+        // Protocol field added for ICMP ping socket support. Old guests
+        // that don't send it get 0 (= default, same as before).
+        let protocol: u16 = if buf.len() >= 10 {
+            byte_order::read_le_u16(&buf[8..])
+        } else {
+            0
+        };
+
+        Some(TsiProxyCreate {
+            peer_port,
+            family,
+            _type,
+            protocol,
+        })
     }
 
     pub fn read_connect_req(&self) -> Option<TsiConnectReq> {

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -625,7 +625,7 @@ impl VsockPacket {
     }
 
     pub fn read_proxy_create(&self) -> Option<TsiProxyCreate> {
-        if self.buf_size >= 6 {
+        if self.buf_size >= 8 {
             let peer_port: u32 = byte_order::read_le_u32(&self.buf().unwrap()[0..]);
             let family: u16 = byte_order::read_le_u16(&self.buf().unwrap()[4..]);
             let _type: u16 = byte_order::read_le_u16(&self.buf().unwrap()[6..]);

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -103,6 +103,7 @@ pub struct TsiProxyCreate {
     pub peer_port: u32,
     pub family: u16,
     pub _type: u16,
+    pub protocol: u16,
 }
 
 #[repr(C)]
@@ -626,14 +627,23 @@ impl VsockPacket {
 
     pub fn read_proxy_create(&self) -> Option<TsiProxyCreate> {
         if self.buf_size >= 8 {
-            let peer_port: u32 = byte_order::read_le_u32(&self.buf().unwrap()[0..]);
-            let family: u16 = byte_order::read_le_u16(&self.buf().unwrap()[4..]);
-            let _type: u16 = byte_order::read_le_u16(&self.buf().unwrap()[6..]);
+            let buf = self.buf().unwrap();
+            let peer_port: u32 = byte_order::read_le_u32(&buf[0..]);
+            let family: u16 = byte_order::read_le_u16(&buf[4..]);
+            let _type: u16 = byte_order::read_le_u16(&buf[6..]);
+            // Protocol field added for ICMP ping socket support. Old guests
+            // that don't send it get 0 (= default, same as before).
+            let protocol: u16 = if self.buf_size >= 10 {
+                byte_order::read_le_u16(&buf[8..])
+            } else {
+                0
+            };
 
             Some(TsiProxyCreate {
                 peer_port,
                 family,
                 _type,
+                protocol,
             })
         } else {
             None

--- a/src/devices/src/virtio/vsock/tsi_dgram.rs
+++ b/src/devices/src/virtio/vsock/tsi_dgram.rs
@@ -38,6 +38,8 @@ pub struct TsiDgramProxy {
     sendto_addr: Option<SockaddrStorage>,
     listening: bool,
     family: AddressFamily,
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    protocol: u16,
     mem: GuestMemoryMmap,
     queue: Arc<Mutex<VirtQueue>>,
     rxq: Arc<Mutex<MuxerRxQ>>,
@@ -116,6 +118,7 @@ impl TsiDgramProxy {
             sendto_addr: None,
             listening: false,
             family,
+            protocol,
             mem,
             queue,
             rxq,
@@ -180,11 +183,31 @@ impl TsiDgramProxy {
             match recv(self.fd.as_raw_fd(), &mut buf[..max_len], MsgFlags::empty()) {
                 Ok(cnt) => {
                     debug!("recv cnt={cnt}");
-                    if cnt > 0 {
-                        RecvPkt::Read(cnt)
-                    } else {
-                        RecvPkt::Close
+                    if cnt == 0 {
+                        return RecvPkt::Close;
                     }
+
+                    // macOS DGRAM ICMP sockets include the IP header in
+                    // recv, unlike Linux which strips it. Strip the IP
+                    // header (variable length, from the IHL field) so the
+                    // guest sees the same format as a Linux ping socket.
+                    // buf is the guest's RX virtqueue descriptor — writable.
+                    #[cfg(target_os = "macos")]
+                    if matches!(
+                        self.protocol as _,
+                        libc::IPPROTO_ICMP | libc::IPPROTO_ICMPV6
+                    ) && cnt >= 20
+                    {
+                        // IHL (Internet Header Length): low 4 bits of first
+                        // byte, in 32-bit words. Typically 5 (= 20 bytes).
+                        let ip_hdr_len = (buf[0] & 0x0F) as usize * 4;
+                        if ip_hdr_len <= cnt {
+                            buf.copy_within(ip_hdr_len..cnt, 0);
+                            return RecvPkt::Read(cnt - ip_hdr_len);
+                        }
+                    }
+
+                    RecvPkt::Read(cnt)
                 }
                 Err(e) => {
                     debug!("recv_pkt: recv error: {e:?}");

--- a/src/devices/src/virtio/vsock/tsi_dgram.rs
+++ b/src/devices/src/virtio/vsock/tsi_dgram.rs
@@ -10,7 +10,7 @@ use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::sys::socket::UnixAddr;
 use nix::sys::socket::{
     bind, connect, getpeername, recv, send, sendto, socket, AddressFamily, MsgFlags, SockFlag,
-    SockType, SockaddrIn, SockaddrLike, SockaddrStorage,
+    SockProtocol, SockType, SockaddrIn, SockaddrLike, SockaddrStorage,
 };
 
 #[cfg(target_os = "macos")]
@@ -48,11 +48,13 @@ pub struct TsiDgramProxy {
 }
 
 impl TsiDgramProxy {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: u64,
         cid: u64,
         family: u16,
         peer_port: u32,
+        protocol: u16,
         mem: GuestMemoryMmap,
         queue: Arc<Mutex<VirtQueue>>,
         rxq: Arc<Mutex<MuxerRxQ>>,
@@ -65,7 +67,15 @@ impl TsiDgramProxy {
             _ => return Err(ProxyError::InvalidFamily),
         };
 
-        let fd = socket(family, SockType::Datagram, SockFlag::empty(), None)
+        // When the guest requests IPPROTO_ICMP (1) or IPPROTO_ICMPV6 (58),
+        // create a ping socket instead of a plain UDP socket.
+        let sock_protocol = match protocol as _ {
+            libc::IPPROTO_ICMP => Some(SockProtocol::Icmp),
+            libc::IPPROTO_ICMPV6 => Some(SockProtocol::IcmpV6),
+            _ => None,
+        };
+
+        let fd = socket(family, SockType::Datagram, SockFlag::empty(), sock_protocol)
             .map_err(ProxyError::CreatingSocket)?;
 
         // macOS forces us to do this here instead of just using SockFlag::SOCK_NONBLOCK above.

--- a/src/devices/src/virtio/vsock/tsi_dgram.rs
+++ b/src/devices/src/virtio/vsock/tsi_dgram.rs
@@ -9,8 +9,8 @@ use nix::fcntl::{FcntlArg, OFlag, fcntl};
 #[cfg(target_os = "linux")]
 use nix::sys::socket::UnixAddr;
 use nix::sys::socket::{
-    AddressFamily, MsgFlags, SockFlag, SockType, SockaddrIn, SockaddrLike, SockaddrStorage, bind,
-    connect, getpeername, recv, send, sendto, socket,
+    AddressFamily, MsgFlags, SockFlag, SockProtocol, SockType, SockaddrIn, SockaddrLike,
+    SockaddrStorage, bind, connect, getpeername, recv, send, sendto, socket,
 };
 
 use super::super::Queue as VirtQueue;
@@ -48,11 +48,13 @@ pub struct TsiDgramProxy {
 }
 
 impl TsiDgramProxy {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: u64,
         cid: u64,
         family: u16,
         peer_port: u32,
+        protocol: u16,
         mem: GuestMemoryMmap,
         queue: Arc<Mutex<VirtQueue>>,
         rxq: Arc<Mutex<MuxerRxQ>>,
@@ -65,7 +67,15 @@ impl TsiDgramProxy {
             _ => return Err(ProxyError::InvalidFamily),
         };
 
-        let fd = socket(family, SockType::Datagram, SockFlag::empty(), None)
+        // When the guest requests IPPROTO_ICMP (1) or IPPROTO_ICMPV6 (58),
+        // create a ping socket instead of a plain UDP socket.
+        let sock_protocol = match protocol as _ {
+            libc::IPPROTO_ICMP => Some(SockProtocol::Icmp),
+            libc::IPPROTO_ICMPV6 => Some(SockProtocol::IcmpV6),
+            _ => None,
+        };
+
+        let fd = socket(family, SockType::Datagram, SockFlag::empty(), sock_protocol)
             .map_err(ProxyError::CreatingSocket)?;
 
         // macOS forces us to do this here instead of just using SockFlag::SOCK_NONBLOCK above.

--- a/src/devices/src/virtio/vsock/tsi_dgram.rs
+++ b/src/devices/src/virtio/vsock/tsi_dgram.rs
@@ -38,6 +38,8 @@ pub struct TsiDgramProxy {
     sendto_addr: Option<SockaddrStorage>,
     listening: bool,
     family: AddressFamily,
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    protocol: u16,
     mem: GuestMemoryMmap,
     queue: Arc<Mutex<VirtQueue>>,
     rxq: Arc<Mutex<MuxerRxQ>>,
@@ -116,6 +118,7 @@ impl TsiDgramProxy {
             sendto_addr: None,
             listening: false,
             family,
+            protocol,
             mem,
             queue,
             rxq,
@@ -180,11 +183,27 @@ impl TsiDgramProxy {
             match recv(self.fd.as_raw_fd(), &mut buf[..max_len], MsgFlags::empty()) {
                 Ok(cnt) => {
                     debug!("recv cnt={cnt}");
-                    if cnt > 0 {
-                        RecvPkt::Read(cnt)
-                    } else {
-                        RecvPkt::Close
+                    if cnt == 0 {
+                        return RecvPkt::Close;
                     }
+
+                    // macOS DGRAM ICMP sockets include the IPv4 header in
+                    // recv, unlike Linux which strips it.  Strip the IPv4
+                    // header so the guest sees the same format as a Linux
+                    // ping socket.  IPv6 DGRAM sockets do NOT prepend a
+                    // header on any platform, so only strip for IPPROTO_ICMP.
+                    #[cfg(target_os = "macos")]
+                    if self.protocol as libc::c_int == libc::IPPROTO_ICMP && cnt >= 20 {
+                        // IHL (Internet Header Length): low 4 bits of first
+                        // byte, in 32-bit words.
+                        let ip_hdr_len = (buf[0] & 0x0F) as usize * 4;
+                        if ip_hdr_len <= cnt {
+                            buf.copy_within(ip_hdr_len..cnt, 0);
+                            return RecvPkt::Read(cnt - ip_hdr_len);
+                        }
+                    }
+
+                    RecvPkt::Read(cnt)
                 }
                 Err(e) => {
                     debug!("recv_pkt: recv error: {e:?}");

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -142,6 +142,7 @@ fn run_single_test(
     };
     let use_buildah_unshare = cfg!(target_os = "linux")
         && std::env::var_os("KRUN_NO_UNSHARE").is_none()
+        && !test_case.needs_host_network()
         && has_cmd("buildah")
         && has_cmd("unshare");
 

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -152,7 +152,7 @@ fn run_single_test(
         Command::new("buildah")
             .args(["unshare", "--", "unshare", "--net", "--", "sh", "-c"])
             .arg(format!(
-                "echo '=== namespace debug ===' >&2; id >&2; cat /proc/self/uid_map >&2; cat /proc/self/gid_map >&2; ip link >&2; ip addr add 127.0.0.1/8 dev lo && ip link set lo up; echo '=== lo setup exit: '$?' ===' >&2; ip addr >&2; echo '=== end debug ===' >&2; exec {exe} start-vm --test-case {name} --tmp-dir {dir}"
+                "echo '=== namespace debug ===' >&2; id >&2; cat /proc/self/uid_map >&2; cat /proc/self/gid_map >&2; ip link >&2; ip addr add 127.0.0.1/8 dev lo && ip link set lo up; ip addr add 192.0.2.1/32 dev lo; ip -6 addr add 2001:db8::1/128 dev lo; echo '0 0' > /proc/sys/net/ipv4/ping_group_range; echo '=== lo setup exit: '$?' ===' >&2; ip addr >&2; echo '=== end debug ===' >&2; exec {exe} start-vm --test-case {name} --tmp-dir {dir}"
             ))
             .stdin(Stdio::piped())
             .stdout(stdout_file)

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -19,6 +19,9 @@ use test_net_perf::TestNetPerf;
 mod test_multiport_console;
 use test_multiport_console::TestMultiportConsole;
 
+mod test_tsi_ping;
+use test_tsi_ping::TestTsiPing;
+
 mod test_virtiofs_root_ro;
 use test_virtiofs_root_ro::TestVirtiofsRootRo;
 
@@ -82,6 +85,7 @@ pub fn test_cases() -> Vec<TestCase> {
         TestCase::new("net-tap", Box::new(TestNet::new_tap())),
         TestCase::new("net-gvproxy", Box::new(TestNet::new_gvproxy())),
         TestCase::new("net-vmnet-helper", Box::new(TestNet::new_vmnet_helper())),
+        TestCase::new("tsi-ping", Box::new(TestTsiPing)),
         TestCase::new("multiport-console", Box::new(TestMultiportConsole)),
         TestCase::new("virtiofs-root-ro", Box::new(TestVirtiofsRootRo)),
         TestCase::new("virtiofs-misc", Box::new(TestVirtioFsMisc)),
@@ -221,6 +225,11 @@ pub trait Test {
     fn timeout_secs(&self) -> u64 {
         15
     }
+
+    /// Whether this test needs the host's real network (skips unshare --net).
+    fn needs_host_network(&self) -> bool {
+        false
+    }
 }
 
 #[guest]
@@ -255,6 +264,11 @@ impl TestCase {
     #[host]
     pub fn timeout_secs(&self) -> u64 {
         self.test.timeout_secs()
+    }
+
+    #[host]
+    pub fn needs_host_network(&self) -> bool {
+        self.test.needs_host_network()
     }
 
     #[allow(dead_code)]

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -27,6 +27,9 @@ use test_net_perf::TestNetPerf;
 mod test_multiport_console;
 use test_multiport_console::TestMultiportConsole;
 
+mod test_tsi_ping;
+use test_tsi_ping::TestTsiPing;
+
 #[cfg(any(feature = "host", target_os = "linux"))]
 mod test_virtiofs_root_ro;
 #[cfg(any(feature = "host", target_os = "linux"))]
@@ -117,6 +120,8 @@ pub fn test_cases() -> Vec<TestCase> {
             Box::new(TestNet::new_gvproxy_long_path()),
         ),
         TestCase::new("net-vmnet-helper", Box::new(TestNet::new_vmnet_helper())),
+        TestCase::new("tsi-ping", Box::new(TestTsiPing::v4())),
+        TestCase::new("tsi-ping6", Box::new(TestTsiPing::v6())),
         TestCase::new("multiport-console", Box::new(TestMultiportConsole)),
         #[cfg(any(feature = "host", target_os = "linux"))]
         TestCase::new("virtiofs-root-ro", Box::new(TestVirtiofsRootRo)),

--- a/tests/test_cases/src/test_tsi_ping.rs
+++ b/tests/test_cases/src/test_tsi_ping.rs
@@ -1,0 +1,84 @@
+use macros::{guest, host};
+
+pub struct TestTsiPing;
+
+#[host]
+mod host {
+    use super::*;
+    use crate::common::setup_fs_and_enter;
+    use crate::{krun_call, krun_call_u32};
+    use crate::{ShouldRun, Test, TestOutcome, TestSetup};
+    use krun_sys::*;
+
+    const CONTAINERFILE: &str = "\
+FROM fedora:44
+RUN dnf install -y iputils && dnf clean all
+";
+
+    impl Test for TestTsiPing {
+        fn rootfs_image(&self) -> Option<&'static str> {
+            Some(CONTAINERFILE)
+        }
+
+        fn should_run(&self) -> ShouldRun {
+            ShouldRun::Yes
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            30
+        }
+
+        fn needs_host_network(&self) -> bool {
+            true
+        }
+
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            unsafe {
+                krun_call!(krun_set_log_level(KRUN_LOG_LEVEL_TRACE))?;
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                setup_fs_and_enter(ctx, test_setup)?;
+            }
+            Ok(())
+        }
+
+        fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
+            let output = String::from_utf8(stdout).unwrap_or_default();
+            if output == "OK\n" {
+                TestOutcome::Pass
+            } else {
+                TestOutcome::Fail(format!("expected {:?}, got {:?}", "OK\n", output))
+            }
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+    use std::process::Command;
+
+    impl Test for TestTsiPing {
+        fn in_guest(self: Box<Self>) {
+            // Ping an external address so the guest kernel can't satisfy it
+            // locally — forces the TSI vsock proxy path.  Without the
+            // protocol fix, TSI creates a UDP socket and ping times out.
+            let output = Command::new("/usr/bin/ping")
+                .args(["-c", "3", "-W", "2", "8.8.8.8"])
+                .output()
+                .expect("Failed to run ping");
+
+            if output.status.success() {
+                println!("OK");
+            } else {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                panic!(
+                    "ping failed (exit={}):\nstdout: {}\nstderr: {}",
+                    output.status, stdout, stderr
+                );
+            }
+        }
+    }
+}

--- a/tests/test_cases/src/test_tsi_ping.rs
+++ b/tests/test_cases/src/test_tsi_ping.rs
@@ -1,0 +1,249 @@
+use macros::{guest, host};
+
+#[derive(Clone, Copy)]
+pub enum IpVersion {
+    V4,
+    V6,
+}
+
+pub struct TestTsiPing {
+    version: IpVersion,
+}
+
+impl TestTsiPing {
+    pub fn v4() -> Self {
+        Self {
+            version: IpVersion::V4,
+        }
+    }
+
+    pub fn v6() -> Self {
+        Self {
+            version: IpVersion::V6,
+        }
+    }
+}
+
+#[host]
+mod host {
+    use super::*;
+    use crate::common::setup_fs_and_enter_with_env;
+    use crate::{Test, TestOutcome, TestSetup};
+    use crate::{krun_call, krun_call_u32};
+    use krun_sys::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::os::unix::io::AsRawFd;
+    use std::process::Command;
+
+    const CONTAINERFILE: &str = "\
+FROM fedora:latest
+RUN dnf install -y iputils && dnf clean all
+";
+
+    /// 1-second timeout for host-side `ping -W`: macOS wants milliseconds, Linux wants seconds.
+    const PING_W_TIMEOUT: &str = if cfg!(target_os = "macos") {
+        "1000"
+    } else {
+        "1"
+    };
+
+    fn find_pingable_ipv4() -> Option<Ipv4Addr> {
+        // Use `ip` on Linux, `ifconfig` on macOS to find non-loopback IPv4 addresses.
+        let text = if cfg!(target_os = "linux") {
+            let output = Command::new("ip")
+                .args(["-4", "-o", "addr", "show", "scope", "global"])
+                .output()
+                .ok()?;
+            String::from_utf8(output.stdout).ok()?
+        } else {
+            let output = Command::new("ifconfig").output().ok()?;
+            String::from_utf8(output.stdout).ok()?
+        };
+
+        for line in text.lines() {
+            let mut tokens = line.split_whitespace();
+            while let Some(token) = tokens.next() {
+                if token == "inet" {
+                    if let Some(addr_token) = tokens.next() {
+                        let addr_str = addr_token.split('/').next().unwrap_or(addr_token);
+                        if let Ok(addr) = addr_str.parse::<Ipv4Addr>()
+                            && !addr.is_loopback()
+                            && !addr.is_unspecified()
+                        {
+                            let status = Command::new("ping")
+                                .args(["-c", "1", "-W", PING_W_TIMEOUT, addr_str])
+                                .output()
+                                .ok()?
+                                .status;
+                            if status.success() {
+                                return Some(addr);
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        None
+    }
+
+    fn find_pingable_ipv6() -> Option<Ipv6Addr> {
+        // Use `ip` on Linux, `ifconfig` on macOS to find global IPv6 addresses.
+        let text = if cfg!(target_os = "linux") {
+            let output = Command::new("ip")
+                .args(["-6", "-o", "addr", "show", "scope", "global"])
+                .output()
+                .ok()?;
+            String::from_utf8(output.stdout).ok()?
+        } else {
+            let output = Command::new("ifconfig").output().ok()?;
+            String::from_utf8(output.stdout).ok()?
+        };
+
+        for line in text.lines() {
+            let mut tokens = line.split_whitespace();
+            while let Some(token) = tokens.next() {
+                if token == "inet6" {
+                    if let Some(addr_token) = tokens.next() {
+                        // Strip prefix length (e.g. /64, /128) and scope id (e.g. %en0)
+                        let addr_str = addr_token.split('/').next().unwrap_or(addr_token);
+                        let addr_str = addr_str.split('%').next().unwrap_or(addr_str);
+                        if let Ok(addr) = addr_str.parse::<Ipv6Addr>()
+                            && !addr.is_loopback()
+                            && !addr.is_unspecified()
+                            && !addr.is_unicast_link_local()
+                        {
+                            // macOS uses `ping6`, Linux uses `ping -6`.
+                            // macOS ping6 has no -W flag.
+                            let status = if cfg!(target_os = "macos") {
+                                Command::new("ping6").args(["-c", "1", addr_str]).output()
+                            } else {
+                                Command::new("ping")
+                                    .args(["-6", "-c", "1", "-W", PING_W_TIMEOUT, addr_str])
+                                    .output()
+                            }
+                            .ok()?
+                            .status;
+                            if status.success() {
+                                return Some(addr);
+                            }
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+        None
+    }
+
+    impl Test for TestTsiPing {
+        fn rootfs_image(&self) -> Option<&'static str> {
+            Some(CONTAINERFILE)
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            10
+        }
+
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let (env_name, target_str) = match self.version {
+                IpVersion::V4 => {
+                    let addr = if let Ok(target) = std::env::var("PING_TARGET") {
+                        target
+                    } else if let Some(a) = find_pingable_ipv4() {
+                        a.to_string()
+                    } else {
+                        println!("SKIP:no pingable IPv4 address found on host");
+                        return Ok(());
+                    };
+                    ("PING_TARGET", addr)
+                }
+                IpVersion::V6 => {
+                    let addr = if let Ok(target) = std::env::var("PING6_TARGET") {
+                        target
+                    } else if let Some(a) = find_pingable_ipv6() {
+                        a.to_string()
+                    } else {
+                        println!("SKIP:no pingable IPv6 address found on host");
+                        return Ok(());
+                    };
+                    ("PING6_TARGET", addr)
+                }
+            };
+
+            let env_val = format!("{env_name}={target_str}");
+            unsafe {
+                krun_call!(krun_init_log(
+                    KRUN_LOG_TARGET_DEFAULT,
+                    KRUN_LOG_LEVEL_TRACE,
+                    KRUN_LOG_STYLE_AUTO,
+                    0
+                ))?;
+                let ctx = krun_call_u32!(krun_create_ctx())?;
+                krun_call!(krun_add_vsock(ctx, KRUN_TSI_HIJACK_INET))?;
+                krun_call!(krun_set_vm_config(ctx, 1, 512))?;
+                krun_call!(krun_add_virtio_console_default(
+                    ctx,
+                    std::io::stdin().as_raw_fd(),
+                    std::io::stdout().as_raw_fd(),
+                    std::io::stderr().as_raw_fd(),
+                ))?;
+                setup_fs_and_enter_with_env(ctx, test_setup, &[env_val.as_str()])?;
+            }
+            Ok(())
+        }
+
+        fn check(self: Box<Self>, stdout: Vec<u8>, _test_setup: TestSetup) -> TestOutcome {
+            let output = String::from_utf8(stdout).unwrap_or_default();
+            if let Some(reason) = output.strip_prefix("SKIP:") {
+                let reason = Box::leak(reason.trim().to_string().into_boxed_str());
+                TestOutcome::Skip(reason)
+            } else if output == "OK\n" {
+                TestOutcome::Pass
+            } else {
+                TestOutcome::Fail(format!("expected {:?}, got {:?}", "OK\n", output))
+            }
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+    use std::process::Command;
+
+    impl Test for TestTsiPing {
+        fn in_guest(self: Box<Self>) {
+            let (env_var, v6_flag) = match self.version {
+                IpVersion::V4 => ("PING_TARGET", None),
+                IpVersion::V6 => ("PING6_TARGET", Some("-6")),
+            };
+            let target = std::env::var(env_var).unwrap_or_else(|_| panic!("{env_var} not set"));
+
+            let mut args = Vec::new();
+            if let Some(flag) = v6_flag {
+                args.push(flag);
+            }
+            // Uses -w (deadline): ping exits with code 1 if fewer than 3
+            // replies arrive within 5 seconds, ensuring all pings succeed.
+            args.extend(["-c", "3", "-w", "5", &target]);
+
+            let output = Command::new("/usr/bin/ping")
+                .args(&args)
+                .output()
+                .expect("Failed to run ping");
+
+            if output.status.success() {
+                println!("OK");
+            } else {
+                let stderr = String::from_utf8(output.stderr).unwrap();
+                let stdout = String::from_utf8(output.stdout).unwrap();
+                panic!(
+                    "ping {target} failed (exit={}):\nstdout: {stdout}\nstderr: {stderr}",
+                    output.status,
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Three things were missing for ping to work through TSI:

1. Host used to create UDP sockets instead of ICMP — now reads the protocol field from the guest - needs https://github.com/containers/libkrunfw/pull/127

2. Guest used to reject SOCK_DGRAM+ICMP with EACCES — init now sets ping_group_range

3. macOS host includes the IP header in ICMP recv — we need to strip it before forwarding to guest

NOTE: This only works with modern ping implementations using DGRAM+ICMP "ping" sockets  ( works on modern Fedora, Ubuntu). Busybox ping uses SOCK_RAW which TSI doesn't hijack.