### PR TITLE
Implement TDShim support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
  "linux-loader",
  "tdx",
  "vm-memory",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "windows-sys",
 ]
 
@@ -709,7 +709,7 @@ version = "0.1.0-2.0.0-dev"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ dependencies = [
  "virtio-bindings",
  "vm-fdt",
  "vm-memory",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "windows-sys",
  "zerocopy",
 ]
@@ -839,7 +839,7 @@ dependencies = [
  "pkg-config",
  "remain",
  "thiserror 1.0.69",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "winapi",
  "zerocopy",
 ]
@@ -861,7 +861,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.30.1",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "windows-sys",
 ]
 
@@ -896,7 +896,7 @@ dependencies = [
  "serde_json",
  "tdx",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util",
  "windows-sys",
  "zstd",
 ]
@@ -915,7 +915,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
 dependencies = [
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -927,7 +927,7 @@ dependencies = [
  "bitflags 2.11.0",
  "kvm-bindings",
  "libc",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1534,7 +1534,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "uuid",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1675,7 +1675,7 @@ dependencies = [
  "libc",
  "uuid",
  "vm-memory",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1705,16 +1705,6 @@ dependencies = [
  "libc",
  "thiserror 2.0.18",
  "winapi",
-]
-
-[[package]]
-name = "vmm-sys-util"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
 ]
 
 [[package]]

--- a/examples/launch-tee.c
+++ b/examples/launch-tee.c
@@ -6,6 +6,7 @@
  */
 
 #include <errno.h>
+#include <getopt.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,6 +31,11 @@ int main(int argc, char *const argv[])
         "6=4096:8192",
         0
     };
+    static const struct option long_opts[] = {
+        { "td-shim", required_argument, 0, 's' },
+        { 0, 0, 0, 0 }
+    };
+    const char *td_shim_path = NULL;
     char current_path[MAX_PATH];
     char volume_tail[] = ":/work\0";
     char *volume;
@@ -37,10 +43,22 @@ int main(int argc, char *const argv[])
     int ctx_id;
     int err;
     int i;
+    int opt;
 
-    if (argc != 4) {
+    while ((opt = getopt_long(argc, argv, "", long_opts, NULL)) != -1) {
+        switch (opt) {
+        case 's':
+            td_shim_path = optarg;
+            break;
+        default:
+            printf("Usage: %s [--td-shim PATH] ROOT_DISK_IMAGE TEE_CONFIG_FILE DATA_DISK_IMAGE\n", argv[0]);
+            return -1;
+        }
+    }
+
+    if (argc - optind != 3) {
         printf("Invalid arguments\n");
-        printf("Usage: %s ROOT_DISK_IMAGE TEE_CONFIG_FILE DATA_DISK_IMAGE\n", argv[0]);
+        printf("Usage: %s [--td-shim PATH] ROOT_DISK_IMAGE TEE_CONFIG_FILE DATA_DISK_IMAGE\n", argv[0]);
         return -1;
     }
 
@@ -67,14 +85,8 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
-    if (err = krun_add_virtio_console_default(ctx_id, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO)) {
-        errno = -err;
-        perror("Error configuring console");
-        return -1;
-    }
-
-    // Use the first command line argument as the disk image containing the root fs.
-    if (err = krun_add_disk(ctx_id, "root", argv[1], false)) {
+    // Use the first positional argument as the disk image containing the root fs.
+    if (err = krun_add_disk2(ctx_id, "root", argv[optind], KRUN_DISK_FORMAT_RAW, false)) {
         errno = -err;
         perror("Error configuring root disk image");
         return -1;
@@ -91,6 +103,12 @@ int main(int argc, char *const argv[])
     if (volume == NULL) {
         errno = -err;
         perror("Error allocating memory for volume string");
+    }
+
+    if (err = krun_add_vsock(ctx_id, KRUN_TSI_HIJACK_INET | KRUN_TSI_HIJACK_UNIX)) {
+        errno = -err;
+        perror("Error adding vsock device");
+        return -1;
     }
 
     // Map port 18000 in the host to 8000 in the guest.
@@ -114,15 +132,37 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
-    if (err = krun_set_tee_config_file(ctx_id, argv[2])) {
+    if (err = krun_set_tee_config_file(ctx_id, argv[optind + 1])) {
         errno = -err;
         perror("Error setting the TEE config file");
         return -1;
     }
 
-    if (err = krun_add_disk(ctx_id, "data", argv[3], false)) {
+    if (td_shim_path != NULL) {
+        if (err = krun_set_tee_firmware(ctx_id, KRUN_TEE_FW_TDSHIM, td_shim_path)) {
+            errno = -err;
+            perror("Error setting TD-Shim firmware path");
+            return -1;
+        }
+    }
+
+    if (err = krun_add_disk2(ctx_id, "data", argv[optind + 2], KRUN_DISK_FORMAT_RAW, false)) {
         errno = -err;
         perror("Error configuring the TEE config data disk");
+        return -1;
+    }
+
+    // Serial console (ttyS0) for kernel log output only (no stdin).
+    if (err = krun_add_serial_console_default(ctx_id, -1, STDOUT_FILENO)) {
+        errno = -err;
+        perror("Error adding serial console");
+        return -1;
+    }
+
+    // Virtio console (hvc0) for interactive shell I/O.
+    if (err = krun_add_virtio_console_default(ctx_id, STDIN_FILENO, STDOUT_FILENO, STDERR_FILENO)) {
+        errno = -err;
+        perror("Error adding virtio console");
         return -1;
     }
 

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -863,6 +863,22 @@ int32_t krun_set_kernel(uint32_t ctx_id,
  */
 int32_t krun_set_tee_config_file(uint32_t ctx_id, const char *filepath);
 
+#define KRUN_TEE_FW_TDSHIM 0
+
+/**
+ * Sets the TEE firmware binary for confidential guests. If not called, the guest
+ * uses the bundled firmware from the corresponding libkrunfw package.
+ *
+ * Arguments:
+ *  "ctx_id"  - the configuration context ID.
+ *  "fw_type" - the firmware type (e.g. KRUN_TEE_FW_TDSHIM).
+ *  "fw_path" - a null-terminated string representing the path to the firmware binary.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_set_tee_firmware(uint32_t ctx_id, uint32_t fw_type, const char *fw_path);
+
 /**
  * Adds a port-path pairing for guest IPC with a process in the host.
  *

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -213,7 +213,7 @@ pub fn arch_memory_regions(
     kernel_load_addr: Option<u64>,
     kernel_size: usize,
     _initrd_size: u64,
-    _firmware_size: Option<usize>,
+    firmware_range: Option<(u64, usize)>,
 ) -> (ArchMemoryInfo, Vec<(GuestAddress, usize)>) {
     let page_size: usize = get_page_size();
 
@@ -232,21 +232,22 @@ pub fn arch_memory_regions(
             None | Some(0) => {
                 let ram_last_addr = size as u64;
                 let shm_start_addr = 0u64;
+                let (fw_addr, fw_sz) =
+                    firmware_range.unwrap_or((FIRMWARE_START, FIRMWARE_SIZE as usize));
                 (
                     size as u64,
                     0,
                     ram_last_addr,
                     shm_start_addr,
-                    vec![
-                        (GuestAddress(0), size),
-                        (GuestAddress(FIRMWARE_START), FIRMWARE_SIZE as usize),
-                    ],
+                    vec![(GuestAddress(0), size), (GuestAddress(fw_addr), fw_sz)],
                 )
             }
             // case2: guest memory extends beyond the gap
             Some(remaining) => {
                 let ram_last_addr = FIRST_ADDR_PAST_32BITS + remaining as u64;
                 let shm_start_addr = 0u64;
+                let (fw_addr, fw_sz) =
+                    firmware_range.unwrap_or((FIRMWARE_START, FIRMWARE_SIZE as usize));
                 (
                     MMIO_MEM_START,
                     remaining as u64,
@@ -254,7 +255,7 @@ pub fn arch_memory_regions(
                     shm_start_addr,
                     vec![
                         (GuestAddress(0), MMIO_MEM_START as usize),
-                        (GuestAddress(FIRMWARE_START), FIRMWARE_SIZE as usize),
+                        (GuestAddress(fw_addr), fw_sz),
                         (GuestAddress(FIRST_ADDR_PAST_32BITS), remaining),
                     ],
                 )
@@ -599,6 +600,19 @@ mod tests {
             false,
         )
         .unwrap();
+    }
+
+    #[cfg(feature = "tee")]
+    #[test]
+    fn test_arch_memory_regions_tee_dynamic_firmware_hole() {
+        let fw_start = 0xfffe_0000u64;
+        let fw_size = 0x2_0000usize;
+        let (_info, regions) =
+            arch_memory_regions(1usize << 29, None, 0, 0, Some((fw_start, fw_size)));
+        let has_fw_region = regions
+            .iter()
+            .any(|&(addr, size)| addr.0 == fw_start && size == fw_size);
+        assert!(has_fw_region, "firmware region not found in memory regions");
     }
 
     #[test]

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -10,7 +10,7 @@ mod gdt;
 pub mod interrupts;
 /// Layout for the x86_64 system.
 pub mod layout;
-#[cfg(not(feature = "tee"))]
+#[cfg(any(not(feature = "tee"), feature = "tdx"))]
 mod mptable;
 /// Logic for configuring x86_64 model specific registers (MSRs).
 pub mod msr;
@@ -61,7 +61,7 @@ pub enum Error {
     /// Invalid e820 setup params.
     E820Configuration,
     /// Error writing MP table to memory.
-    #[cfg(not(feature = "tee"))]
+    #[cfg(any(not(feature = "tee"), feature = "tdx"))]
     MpTableSetup(mptable::Error),
     /// Error writing hvm_start_info to guest memory.
     #[cfg(all(not(feature = "tee"), target_os = "linux"))]
@@ -271,6 +271,14 @@ pub fn arch_memory_regions(
         firmware_addr: 0,
     };
     (info, regions)
+}
+
+/// Writes an MP table to guest memory. Only needed for the TD-Shim path: TD-Shim's
+/// ACPI MADT has no IOAPIC entry, so without an MP table the kernel never programs
+/// the IOAPIC and virtio-mmio IRQs stop working after the PIC→APIC transition.
+#[cfg(feature = "tdx")]
+pub fn setup_mptable_for_tdshim(guest_mem: &GuestMemoryMmap, num_cpus: u8) -> super::Result<()> {
+    mptable::setup_mptable(guest_mem, num_cpus).map_err(Error::MpTableSetup)
 }
 
 /// Configures the system and should be called once per vm before starting vcpu threads.

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -58,6 +58,8 @@ use vmm::vmm_config::block::{BlockDeviceConfig, BlockRootConfig};
 use vmm::vmm_config::external_kernel::{ExternalKernel, KernelFormat};
 #[cfg(not(feature = "tee"))]
 use vmm::vmm_config::firmware::FirmwareConfig;
+#[cfg(feature = "tdx")]
+use vmm::vmm_config::firmware::{TeeFirmwareConfig, TeeFirmwareType};
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use vmm::vmm_config::fs::FsDeviceConfig;
 use vmm::vmm_config::kernel_bundle::KernelBundle;
@@ -182,6 +184,8 @@ struct ContextConfig {
     block_root: Option<BlockRootConfig>,
     #[cfg(feature = "tee")]
     tee_config_file: Option<PathBuf>,
+    #[cfg(feature = "tdx")]
+    tee_firmware_config: Option<TeeFirmwareConfig>,
     unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     shutdown_efd: Option<EventFd>,
     gpu_virgl_flags: Option<u32>,
@@ -272,6 +276,16 @@ impl ContextConfig {
     #[cfg(feature = "tee")]
     fn get_tee_config_file(&self) -> Option<PathBuf> {
         self.tee_config_file.clone()
+    }
+
+    #[cfg(feature = "tdx")]
+    fn set_tee_firmware_config(&mut self, config: TeeFirmwareConfig) {
+        self.tee_firmware_config = Some(config);
+    }
+
+    #[cfg(feature = "tdx")]
+    fn get_tee_firmware_config(&self) -> Option<TeeFirmwareConfig> {
+        self.tee_firmware_config.clone()
     }
 
     fn add_vsock_port(&mut self, port: u32, filepath: PathBuf, listen: bool) {
@@ -1311,6 +1325,47 @@ pub unsafe extern "C" fn krun_set_tee_config_file(ctx_id: u32, c_filepath: *cons
 
         KRUN_SUCCESS
     }
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+#[cfg(feature = "tdx")]
+pub unsafe extern "C" fn krun_set_tee_firmware(
+    ctx_id: u32,
+    fw_type: u32,
+    c_fw_path: *const c_char,
+) -> i32 {
+    let fw_type = match fw_type {
+        0 => TeeFirmwareType::TdShim,
+        _ => {
+            error!("Unknown TEE firmware type: {fw_type}");
+            return -libc::EINVAL;
+        }
+    };
+
+    if c_fw_path.is_null() {
+        error!("c_fw_path is null");
+        return -libc::EINVAL;
+    }
+
+    let path = match unsafe { CStr::from_ptr(c_fw_path).to_str() } {
+        Ok(p) => PathBuf::from(p),
+        Err(e) => {
+            error!("Error parsing fw_path: {e:?}");
+            return -libc::EINVAL;
+        }
+    };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            ctx_cfg
+                .get_mut()
+                .set_tee_firmware_config(TeeFirmwareConfig { fw_type, path });
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -2913,11 +2968,17 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         return -libc::EINVAL;
     }
 
+    #[cfg(feature = "tdx")]
+    if let Some(tee_fw_config) = ctx_cfg.get_tee_firmware_config() {
+        ctx_cfg.vmr.set_tee_firmware_config(tee_fw_config);
+    }
+
     let mut prolog = DEFAULT_KERNEL_CMDLINE.to_string();
     for arg in &ctx_cfg.extra_kernel_cmdline {
         prolog.push(' ');
         prolog.push_str(arg);
     }
+
     let kernel_cmdline = KernelCmdlineConfig {
         prolog: Some(prolog),
         krun_env: Some(format!(" {}", ctx_cfg.get_block_root())),

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -2973,6 +2973,19 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         ctx_cfg.vmr.set_tee_firmware_config(tee_fw_config);
     }
 
+    // In the TD-Shim path, init.krun reads its exec config from the TEE config on
+    // the data disk (vdb), not from the kernel cmdline.  Including krun_env and the
+    // " -- " epilog here would cause init.krun to take the non-TEE vsock code path
+    // and block waiting for a host-side exec command that never arrives.
+    #[cfg(feature = "tdx")]
+    let is_tdshim = ctx_cfg
+        .vmr
+        .tee_firmware_config
+        .as_ref()
+        .is_some_and(|cfg| matches!(cfg.fw_type, TeeFirmwareType::TdShim));
+    #[cfg(not(feature = "tdx"))]
+    let is_tdshim = false;
+
     let mut prolog = DEFAULT_KERNEL_CMDLINE.to_string();
     for arg in &ctx_cfg.extra_kernel_cmdline {
         prolog.push(' ');
@@ -2981,7 +2994,11 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
 
     let kernel_cmdline = KernelCmdlineConfig {
         prolog: Some(prolog),
-        krun_env: Some(format!(" {}", ctx_cfg.get_block_root())),
+        krun_env: if is_tdshim {
+            None
+        } else {
+            Some(format!(" {}", ctx_cfg.get_block_root()))
+        },
         epilog: None,
     };
 

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -26,7 +26,7 @@ libc = ">=0.2.39"
 linux-loader = { version = "0.13.2", features = ["bzimage", "elf", "pe"] }
 log = "0.4.0"
 vm-memory = { version = "0.17.0", default-features = false, features = ["backend-mmap"] }
-vmm-sys-util = "0.14"
+vmm-sys-util = "0.15"
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", optional = true, features = ["bindgen_clang_runtime"] }
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -66,6 +66,8 @@ use devices::virtio::{MmioTransport, PortDescription, VirtioDevice, Vsock, port_
 use kbs_types::Tee;
 
 use crate::device_manager;
+#[cfg(feature = "tdx")]
+use crate::linux::tee::tdshim::TdShim;
 #[cfg(all(feature = "vhost-user", target_os = "linux"))]
 use crate::resources::VhostUserDeviceConfig;
 #[cfg(target_os = "linux")]
@@ -75,6 +77,8 @@ use crate::signal_handler::register_sigwinch_handler;
 use crate::terminal::{term_restore_mode, term_set_raw_mode};
 #[cfg(feature = "blk")]
 use crate::vmm_config::block::BlockBuilder;
+#[cfg(feature = "tdx")]
+use crate::vmm_config::firmware::TeeFirmwareType;
 #[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use crate::vmm_config::fs::FsDeviceConfig;
 use crate::vmm_config::kernel_cmdline::DEFAULT_KERNEL_CMDLINE;
@@ -114,6 +118,8 @@ use vm_memory::Bytes;
 use vm_memory::FileOffset;
 #[cfg(not(feature = "aws-nitro"))]
 use vm_memory::GuestMemory;
+#[cfg(feature = "tdx")]
+use vm_memory::GuestMemoryRegion;
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
 use vm_memory::GuestRegionMmap;
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
@@ -241,6 +247,9 @@ pub enum StartMicrovmError {
     ShmCreate(device_manager::shm::Error),
     /// Error obtaining the host address of an SHM region.
     ShmHostAddr(vm_memory::GuestMemoryError),
+    /// Error in TD-Shim firmware handling.
+    #[cfg(feature = "tdx")]
+    TdShimError(String),
     /// The TEE specified is not supported.
     InvalidTee,
 }
@@ -529,6 +538,10 @@ impl Display for StartMicrovmError {
 
                 write!(f, "Error while creating an SHM region. {err_msg}")
             }
+            #[cfg(feature = "tdx")]
+            TdShimError(ref err) => {
+                write!(f, "TD-Shim error: {err}")
+            }
             InvalidTee => {
                 write!(f, "TEE selected is not currently supported")
             }
@@ -552,7 +565,16 @@ pub enum Payload {
 fn choose_payload(vm_resources: &VmResources) -> Result<Payload, StartMicrovmError> {
     if let Some(_kernel_bundle) = &vm_resources.kernel_bundle {
         #[cfg(feature = "tee")]
-        if vm_resources.qboot_bundle.is_none() || vm_resources.initrd_bundle.is_none() {
+        if vm_resources.initrd_bundle.is_none() {
+            return Err(StartMicrovmError::MissingKernelConfig);
+        }
+        #[cfg(feature = "tee")]
+        if vm_resources.qboot_bundle.is_none() {
+            #[cfg(feature = "tdx")]
+            if vm_resources.tee_firmware_config.is_none() {
+                return Err(StartMicrovmError::MissingKernelConfig);
+            }
+            #[cfg(not(feature = "tdx"))]
             return Err(StartMicrovmError::MissingKernelConfig);
         }
 
@@ -573,6 +595,104 @@ fn choose_payload(vm_resources: &VmResources) -> Result<Payload, StartMicrovmErr
     }
 }
 
+#[cfg(feature = "tdx")]
+fn measure_tdshim_regions(
+    td_shim: TdShim,
+    vm_resources: &super::resources::VmResources,
+    guest_memory: &GuestMemoryMmap,
+) -> Result<(Vec<MeasuredRegion>, u64), StartMicrovmError> {
+    td_shim
+        .load_sections(guest_memory)
+        .map_err(|e| StartMicrovmError::TdShimError(format!("{e}")))?;
+
+    let high_fw = td_shim.high_firmware_range();
+    let ram_regions: Vec<(u64, u64)> = guest_memory
+        .iter()
+        .filter_map(|region| {
+            let start = region.start_addr().0;
+            let len = region.len();
+            if let Some((fw_start, fw_end)) = high_fw
+                && start >= fw_start
+                && start < fw_end
+            {
+                return None;
+            }
+            Some((start, len))
+        })
+        .collect();
+
+    let kernel_bundle = vm_resources
+        .kernel_bundle
+        .as_ref()
+        .ok_or(StartMicrovmError::MissingKernelConfig)?;
+
+    // libkrunfw packages a raw ELF vmlinux, not a bzImage. The entry_addr
+    // is the ELF e_entry (startup_64 physical address), which td-shim
+    // uses directly with PayloadImageTypeRawVmLinux.
+    td_shim
+        .generate_hobs(guest_memory, kernel_bundle.entry_addr, &ram_regions)
+        .map_err(|e| StartMicrovmError::TdShimError(format!("{e}")))?;
+
+    // All RAM as one block (attributes=0, add but don't measure), plus the
+    // high firmware sections (BFV etc.) with their per-section attributes.
+    // Low-address TDVF sections (TempMem, TD_HOB) fall inside the RAM range
+    // and must not be added separately — TDX rejects duplicate TDH.MEM.PAGE.ADD.
+    let mut regions: Vec<MeasuredRegion> = guest_memory
+        .iter()
+        .filter(|r| r.start_addr().0 < arch::x86_64::layout::MMIO_MEM_START)
+        .map(|r| MeasuredRegion {
+            guest_addr: r.start_addr().0,
+            host_addr: guest_memory.get_host_address(r.start_addr()).unwrap() as u64,
+            size: r.len() as usize,
+            attributes: 0,
+        })
+        .collect();
+
+    for section in &td_shim.sections {
+        if section.memory_address >= arch::x86_64::layout::MMIO_MEM_START {
+            regions.push(MeasuredRegion {
+                guest_addr: section.memory_address,
+                host_addr: guest_memory
+                    .get_host_address(GuestAddress(section.memory_address))
+                    .unwrap() as u64,
+                size: section.memory_data_size as usize,
+                attributes: section.attributes,
+            });
+        }
+    }
+
+    Ok((regions, td_shim.hob_address))
+}
+
+#[cfg(feature = "tdx")]
+fn measure_qboot_regions(
+    vm_resources: &super::resources::VmResources,
+    guest_memory: &GuestMemoryMmap,
+) -> Result<(Vec<MeasuredRegion>, u64), StartMicrovmError> {
+    let qboot_size = if let Some(qboot_bundle) = &vm_resources.qboot_bundle {
+        qboot_bundle.size
+    } else {
+        return Err(StartMicrovmError::MissingKernelConfig);
+    };
+    let regions = vec![
+        MeasuredRegion {
+            guest_addr: 0,
+            host_addr: guest_memory.get_host_address(GuestAddress(0)).unwrap() as u64,
+            size: 0x8000_0000,
+            attributes: 0,
+        },
+        MeasuredRegion {
+            guest_addr: arch::FIRMWARE_START,
+            host_addr: guest_memory
+                .get_host_address(GuestAddress(arch::FIRMWARE_START))
+                .unwrap() as u64,
+            size: qboot_size,
+            attributes: 1,
+        },
+    ];
+    Ok((regions, 0u64))
+}
+
 /// Builds and starts a microVM based on the current Firecracker VmResources configuration.
 ///
 /// This is the default build recipe, one could build other microVM flavors by using the
@@ -588,6 +708,25 @@ pub fn build_microvm(
 ) -> std::result::Result<Arc<Mutex<Vmm>>, StartMicrovmError> {
     let payload = choose_payload(vm_resources)?;
 
+    #[cfg(feature = "tdx")]
+    let td_shim_parsed = match &vm_resources.tee_firmware_config {
+        Some(tee_fw_cfg) => match tee_fw_cfg.fw_type {
+            TeeFirmwareType::TdShim => Some(
+                TdShim::parse(&tee_fw_cfg.path)
+                    .map_err(|e| StartMicrovmError::TdShimError(format!("{e}")))?,
+            ),
+        },
+        None => None,
+    };
+
+    #[cfg(feature = "tdx")]
+    let fw_range_for_mem = td_shim_parsed.as_ref().and_then(|ts| {
+        ts.high_firmware_range()
+            .map(|(start, end)| (start, (end - start) as usize))
+    });
+    #[cfg(all(feature = "tee", not(feature = "tdx")))]
+    let fw_range_for_mem: Option<(u64, usize)> = None;
+
     let (guest_memory, arch_memory_info, mut _shm_manager, payload_config) = create_guest_memory(
         vm_resources
             .vm_config()
@@ -595,6 +734,8 @@ pub fn build_microvm(
             .ok_or(StartMicrovmError::MissingMemSizeConfig)?,
         vm_resources,
         &payload,
+        #[cfg(feature = "tee")]
+        fw_range_for_mem,
     )?;
 
     let vcpu_config = vm_resources.vcpu_config();
@@ -725,31 +866,14 @@ pub fn build_microvm(
     };
 
     #[cfg(feature = "tdx")]
-    let measured_regions = {
+    let (measured_regions, tdx_hob_address) = {
         println!("Injecting and measuring memory regions. This may take a while.");
-        let qboot_size = if let Some(qboot_bundle) = &vm_resources.qboot_bundle {
-            qboot_bundle.size
-        } else {
-            return Err(StartMicrovmError::MissingKernelConfig);
-        };
-        let m = vec![
-            MeasuredRegion {
-                guest_addr: 0,
-                host_addr: guest_memory.get_host_address(GuestAddress(0)).unwrap() as u64,
-                size: 0x8000_0000,
-                attributes: 0,
-            },
-            MeasuredRegion {
-                guest_addr: arch::FIRMWARE_START,
-                host_addr: guest_memory
-                    .get_host_address(GuestAddress(arch::FIRMWARE_START))
-                    .unwrap() as u64,
-                size: qboot_size,
-                attributes: 1,
-            },
-        ];
 
-        m
+        if let Some(td_shim) = td_shim_parsed {
+            measure_tdshim_regions(td_shim, vm_resources, &guest_memory)?
+        } else {
+            measure_qboot_regions(vm_resources, &guest_memory)?
+        }
     };
 
     let mut serial_devices = Vec::new();
@@ -890,7 +1014,8 @@ pub fn build_microvm(
         for vcpu in &vcpus {
             vcpu.tdx_secure_virt_prepare(&mut tdx_launcher);
         }
-        vm.tdx_secure_virt_init_vcpus(&mut tdx_launcher).unwrap();
+        vm.tdx_secure_virt_init_vcpus(&mut tdx_launcher, tdx_hob_address)
+            .unwrap();
     }
 
     // On aarch64, the vCPUs need to be created (i.e call KVM_CREATE_VCPU) and configured before
@@ -1550,17 +1675,24 @@ fn load_payload(
                 .write(kernel_data, GuestAddress(kernel_guest_addr))
                 .unwrap();
 
-            let (qboot_host_addr, qboot_size) =
-                if let Some(qboot_bundle) = &_vm_resources.qboot_bundle {
-                    (qboot_bundle.host_addr, qboot_bundle.size)
-                } else {
-                    return Err(StartMicrovmError::MissingKernelConfig);
+            // TD-Shim supplies its own firmware; skip qboot when it's configured.
+            #[cfg(feature = "tdx")]
+            let write_qboot = _vm_resources.tee_firmware_config.is_none();
+            #[cfg(not(feature = "tdx"))]
+            let write_qboot = true;
+
+            if write_qboot {
+                let qboot_bundle = _vm_resources
+                    .qboot_bundle
+                    .as_ref()
+                    .ok_or(StartMicrovmError::MissingKernelConfig)?;
+                let qboot_data = unsafe {
+                    std::slice::from_raw_parts(qboot_bundle.host_addr as *mut u8, qboot_bundle.size)
                 };
-            let qboot_data =
-                unsafe { std::slice::from_raw_parts(qboot_host_addr as *mut u8, qboot_size) };
-            guest_mem
-                .write(qboot_data, GuestAddress(arch::FIRMWARE_START))
-                .unwrap();
+                guest_mem
+                    .write(qboot_data, GuestAddress(arch::FIRMWARE_START))
+                    .unwrap();
+            }
 
             let (initrd_host_addr, initrd_size) =
                 if let Some(initrd_bundle) = &_vm_resources.initrd_bundle {
@@ -1608,6 +1740,7 @@ pub fn create_guest_memory(
     mem_size: usize,
     vm_resources: &VmResources,
     payload: &Payload,
+    #[cfg(feature = "tee")] firmware_range: Option<(u64, usize)>,
 ) -> std::result::Result<
     (GuestMemoryMmap, ArchMemoryInfo, ShmManager, PayloadConfig),
     StartMicrovmError,
@@ -1649,7 +1782,13 @@ pub fn create_guest_memory(
                 } else {
                     return Err(StartMicrovmError::MissingKernelConfig);
                 };
-            arch::arch_memory_regions(mem_size, Some(kernel_guest_addr), kernel_size, 0, None)
+            arch::arch_memory_regions(
+                mem_size,
+                Some(kernel_guest_addr),
+                kernel_size,
+                0,
+                firmware_range,
+            )
         }
         #[cfg(test)]
         Payload::Empty => arch::arch_memory_regions(mem_size, None, 0, 0, None),
@@ -2812,7 +2951,13 @@ pub mod tests {
             size: 0x1000,
         });
 
-        create_guest_memory(mem_size_mib, &vm_resources, &Payload::Empty)
+        create_guest_memory(
+            mem_size_mib,
+            &vm_resources,
+            &Payload::Empty,
+            #[cfg(feature = "tee")]
+            None,
+        )
     }
 
     #[test]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -697,6 +697,7 @@ pub fn build_microvm(
                     .get_host_address(GuestAddress(arch::FIRMWARE_START))
                     .unwrap() as u64,
                 size: qboot_size,
+                attributes: 0,
             },
             MeasuredRegion {
                 guest_addr: kernel_guest_addr,
@@ -704,11 +705,13 @@ pub fn build_microvm(
                     .get_host_address(GuestAddress(kernel_guest_addr))
                     .unwrap() as u64,
                 size: kernel_size,
+                attributes: 0,
             },
             MeasuredRegion {
                 guest_addr: initrd_addr.0,
                 host_addr: guest_memory.get_host_address(initrd_addr).unwrap() as u64,
                 size: initrd_size,
+                attributes: 0,
             },
             MeasuredRegion {
                 guest_addr: arch::x86_64::layout::ZERO_PAGE_START,
@@ -716,6 +719,7 @@ pub fn build_microvm(
                     .get_host_address(GuestAddress(arch::x86_64::layout::ZERO_PAGE_START))
                     .unwrap() as u64,
                 size: 4096,
+                attributes: 0,
             },
         ]
     };
@@ -733,6 +737,7 @@ pub fn build_microvm(
                 guest_addr: 0,
                 host_addr: guest_memory.get_host_address(GuestAddress(0)).unwrap() as u64,
                 size: 0x8000_0000,
+                attributes: 0,
             },
             MeasuredRegion {
                 guest_addr: arch::FIRMWARE_START,
@@ -740,6 +745,7 @@ pub fn build_microvm(
                     .get_host_address(GuestAddress(arch::FIRMWARE_START))
                     .unwrap() as u64,
                 size: qboot_size,
+                attributes: 1,
             },
         ];
 

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -67,7 +67,7 @@ use kbs_types::Tee;
 
 use crate::device_manager;
 #[cfg(feature = "tdx")]
-use crate::linux::tee::tdshim::TdShim;
+use crate::linux::tee::tdshim::{self, TdShim};
 #[cfg(all(feature = "vhost-user", target_os = "linux"))]
 use crate::resources::VhostUserDeviceConfig;
 #[cfg(target_os = "linux")]
@@ -621,16 +621,21 @@ fn measure_tdshim_regions(
         })
         .collect();
 
-    let kernel_bundle = vm_resources
+    let startup_64 = vm_resources
         .kernel_bundle
         .as_ref()
-        .ok_or(StartMicrovmError::MissingKernelConfig)?;
-
-    // libkrunfw packages a raw ELF vmlinux, not a bzImage. The entry_addr
-    // is the ELF e_entry (startup_64 physical address), which td-shim
-    // uses directly with PayloadImageTypeRawVmLinux.
+        .ok_or(StartMicrovmError::MissingKernelConfig)?
+        .entry_addr;
+    // When an initrd is present, the HOB entry point is backed up by
+    // TRAMPOLINE_SIZE so td-shim lands on the boot_params trampoline
+    // that patches initrd address/size before jumping to startup_64.
+    let hob_entry_point = if vm_resources.initrd_bundle.is_some() {
+        startup_64 - tdshim::TRAMPOLINE_SIZE
+    } else {
+        startup_64
+    };
     td_shim
-        .generate_hobs(guest_memory, kernel_bundle.entry_addr, &ram_regions)
+        .generate_hobs(guest_memory, hob_entry_point, &ram_regions)
         .map_err(|e| StartMicrovmError::TdShimError(format!("{e}")))?;
 
     // All RAM as one block (attributes=0, add but don't measure), plus the
@@ -768,6 +773,55 @@ pub fn build_microvm(
         );
         kernel_cmdline = Cmdline::new(arch::CMDLINE_MAX_SIZE);
         kernel_cmdline.insert_str(cmdline).unwrap();
+    }
+
+    // Write the TD-Shim initrd trampoline and firmware sections into guest memory
+    // BEFORE setup_vm()/memory_init(). At this point the GuestMemoryMmap is backed
+    // by plain anonymous mmap pages. Once KVM registers the memory slots (memory_init),
+    // pages become KVM_MEM_PRIVATE and TDH.MEM.PAGE.ADD copies the shared content to
+    // the TD's private memory — so any writes here are guaranteed to reach the TD.
+    #[cfg(feature = "tdx")]
+    if let Some(ref td_shim) = td_shim_parsed {
+        td_shim
+            .load_sections(&guest_memory)
+            .map_err(|e| StartMicrovmError::TdShimError(format!("{e}")))?;
+
+        arch::x86_64::setup_mptable_for_tdshim(
+            &guest_memory,
+            vm_resources.vm_config().vcpu_count.unwrap_or(1),
+        )
+        .map_err(|e| StartMicrovmError::Internal(Error::ConfigureSystem(e)))?;
+
+        // Place the trampoline INSIDE the kernel image, just before startup_64.
+        // The HOB entry_point must be in the kernel's address range — any address
+        // outside (like 0x801000 in the TD_HOB section) causes td-shim to treat
+        // the jump target as HOB data and behave incorrectly before the kernel runs.
+        //
+        // The bytes before startup_64 are PE/COFF header data that td-shim's
+        // RawVmLinux boot path never reads or executes, so overwriting them is safe.
+        //
+        // td-shim creates its own boot_params with cmd_line_ptr=0, so the
+        // kernel falls back to CONFIG_CMDLINE and we have no way to inject a
+        // custom cmdline.  Patching cmd_line_ptr here lets load_cmdline's
+        // content (written to CMDLINE_START) reach the kernel.
+        //
+        // Note: the trampoline is only written when an initrd is present. Without
+        // an initrd no trampoline is placed, so boot_params.cmd_line_ptr will remain
+        // 0 and the kernel won't see any cmdline passed via load_cmdline. This is a
+        // known limitation of the current TD-Shim boot path.
+        if let (Some(kernel_bundle), Some(initrd_bundle)) =
+            (&vm_resources.kernel_bundle, &vm_resources.initrd_bundle)
+        {
+            let trampoline_addr = kernel_bundle.entry_addr - tdshim::TRAMPOLINE_SIZE;
+            let trampoline = tdshim::build_boot_params_trampoline(
+                arch::x86_64::layout::INITRD_SEV_START as u32,
+                initrd_bundle.size.try_into().unwrap(),
+                arch::x86_64::layout::CMDLINE_START as u32,
+            );
+            guest_memory
+                .write(&trampoline, GuestAddress(trampoline_addr))
+                .map_err(|e| StartMicrovmError::TdShimError(format!("{e}")))?;
+        }
     }
 
     #[cfg(not(feature = "tee"))]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1265,8 +1265,15 @@ pub fn build_microvm(
 
     // Write the kernel command line to guest memory. This is x86_64 specific, since on
     // aarch64 the command line will be specified through the FDT.
+    // For the TD-Shim path, the cmdline is written so TD-Shim can reference it when
+    // populating boot_params for the Linux kernel (cmd_line_ptr already points here
+    // via configure_system).
     #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
     load_cmdline(&vmm)?;
+    #[cfg(all(target_arch = "x86_64", feature = "tdx"))]
+    if vm_resources.tee_firmware_config.is_some() {
+        load_cmdline(&vmm)?;
+    }
 
     vmm.configure_system(
         vcpus.as_slice(),
@@ -1916,7 +1923,7 @@ pub fn create_guest_memory(
     Ok((guest_mem, arch_mem_info, shm_manager, payload_config))
 }
 
-#[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
+#[cfg(all(target_arch = "x86_64", any(not(feature = "tee"), feature = "tdx")))]
 fn load_cmdline(vmm: &Vmm) -> std::result::Result<(), StartMicrovmError> {
     kernel::loader::load_cmdline(
         vmm.guest_memory(),

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1614,7 +1614,7 @@ pub fn create_guest_memory(
 > {
     let mem_size = mem_size << 20;
 
-    let (firmware_data, firmware_size) = if let Some(firmware) = &vm_resources.firmware_config {
+    let (firmware_data, _firmware_size) = if let Some(firmware) = &vm_resources.firmware_config {
         let data = std::fs::read(firmware.path.clone()).map_err(StartMicrovmError::FirmwareRead)?;
         let len = data.len();
         (Some(data), Some(len))
@@ -1634,13 +1634,13 @@ pub fn create_guest_memory(
                 };
             arch::arch_memory_regions(mem_size, Some(kernel_guest_addr), kernel_size, 0, None)
         }
-        Payload::ExternalKernel(external_kernel) => arch::arch_memory_regions(
-            mem_size,
-            None,
-            0,
-            external_kernel.initramfs_size,
-            firmware_size,
-        ),
+        Payload::ExternalKernel(external_kernel) => {
+            #[cfg(not(feature = "tee"))]
+            let fw = _firmware_size;
+            #[cfg(feature = "tee")]
+            let fw: Option<(u64, usize)> = None;
+            arch::arch_memory_regions(mem_size, None, 0, external_kernel.initramfs_size, fw)
+        }
         #[cfg(feature = "tee")]
         Payload::Tee => {
             let (kernel_guest_addr, kernel_size) =
@@ -1653,14 +1653,17 @@ pub fn create_guest_memory(
         }
         #[cfg(test)]
         Payload::Empty => arch::arch_memory_regions(mem_size, None, 0, 0, None),
-        Payload::Firmware => arch::arch_memory_regions(mem_size, None, 0, 0, firmware_size),
+        #[cfg(not(feature = "tee"))]
+        Payload::Firmware => arch::arch_memory_regions(mem_size, None, 0, 0, _firmware_size),
+        #[cfg(feature = "tee")]
+        Payload::Firmware => arch::arch_memory_regions(mem_size, None, 0, 0, None),
     };
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     let (arch_mem_info, mut arch_mem_regions) = match payload {
         Payload::ExternalKernel(external_kernel) => {
             arch::arch_memory_regions(mem_size, external_kernel.initramfs_size, None)
         }
-        _ => arch::arch_memory_regions(mem_size, 0, firmware_size),
+        _ => arch::arch_memory_regions(mem_size, 0, _firmware_size),
     };
 
     let mut shm_manager = ShmManager::new(&arch_mem_info);

--- a/src/vmm/src/linux/tee/amdsnp/mod.rs
+++ b/src/vmm/src/linux/tee/amdsnp/mod.rs
@@ -323,6 +323,7 @@ impl AmdSnp {
                     .get_host_address(GuestAddress(SNP_LIDT_START))
                     .unwrap() as u64,
                 size: 0x1000,
+                attributes: 0,
             },
             &mut launcher,
             PageType::Zero,
@@ -337,6 +338,7 @@ impl AmdSnp {
                     .get_host_address(GuestAddress(SNP_SECRETS_START))
                     .unwrap() as u64,
                 size: 0x1000,
+                attributes: 0,
             },
             &mut launcher,
             PageType::Secrets,
@@ -352,6 +354,7 @@ impl AmdSnp {
                     .get_host_address(GuestAddress(SNP_CPUID_START))
                     .unwrap() as u64,
                 size: 0x1000,
+                attributes: 0,
             },
             &mut launcher,
             PageType::Cpuid,
@@ -368,6 +371,7 @@ impl AmdSnp {
                         .get_host_address(GuestAddress(SNP_CPUID_START))
                         .unwrap() as u64,
                     size: 0x1000,
+                    attributes: 0,
                 },
                 &mut launcher,
                 PageType::Cpuid,
@@ -385,6 +389,7 @@ impl AmdSnp {
                     .get_host_address(GuestAddress(SNP_FWDATA_START))
                     .unwrap() as u64,
                 size: SNP_FWDATA_SIZE,
+                attributes: 0,
             },
             &mut launcher,
             PageType::Zero,

--- a/src/vmm/src/linux/tee/inteltdx.rs
+++ b/src/vmm/src/linux/tee/inteltdx.rs
@@ -38,7 +38,7 @@ impl IntelTdx {
             let mem_region = tdx::launch::MemRegion::new(
                 region.guest_addr,
                 (region.size / 4096) as u64,
-                (arch::FIRMWARE_START == region.guest_addr).into(),
+                region.attributes,
                 region.host_addr,
             );
             launcher

--- a/src/vmm/src/linux/tee/mod.rs
+++ b/src/vmm/src/linux/tee/mod.rs
@@ -3,3 +3,6 @@ pub mod amdsnp;
 
 #[cfg(feature = "tdx")]
 pub mod inteltdx;
+
+#[cfg(feature = "tdx")]
+pub mod tdshim;

--- a/src/vmm/src/linux/tee/tdshim.rs
+++ b/src/vmm/src/linux/tee/tdshim.rs
@@ -1,8 +1,26 @@
+use std::fmt::{self, Display, Formatter};
 use std::fs::File;
 use std::io::{self, Read, Seek};
+use std::mem;
 use std::path::Path;
+
 use tdx::tdvf::{self, TdvfSection, TdvfSectionType};
-use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+use vm_memory::{ByteValued, Bytes, GuestAddress, GuestMemoryMmap};
+
+const HOB_TYPE_PHIT: u16 = 0x0001;
+const HOB_TYPE_RESOURCE: u16 = 0x0003;
+const HOB_TYPE_GUID_EXT: u16 = 0x0004;
+const HOB_TYPE_END: u16 = 0xFFFF;
+const EFI_RESOURCE_SYSTEM_MEMORY: u32 = 0x00000000;
+// PRESENT | INITIALIZED | TESTED (bits 0–2). 0x307 would also set
+// WRITE_PROTECTED | EXECUTION_PROTECTED, which is wrong for system RAM.
+// td-shim ignores those bits today, but QEMU uses 0x7 and so do we.
+const EFI_RESOURCE_ATTR_TESTED: u32 = 0x7;
+
+// B96FA412-461F-4BE3-8C0D-AD805A497AC0
+const PAYLOAD_INFO_GUID: [u8; 16] = [
+    0x12, 0xa4, 0x6f, 0xb9, 0x1f, 0x46, 0xe3, 0x4b, 0x8c, 0x0d, 0xad, 0x80, 0x5a, 0x49, 0x7a, 0xc0,
+];
 
 #[derive(Debug)]
 pub enum Error {
@@ -12,11 +30,12 @@ pub enum Error {
     InvalidSectionOffset,
     MissingBfv,
     MissingTdHob,
+    HobRegionTooSmall,
     GuestMemory(vm_memory::GuestMemoryError),
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match self {
             Self::OpenFirmware(e) => write!(f, "Unable to open TDShim firmware: {e}"),
             Self::ReadFirmware(e) => write!(f, "Unable to read TDShim firmware: {e}"),
@@ -24,6 +43,7 @@ impl std::fmt::Display for Error {
             Self::InvalidSectionOffset => write!(f, "Invalid TDShim section offset"),
             Self::MissingBfv => write!(f, "TDShim missing BFV section"),
             Self::MissingTdHob => write!(f, "TDShim missing TD HOB section"),
+            Self::HobRegionTooSmall => write!(f, "TDShim TD HOB region too small"),
             Self::GuestMemory(e) => {
                 write!(f, "Unable to write TDShim data to guest memory: {e}")
             }
@@ -39,13 +59,178 @@ pub struct TdShim {
     pub firmware_data: Vec<u8>,
 }
 
+#[derive(Copy, Clone, Default)]
+#[repr(C, packed)]
+struct HobHeader {
+    hob_type: u16,
+    hob_length: u16,
+    reserved: u32,
+}
+unsafe impl ByteValued for HobHeader {}
+
+impl HobHeader {
+    fn new(hob_type: u16, hob_length: u16) -> Self {
+        Self {
+            hob_type,
+            hob_length,
+            reserved: 0,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+struct PhitHob {
+    header: HobHeader,
+    version: u32,
+    boot_mode: u32,
+    efi_memory_top: u64,
+    efi_memory_bottom: u64,
+    efi_free_memory_top: u64,
+    efi_free_memory_bottom: u64,
+    efi_end_of_hob_list: u64,
+}
+unsafe impl ByteValued for PhitHob {}
+
+impl Default for PhitHob {
+    fn default() -> Self {
+        Self {
+            header: HobHeader::new(HOB_TYPE_PHIT, mem::size_of::<PhitHob>() as u16),
+            version: 0x0009,
+            boot_mode: 0,
+            efi_memory_top: 0,
+            efi_memory_bottom: 0,
+            efi_free_memory_top: 0,
+            efi_free_memory_bottom: 0,
+            efi_end_of_hob_list: 0,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+struct ResourceHob {
+    header: HobHeader,
+    owner: [u8; 16],
+    resource_type: u32,
+    resource_attributes: u32,
+    physical_start: u64,
+    resource_length: u64,
+}
+unsafe impl ByteValued for ResourceHob {}
+
+impl Default for ResourceHob {
+    fn default() -> Self {
+        Self {
+            header: HobHeader::new(HOB_TYPE_RESOURCE, mem::size_of::<ResourceHob>() as u16),
+            owner: [0u8; 16],
+            resource_type: EFI_RESOURCE_SYSTEM_MEMORY,
+            resource_attributes: EFI_RESOURCE_ATTR_TESTED,
+            physical_start: 0,
+            resource_length: 0,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+#[repr(C, packed)]
+struct GuidExtHobHeader {
+    header: HobHeader,
+    name: [u8; 16],
+}
+unsafe impl ByteValued for GuidExtHobHeader {}
+
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+struct PayloadInfoHob {
+    guid_header: GuidExtHobHeader,
+    image_type: u32,
+    reserved: u32,
+    entry_point: u64,
+}
+unsafe impl ByteValued for PayloadInfoHob {}
+
+impl Default for PayloadInfoHob {
+    fn default() -> Self {
+        Self {
+            guid_header: GuidExtHobHeader {
+                header: HobHeader::new(HOB_TYPE_GUID_EXT, mem::size_of::<PayloadInfoHob>() as u16),
+                name: PAYLOAD_INFO_GUID,
+            },
+            // libkrunfw packages the kernel as a raw ELF vmlinux (not bzImage).
+            // Use RawVmLinux (2) so td-shim jumps directly to entry_point rather
+            // than treating the image as a bzImage and miscalculating startup_64.
+            image_type: 2,
+            reserved: 0,
+            entry_point: 0,
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+#[repr(C, packed)]
+struct EndHob {
+    header: HobHeader,
+}
+unsafe impl ByteValued for EndHob {}
+
+impl Default for EndHob {
+    fn default() -> Self {
+        Self {
+            header: HobHeader::new(HOB_TYPE_END, mem::size_of::<EndHob>() as u16),
+        }
+    }
+}
+
+fn append<T: ByteValued>(buf: &mut Vec<u8>, val: &T) {
+    buf.extend_from_slice(val.as_slice());
+}
+
 pub fn write_hob_chain(
     out: &mut [u8],
     hob_region_addr: u64,
     memory_regions: &[(u64, u64)],
     kernel_entry_addr: u64,
 ) -> Result<()> {
-    unimplemented!()
+    let mut chain: Vec<u8> = Vec::new();
+
+    let phit_offset = chain.len();
+    append(&mut chain, &PhitHob::default());
+
+    for &(start, length) in memory_regions {
+        append(
+            &mut chain,
+            &ResourceHob {
+                physical_start: start,
+                resource_length: length,
+                ..Default::default()
+            },
+        );
+    }
+
+    append(
+        &mut chain,
+        &PayloadInfoHob {
+            entry_point: kernel_entry_addr,
+            ..Default::default()
+        },
+    );
+
+    append(&mut chain, &EndHob::default());
+
+    // Patch PHIT: efi_end_of_hob_list points past the End HOB (exclusive end of the chain).
+    // td-shim validates: hob_length == efi_end_of_hob_list - hob_ptr, where
+    // hob_length = end_hob_offset + size_of::<Header>() = chain.len().
+    let end_of_list_addr = hob_region_addr + chain.len() as u64;
+    let eol_off = phit_offset + mem::offset_of!(PhitHob, efi_end_of_hob_list);
+    chain[eol_off..eol_off + 8].copy_from_slice(&end_of_list_addr.to_le_bytes());
+
+    if chain.len() > out.len() {
+        return Err(Error::HobRegionTooSmall);
+    }
+
+    out[..chain.len()].copy_from_slice(&chain);
+    Ok(())
 }
 
 fn is_bfv(s: &TdvfSection) -> bool {
@@ -168,7 +353,6 @@ impl TdShim {
         write_hob_chain(
             &mut buf,
             hob_section.memory_address,
-            hob_size,
             ram_regions,
             kernel_entry_addr,
         )?;
@@ -291,14 +475,7 @@ mod tests {
     #[test]
     fn test_hob_chain_starts_with_phit() {
         let mut buf = vec![0u8; 4096];
-        write_hob_chain(
-            &mut buf,
-            0x5000_0000,
-            4096,
-            &[(0, 0x4000_0000)],
-            0x0100_0000,
-        )
-        .unwrap();
+        write_hob_chain(&mut buf, 0x5000_0000, &[(0, 0x4000_0000)], 0x0100_0000).unwrap();
         let hob_type = u16::from_le_bytes([buf[0], buf[1]]);
         assert_eq!(hob_type, 0x0001, "First HOB must be PHIT");
     }
@@ -306,7 +483,7 @@ mod tests {
     #[test]
     fn test_hob_chain_ends_with_end_hob() {
         let mut buf = vec![0u8; 4096];
-        write_hob_chain(&mut buf, 0x5000_0000, 4096, &[(0, 0x4000_0000)], 0x100_0000).unwrap();
+        write_hob_chain(&mut buf, 0x5000_0000, &[(0, 0x4000_0000)], 0x100_0000).unwrap();
         let mut offset = 0usize;
         let mut found_end = false;
         while offset + 4 <= buf.len() {
@@ -327,7 +504,41 @@ mod tests {
     #[test]
     fn test_hob_chain_too_small_returns_error() {
         let mut buf = vec![0u8; 8];
-        let result = write_hob_chain(&mut buf, 0x5000_0000, 8, &[(0, 0x1000)], 0x100_0000);
+        let result = write_hob_chain(&mut buf, 0x5000_0000, &[(0, 0x1000)], 0x100_0000);
         assert!(matches!(result, Err(Error::HobRegionTooSmall)));
+    }
+
+    #[test]
+    fn test_phit_efi_end_of_hob_list_points_past_end_hob() {
+        // td-shim validates: hob_length == efi_end_of_hob_list - hob_region_addr
+        // where hob_length = end_hob_offset + 8 = chain.len()
+        let hob_region_addr = 0x5000_0000u64;
+        let mut buf = vec![0u8; 4096];
+        write_hob_chain(&mut buf, hob_region_addr, &[(0, 0x4000_0000)], 0x100_0000).unwrap();
+
+        // Read efi_end_of_hob_list from PHIT at offset 48 (after header+version+boot_mode+3×u64)
+        let efi_end = u64::from_le_bytes(buf[48..56].try_into().unwrap());
+
+        // Find the End HOB and compute hob_length = end_hob_offset + 8
+        let mut offset = 0usize;
+        let mut end_hob_offset = None;
+        while offset + 4 <= buf.len() {
+            let hob_type = u16::from_le_bytes([buf[offset], buf[offset + 1]]);
+            let hob_len = u16::from_le_bytes([buf[offset + 2], buf[offset + 3]]) as usize;
+            if hob_type == 0xFFFF {
+                end_hob_offset = Some(offset);
+                break;
+            }
+            if hob_len == 0 {
+                break;
+            }
+            offset += hob_len;
+        }
+        let hob_length = end_hob_offset.unwrap() + 8;
+        assert_eq!(
+            efi_end,
+            hob_region_addr + hob_length as u64,
+            "efi_end_of_hob_list must equal hob_region_addr + chain.len()"
+        );
     }
 }

--- a/src/vmm/src/linux/tee/tdshim.rs
+++ b/src/vmm/src/linux/tee/tdshim.rs
@@ -233,6 +233,42 @@ pub fn write_hob_chain(
     Ok(())
 }
 
+/// Size of the boot_params trampoline placed just before startup_64.
+pub const TRAMPOLINE_SIZE: u64 = 38;
+
+/// td-shim builds its own boot_params without ramdisk or cmdline fields.
+/// This trampoline runs just before startup_64 and patches them in via RSI,
+/// so the kernel finds the initrd and command line normally.
+pub fn build_boot_params_trampoline(
+    initrd_addr: u32,
+    initrd_size: u32,
+    cmdline_addr: u32,
+) -> Vec<u8> {
+    const BP_RAMDISK_IMAGE: u32 = 0x218;
+    const BP_RAMDISK_SIZE: u32 = 0x21c;
+    const BP_CMD_LINE_PTR: u32 = 0x228;
+
+    let patches = [
+        (BP_RAMDISK_IMAGE, initrd_addr),
+        (BP_RAMDISK_SIZE, initrd_size),
+        (BP_CMD_LINE_PTR, cmdline_addr),
+    ];
+
+    let mut code = Vec::with_capacity(TRAMPOLINE_SIZE as usize);
+    for (offset, value) in patches {
+        // mov eax, imm32
+        code.push(0xB8);
+        code.extend_from_slice(&value.to_le_bytes());
+        // mov [rsi+disp32], eax
+        code.extend_from_slice(&[0x89, 0x86]);
+        code.extend_from_slice(&offset.to_le_bytes());
+    }
+    // jmp +0 (startup_64 immediately follows)
+    code.extend_from_slice(&[0xE9, 0x00, 0x00, 0x00, 0x00]);
+    debug_assert_eq!(code.len() as u64, TRAMPOLINE_SIZE);
+    code
+}
+
 fn is_bfv(s: &TdvfSection) -> bool {
     matches!(s.section_type, TdvfSectionType::Bfv)
 }
@@ -540,5 +576,37 @@ mod tests {
             hob_region_addr + hob_length as u64,
             "efi_end_of_hob_list must equal hob_region_addr + chain.len()"
         );
+    }
+
+    #[test]
+    fn test_trampoline_length() {
+        let code = build_boot_params_trampoline(0x00a0_0000, 0x1000, 0x0002_0000);
+        assert_eq!(code.len() as u64, TRAMPOLINE_SIZE);
+    }
+
+    #[test]
+    fn test_trampoline_immediate_values() {
+        let initrd_addr: u32 = 0x00a0_0000;
+        let initrd_size: u32 = 0x0040_0000;
+        let cmdline_addr: u32 = 0x0002_0000;
+        let code = build_boot_params_trampoline(initrd_addr, initrd_size, cmdline_addr);
+
+        // First mov eax, imm32 at offset 1..5
+        assert_eq!(
+            u32::from_le_bytes(code[1..5].try_into().unwrap()),
+            initrd_addr
+        );
+        // Second mov eax, imm32 at offset 11..15
+        assert_eq!(
+            u32::from_le_bytes(code[11..15].try_into().unwrap()),
+            initrd_size
+        );
+        // Third mov eax, imm32 at offset 21..25
+        assert_eq!(
+            u32::from_le_bytes(code[21..25].try_into().unwrap()),
+            cmdline_addr
+        );
+        // Ends with jmp rel32=0
+        assert_eq!(&code[33..38], &[0xE9, 0x00, 0x00, 0x00, 0x00]);
     }
 }

--- a/src/vmm/src/linux/tee/tdshim.rs
+++ b/src/vmm/src/linux/tee/tdshim.rs
@@ -1,0 +1,333 @@
+use std::fs::File;
+use std::io::{self, Read, Seek};
+use std::path::Path;
+use tdx::tdvf::{self, TdvfSection, TdvfSectionType};
+use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+
+#[derive(Debug)]
+pub enum Error {
+    OpenFirmware(io::Error),
+    ReadFirmware(io::Error),
+    ParseSections(tdx::tdvf::Error),
+    InvalidSectionOffset,
+    MissingBfv,
+    MissingTdHob,
+    GuestMemory(vm_memory::GuestMemoryError),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::OpenFirmware(e) => write!(f, "Unable to open TDShim firmware: {e}"),
+            Self::ReadFirmware(e) => write!(f, "Unable to read TDShim firmware: {e}"),
+            Self::ParseSections(e) => write!(f, "Unable to parse TDShim sections: {e}"),
+            Self::InvalidSectionOffset => write!(f, "Invalid TDShim section offset"),
+            Self::MissingBfv => write!(f, "TDShim missing BFV section"),
+            Self::MissingTdHob => write!(f, "TDShim missing TD HOB section"),
+            Self::GuestMemory(e) => {
+                write!(f, "Unable to write TDShim data to guest memory: {e}")
+            }
+        }
+    }
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub struct TdShim {
+    pub sections: Vec<TdvfSection>,
+    pub hob_address: u64,
+    pub firmware_data: Vec<u8>,
+}
+
+pub fn write_hob_chain(
+    out: &mut [u8],
+    hob_region_addr: u64,
+    memory_regions: &[(u64, u64)],
+    kernel_entry_addr: u64,
+) -> Result<()> {
+    unimplemented!()
+}
+
+fn is_bfv(s: &TdvfSection) -> bool {
+    matches!(s.section_type, TdvfSectionType::Bfv)
+}
+
+fn is_td_hob(s: &TdvfSection) -> bool {
+    matches!(s.section_type, TdvfSectionType::TdHob)
+}
+
+fn validate_sections(sections: &[TdvfSection]) -> Result<()> {
+    if !sections.iter().any(is_bfv) {
+        return Err(Error::MissingBfv);
+    }
+    if !sections.iter().any(is_td_hob) {
+        return Err(Error::MissingTdHob);
+    }
+    Ok(())
+}
+
+impl TdShim {
+    pub fn parse(path: &Path) -> Result<Self> {
+        let mut file = File::open(path).map_err(Error::OpenFirmware)?;
+        let sections = tdvf::parse_sections(&mut file).map_err(Error::ParseSections)?;
+        validate_sections(&sections)?;
+
+        let file_size = file
+            .seek(io::SeekFrom::End(0))
+            .map_err(Error::ReadFirmware)?;
+        for section in &sections {
+            if u64::from(section.data_offset) + u64::from(section.raw_data_size) > file_size {
+                return Err(Error::InvalidSectionOffset);
+            }
+        }
+
+        // safe to unwrap since validate_sections() will verify the TDHob is present
+        let hob_address = sections
+            .iter()
+            .find(|s| is_td_hob(s))
+            .unwrap()
+            .memory_address;
+        file.rewind().map_err(Error::ReadFirmware)?;
+        let mut firmware_data = Vec::new();
+        file.read_to_end(&mut firmware_data)
+            .map_err(Error::ReadFirmware)?;
+        Ok(Self {
+            sections,
+            hob_address,
+            firmware_data,
+        })
+    }
+
+    #[cfg(test)]
+    fn firmware_range(&self) -> (u64, u64) {
+        let min = self
+            .sections
+            .iter()
+            .map(|s| s.memory_address)
+            .min()
+            .unwrap();
+        let max = self
+            .sections
+            .iter()
+            .map(|s| s.memory_address + s.memory_data_size)
+            .max()
+            .unwrap();
+        (min, max)
+    }
+
+    /// Returns [min_addr, max_addr) covering only sections above the 32-bit MMIO gap.
+    /// These sections need their own GuestMemoryMmap region; sections below the gap
+    /// fall within the normal RAM mapping and need no separate hole.
+    pub fn high_firmware_range(&self) -> Option<(u64, u64)> {
+        let mmio_start = arch::x86_64::layout::MMIO_MEM_START;
+        let min = self
+            .sections
+            .iter()
+            .filter(|s| s.memory_address >= mmio_start)
+            .map(|s| s.memory_address)
+            .min()?;
+        let max = self
+            .sections
+            .iter()
+            .filter(|s| s.memory_address >= mmio_start)
+            .map(|s| s.memory_address + s.memory_data_size)
+            .max()?;
+        Some((min, max))
+    }
+
+    /// Copies sections with raw data into guest memory. Zero-fill sections are
+    /// already handled by the mmap backing.
+    pub fn load_sections(&self, guest_mem: &GuestMemoryMmap) -> Result<()> {
+        for section in &self.sections {
+            if section.raw_data_size == 0 {
+                continue;
+            }
+            // Bounds already validated by parse(), safe to slice directly.
+            let start = section.data_offset as usize;
+            let end = start + section.raw_data_size as usize;
+            guest_mem
+                .write(
+                    &self.firmware_data[start..end],
+                    GuestAddress(section.memory_address),
+                )
+                .map_err(Error::GuestMemory)?;
+        }
+        Ok(())
+    }
+
+    pub fn generate_hobs(
+        &self,
+        guest_mem: &GuestMemoryMmap,
+        kernel_entry_addr: u64,
+        ram_regions: &[(u64, u64)],
+    ) -> Result<()> {
+        let hob_section = self.sections.iter().find(|s| is_td_hob(s)).unwrap();
+        let hob_size = hob_section.memory_data_size as usize;
+        let mut buf = vec![0u8; hob_size];
+
+        write_hob_chain(
+            &mut buf,
+            hob_section.memory_address,
+            hob_size,
+            ram_regions,
+            kernel_entry_addr,
+        )?;
+
+        guest_mem
+            .write(&buf, GuestAddress(hob_section.memory_address))
+            .map_err(Error::GuestMemory)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn bfv_section() -> TdvfSection {
+        TdvfSection {
+            data_offset: 0,
+            raw_data_size: 0x1000,
+            memory_address: 0xffff_0000,
+            memory_data_size: 0x1000,
+            section_type: TdvfSectionType::Bfv,
+            attributes: 1,
+        }
+    }
+
+    fn hob_section() -> TdvfSection {
+        TdvfSection {
+            data_offset: 0,
+            raw_data_size: 0,
+            memory_address: 0x5000_0000,
+            memory_data_size: 0x1000,
+            section_type: TdvfSectionType::TdHob,
+            attributes: 0,
+        }
+    }
+
+    #[test]
+    fn test_validate_missing_bfv() {
+        let sections = vec![hob_section()];
+        assert!(matches!(
+            validate_sections(&sections),
+            Err(Error::MissingBfv)
+        ));
+    }
+
+    #[test]
+    fn test_validate_missing_hob() {
+        let sections = vec![bfv_section()];
+        assert!(matches!(
+            validate_sections(&sections),
+            Err(Error::MissingTdHob)
+        ));
+    }
+
+    #[test]
+    fn test_validate_both_present() {
+        let sections = vec![bfv_section(), hob_section()];
+        assert!(validate_sections(&sections).is_ok());
+    }
+
+    #[test]
+    fn test_hob_address_extracted() {
+        let hob_addr = 0x5000_0000u64;
+        let sections = vec![bfv_section(), hob_section()];
+        validate_sections(&sections).unwrap();
+        let found = sections.iter().find(|s| is_td_hob(s)).unwrap();
+        assert_eq!(found.memory_address, hob_addr);
+    }
+
+    #[test]
+    fn test_firmware_range() {
+        let sections = vec![bfv_section(), hob_section()];
+        // hob at 0x5000_0000 with size 0x1000 and bfv at 0xffff_0000 with size 0x1000
+        let td = TdShim {
+            hob_address: 0x5000_0000,
+            sections,
+            firmware_data: vec![],
+        };
+        let (min, max) = td.firmware_range();
+        assert_eq!(min, 0x5000_0000);
+        assert_eq!(max, 0xffff_0000 + 0x1000);
+    }
+
+    #[test]
+    fn test_high_firmware_range_excludes_low_sections() {
+        let sections = vec![bfv_section(), hob_section()];
+        let td = TdShim {
+            hob_address: 0x5000_0000,
+            sections,
+            firmware_data: vec![],
+        };
+        let (start, end) = td.high_firmware_range().expect("BFV is above MMIO gap");
+        assert_eq!(start, 0xffff_0000);
+        assert_eq!(end, 0xffff_0000 + 0x1000);
+    }
+
+    #[test]
+    fn test_high_firmware_range_none_when_all_sections_low() {
+        let sections = vec![
+            TdvfSection {
+                data_offset: 0,
+                raw_data_size: 0,
+                memory_address: 0x0080_0000,
+                memory_data_size: 0x1000,
+                section_type: TdvfSectionType::TempMem,
+                attributes: 0,
+            },
+            hob_section(),
+        ];
+        let td = TdShim {
+            hob_address: 0x5000_0000,
+            sections,
+            firmware_data: vec![],
+        };
+        assert!(td.high_firmware_range().is_none());
+    }
+
+    #[test]
+    fn test_hob_chain_starts_with_phit() {
+        let mut buf = vec![0u8; 4096];
+        write_hob_chain(
+            &mut buf,
+            0x5000_0000,
+            4096,
+            &[(0, 0x4000_0000)],
+            0x0100_0000,
+        )
+        .unwrap();
+        let hob_type = u16::from_le_bytes([buf[0], buf[1]]);
+        assert_eq!(hob_type, 0x0001, "First HOB must be PHIT");
+    }
+
+    #[test]
+    fn test_hob_chain_ends_with_end_hob() {
+        let mut buf = vec![0u8; 4096];
+        write_hob_chain(&mut buf, 0x5000_0000, 4096, &[(0, 0x4000_0000)], 0x100_0000).unwrap();
+        let mut offset = 0usize;
+        let mut found_end = false;
+        while offset + 4 <= buf.len() {
+            let hob_type = u16::from_le_bytes([buf[offset], buf[offset + 1]]);
+            let hob_len = u16::from_le_bytes([buf[offset + 2], buf[offset + 3]]) as usize;
+            if hob_type == 0xFFFF {
+                found_end = true;
+                break;
+            }
+            if hob_len == 0 {
+                break;
+            }
+            offset += hob_len;
+        }
+        assert!(found_end, "HOB chain must terminate with 0xFFFF");
+    }
+
+    #[test]
+    fn test_hob_chain_too_small_returns_error() {
+        let mut buf = vec![0u8; 8];
+        let result = write_hob_chain(&mut buf, 0x5000_0000, 8, &[(0, 0x1000)], 0x100_0000);
+        assert!(matches!(result, Err(Error::HobRegionTooSmall)));
+    }
+}

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -796,10 +796,14 @@ impl Vm {
     }
 
     #[cfg(feature = "tdx")]
-    pub fn tdx_secure_virt_init_vcpus(&self, launcher: &mut tdx::launch::Launcher) -> Result<()> {
+    pub fn tdx_secure_virt_init_vcpus(
+        &self,
+        launcher: &mut tdx::launch::Launcher,
+        hob_address: u64,
+    ) -> Result<()> {
         match &self.tdx {
             Some(_) => {
-                launcher.init_vcpus(0).unwrap();
+                launcher.init_vcpus(hob_address).unwrap();
                 Ok(())
             }
             None => Err(Error::InvalidTee),

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -434,6 +434,7 @@ pub struct MeasuredRegion {
     pub guest_addr: u64,
     pub host_addr: u64,
     pub size: usize,
+    pub attributes: u32,
 }
 
 /// Describes a KVM context that gets attached to the microVM.

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -21,6 +21,8 @@ use serde::{Deserialize, Serialize};
 use crate::vmm_config::block::{BlockBuilder, BlockConfigError, BlockDeviceConfig};
 use crate::vmm_config::external_kernel::ExternalKernel;
 use crate::vmm_config::firmware::FirmwareConfig;
+#[cfg(feature = "tdx")]
+use crate::vmm_config::firmware::TeeFirmwareConfig;
 #[cfg(not(feature = "tee"))]
 use crate::vmm_config::fs::*;
 #[cfg(feature = "tee")]
@@ -191,6 +193,9 @@ pub struct VmResources {
     /// The parameters for the initrd bundle to be loaded in this microVM.
     #[cfg(feature = "tee")]
     pub initrd_bundle: Option<InitrdBundle>,
+    /// User-provided TEE firmware configuration for TDX guests.
+    #[cfg(feature = "tdx")]
+    pub tee_firmware_config: Option<TeeFirmwareConfig>,
     /// The fs device.
     #[cfg(not(feature = "tee"))]
     pub fs: Vec<FsDeviceConfig>,
@@ -360,6 +365,11 @@ impl VmResources {
     pub fn set_initrd_bundle(&mut self, initrd_bundle: InitrdBundle) -> Result<KernelBundleError> {
         self.initrd_bundle = Some(initrd_bundle);
         Ok(())
+    }
+
+    #[cfg(feature = "tdx")]
+    pub fn set_tee_firmware_config(&mut self, cfg: TeeFirmwareConfig) {
+        self.tee_firmware_config = Some(cfg);
     }
 
     #[cfg(not(feature = "tee"))]
@@ -542,6 +552,28 @@ mod tests {
         assert_eq!(
             actual_vsock_cfg.lock().unwrap().id(),
             &new_vsock_cfg.vsock_id
+        );
+    }
+}
+
+#[cfg(all(test, feature = "tdx"))]
+mod tee_firmware_tests {
+    use super::*;
+    use crate::vmm_config::firmware::{TeeFirmwareConfig, TeeFirmwareType};
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_set_and_get_tee_firmware_config() {
+        let mut r = VmResources::default();
+        assert!(r.tee_firmware_config.is_none());
+        let cfg = TeeFirmwareConfig {
+            fw_type: TeeFirmwareType::TdShim,
+            path: PathBuf::from("/tmp/td-shim.bin"),
+        };
+        r.set_tee_firmware_config(cfg);
+        assert_eq!(
+            r.tee_firmware_config.unwrap().path,
+            PathBuf::from("/tmp/td-shim.bin")
         );
     }
 }

--- a/src/vmm/src/vmm_config/firmware.rs
+++ b/src/vmm/src/vmm_config/firmware.rs
@@ -7,3 +7,16 @@ use std::path::PathBuf;
 pub struct FirmwareConfig {
     pub path: PathBuf,
 }
+
+#[cfg(feature = "tdx")]
+#[derive(Clone, Debug)]
+pub enum TeeFirmwareType {
+    TdShim,
+}
+
+#[cfg(feature = "tdx")]
+#[derive(Clone, Debug)]
+pub struct TeeFirmwareConfig {
+    pub fw_type: TeeFirmwareType,
+    pub path: PathBuf,
+}


### PR DESCRIPTION
## Background

libkrun currently boots TDX (Trust Domain Extensions) guests using qboot as the
firmware. qboot is a minimal x86 firmware designed for fast VM startup — it
initializes just enough hardware state to hand off to a Linux kernel. For TDX,
qboot sets up the initial guest memory layout and measurement regions, then jumps
to the kernel entry point.

TD-Shim is an alternative firmware specifically designed for TDX. It implements
the UEFI PI (Platform Initialization) Hand-Off Block (HOB) protocol, which is
the standard mechanism for passing platform configuration from firmware to a
payload in the UEFI ecosystem. Where qboot is a general-purpose minimal
firmware, TD-Shim is purpose-built for confidential computing and provides:

- **TDVF section-based memory layout**: Firmware sections (BFV, TempMem, TD_HOB,
  etc.) are described in a TDVF metadata table embedded in the binary, each with
  its own guest physical address, size, and TDX measurement attributes.
- **HOB-based platform description**: RAM regions, the kernel entry point, and
  payload metadata are communicated to the payload through a HOB chain rather
  than through legacy boot protocol structures.
- **Per-section TDX measurement**: Each firmware section carries its own
  `attributes` field controlling whether it is measured into the TD measurement
  registers, enabling fine-grained attestation of the boot chain.

TDVF (TDX Virtual Firmware, i.e., a full OVMF build with TDX support) also uses
the HOB protocol, but it is a complete UEFI implementation — hundreds of
megabytes of firmware that boots through SEC/PEI/DXE phases. TD-Shim is a
lightweight alternative that goes straight from reset to payload execution,
making it a better fit for libkrun's fast-boot philosophy.

## What this series does

This series adds TD-Shim as an alternative firmware for TDX guests, selectable
via a new `krun_set_tee_firmware()` API. The implementation:

1. **Parses TD-Shim firmware binaries** by reading the TDVF metadata table to
   extract section descriptions (addresses, sizes, types, measurement
   attributes).

2. **Builds a HOB chain** in guest memory containing: a PHIT (Phase Handoff
   Information Table) header, resource descriptors for each RAM region, a
   PayloadInfo GUID extension HOB with the kernel entry point, and an end-of-list
   marker.

3. **Loads firmware sections** into guest memory at the addresses specified by
   the TDVF metadata, and constructs `MeasuredRegion` entries with per-section
   attributes for TDX memory initialization.

4. **Writes a boot_params trampoline** — a small block of x86_64 machine code
   placed just before `startup_64` that patches td-shim's `boot_params` struct
   (passed via RSI) with the initrd address/size and cmdline pointer before
   jumping to the kernel. This is necessary because td-shim constructs its own
   `boot_params` and doesn't know about the initrd or command line that libkrun
   placed in guest memory.

5. **Carves a dynamic firmware hole** in the guest memory layout for TD-Shim's
   high-memory sections, replacing the fixed qboot firmware region at
   `FIRMWARE_START`.