### PR TITLE
fs/macos: fix DirStream cache coherence on directory mutations

### DIFF
--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -52,6 +52,7 @@ struct InodeData {
     dev: i32,
     refcount: AtomicU64,
     unlinked_fd: AtomicI64,
+    dir_gen: AtomicU64,
 }
 
 enum InodeHandle {
@@ -68,6 +69,7 @@ struct CachedDirEntry {
 struct DirStream {
     entries: Vec<CachedDirEntry>,
     ready: bool,
+    gen: u64,
 }
 
 impl DirStream {
@@ -75,6 +77,7 @@ impl DirStream {
         Self {
             entries: Vec::new(),
             ready: false,
+            gen: 0,
         }
     }
 
@@ -700,17 +703,26 @@ impl PassthroughFs {
 
         let mut ds = data.dirstream.lock().unwrap();
 
-        if !ds.ready {
-            // Fill the cache on first call
-            if let Err(e) = ds.fill_from_fd(data.file.write().unwrap().as_raw_fd()) {
+        let current_gen = self
+            .inodes
+            .read()
+            .unwrap()
+            .get(&inode)
+            .map(|d| d.dir_gen.load(Ordering::Relaxed))
+            .unwrap_or(0);
+
+        if !ds.ready || ds.gen != current_gen {
+            let fd = data.file.write().unwrap().as_raw_fd();
+            unsafe { libc::lseek(fd, 0, libc::SEEK_SET) };
+            ds.entries.clear();
+            ds.ready = false;
+            if let Err(e) = ds.fill_from_fd(fd) {
                 if ds.entries.is_empty() {
                     return Err(e);
                 }
-                // If we got some valid entries before error happened,
-                // treat this partial read as success and just log
-                // the error.
                 warn!("virtio-fs: error in readdir {}: {:?}", inode, e);
             }
+            ds.gen = current_gen;
             ds.ready = true;
         }
 
@@ -736,6 +748,12 @@ impl PassthroughFs {
         }
 
         Ok(())
+    }
+
+    fn bump_dir_gen(&self, inode: Inode) {
+        if let Some(data) = self.inodes.read().unwrap().get(&inode) {
+            data.dir_gen.fetch_add(1, Ordering::Relaxed);
+        }
     }
 
     fn do_open(
@@ -889,6 +907,7 @@ impl PassthroughFs {
                     warn!("Couldn't store unlinked fd \"{}\": {err}", unlinked_fd);
                 }
             }
+            self.bump_dir_gen(parent);
             Ok(())
         } else {
             if let Some(unlinked_fd) = unlinked_fd {
@@ -1082,6 +1101,7 @@ impl FileSystem for PassthroughFs {
                 dev: st.st_dev,
                 refcount: AtomicU64::new(2),
                 unlinked_fd: AtomicI64::new(-1),
+                dir_gen: AtomicU64::new(0),
             }),
         );
 
@@ -1175,6 +1195,7 @@ impl FileSystem for PassthroughFs {
                     dev: st.st_dev,
                     refcount: AtomicU64::new(1),
                     unlinked_fd: AtomicI64::new(-1),
+                    dir_gen: AtomicU64::new(0),
                 }),
             );
 
@@ -1250,7 +1271,9 @@ impl FileSystem for PassthroughFs {
                 Some((ctx.uid, ctx.gid)),
                 Some(mode & !umask),
             )?;
-            self.lookup(ctx, parent, name)
+            let entry = self.lookup(ctx, parent, name)?;
+            self.bump_dir_gen(parent);
+            Ok(entry)
         } else {
             Err(linux_error(io::Error::last_os_error()))
         }
@@ -1385,6 +1408,7 @@ impl FileSystem for PassthroughFs {
         let file = RwLock::new(unsafe { File::from_raw_fd(fd) });
 
         let entry = self.lookup(ctx, parent, name)?;
+        self.bump_dir_gen(parent);
 
         let handle = self.next_handle.fetch_add(1, Ordering::Relaxed);
         let data = HandleData {
@@ -1686,6 +1710,10 @@ impl FileSystem for PassthroughFs {
             let entry = self.lookup(ctx, newdir, newname)?;
             self.forget(ctx, entry.inode, 1);
 
+            self.bump_dir_gen(olddir);
+            if newdir != olddir {
+                self.bump_dir_gen(newdir);
+            }
             Ok(())
         } else {
             Err(linux_error(io::Error::last_os_error()))
@@ -1732,7 +1760,9 @@ impl FileSystem for PassthroughFs {
             }
 
             unsafe { libc::close(fd) };
-            self.lookup(ctx, parent, name)
+            let entry = self.lookup(ctx, parent, name)?;
+            self.bump_dir_gen(parent);
+            Ok(entry)
         }
     }
 
@@ -1752,7 +1782,9 @@ impl FileSystem for PassthroughFs {
         // Safe because this doesn't modify any memory and we check the return value.
         let res = unsafe { libc::link(orig_c_path.as_ptr(), link_c_path.as_ptr()) };
         if res == 0 {
-            self.lookup(ctx, newparent, newname)
+            let entry = self.lookup(ctx, newparent, newname)?;
+            self.bump_dir_gen(newparent);
+            Ok(entry)
         } else {
             Err(linux_error(io::Error::last_os_error()))
         }
@@ -1779,6 +1811,7 @@ impl FileSystem for PassthroughFs {
             };
 
             let mut entry = self.lookup(ctx, parent, name)?;
+            self.bump_dir_gen(parent);
             let mode = libc::S_IFLNK | 0o777;
             set_xattr_stat(&ihandle, None, Some((ctx.uid, ctx.gid)), Some(mode as u32))?;
             entry.attr.st_uid = ctx.uid;

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -711,7 +711,14 @@ impl PassthroughFs {
             .map(|d| d.dir_gen.load(Ordering::Relaxed))
             .unwrap_or(0);
 
-        if !ds.ready || ds.gen != current_gen {
+        // Only rebuild the cache at the start of a stream (offset == 0, i.e. a
+        // fresh opendir or after rewinddir). Rebuilding mid-iteration would
+        // reorder the entries Vec while the guest is still indexing into it by
+        // offset, which can shift already-returned entries to higher offsets and
+        // make them reappear as duplicates. POSIX leaves readdir unspecified when
+        // the directory is mutated during iteration, so serving the stale snapshot
+        // for the rest of the stream is correct and matches Linux getdents64.
+        if !ds.ready || (ds.gen != current_gen && offset == 0) {
             let fd = data.file.write().unwrap().as_raw_fd();
             unsafe { libc::lseek(fd, 0, libc::SEEK_SET) };
             ds.entries.clear();

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -720,7 +720,9 @@ impl PassthroughFs {
         // for the rest of the stream is correct and matches Linux getdents64.
         if !ds.ready || (ds.gen != current_gen && offset == 0) {
             let fd = data.file.write().unwrap().as_raw_fd();
-            unsafe { libc::lseek(fd, 0, libc::SEEK_SET) };
+            if unsafe { libc::lseek(fd, 0, libc::SEEK_SET) } < 0 {
+                return Err(linux_error(io::Error::last_os_error()));
+            }
             ds.entries.clear();
             ds.ready = false;
             if let Err(e) = ds.fill_from_fd(fd) {


### PR DESCRIPTION
The macOS virtiofs passthrough caches directory entries once per open
handle (`DirStream`) and never refreshes them. Files created by guest
operations are written to the host correctly but are invisible to
subsequent `readdir` calls on the same handle. The Linux passthrough
does not have this problem — it calls `getdents64` on every readdir.

macOS lacks `getdents64`, so the `DirStream` cache is structurally
necessary. This patch adds a per-inode generation counter (`dir_gen`)
that is bumped on every directory mutation (create, mkdir, mknod,
symlink, link, unlink, rmdir, rename). `do_readdir` compares the
stored generation against the current inode generation and re-reads
from the host fd when stale.

The generation counter is a `u64`, so rollover requires ~2^64
mutations on a single inode and is not a practical concern. In the
theoretical wraparound case, the only consequence is a single stale
readdir until the next mutation — no corruption or data loss.

The counter uses `Ordering::Relaxed` which is sufficient here: the
`Mutex` on `DirStream` already provides the necessary
synchronization barrier, ensuring the bumped generation is visible
before the next `do_readdir` on the same inode.