### PR TITLE
init: replace dummy IP address

### DIFF
--- a/init/init.c
+++ b/init/init.c
@@ -1370,7 +1370,7 @@ static int enable_dummy_interface()
     }
 
     addr->sin_family = AF_INET;
-    if (inet_pton(AF_INET, "10.0.0.1", &addr->sin_addr) <= 0) {
+    if (inet_pton(AF_INET, "203.0.113.1", &addr->sin_addr) <= 0) {
         printf("inet_pton address conversion failed\n");
         goto close_socket;
     }
@@ -1380,7 +1380,7 @@ static int enable_dummy_interface()
     }
 
     netmask->sin_family = AF_INET;
-    if (inet_pton(AF_INET, "255.0.0.0", &netmask->sin_addr) <= 0) {
+    if (inet_pton(AF_INET, "255.255.255.0", &netmask->sin_addr) <= 0) {
         printf("inet_pton netmask conversion failed\n");
         goto close_socket;
     }


### PR DESCRIPTION
    In commit 2593accd9b, we extended init to configure a dummy interface
    when TSI is enabled, to help local applications find out the VM has
    network connectivity.

    For the dummy interface, we've used the 10.0.0.1/8 address, which
    collides with the network ranges used by podman by default. In
    principle, this shouldn't be a problem since, with TSI hijack enabled,
    the kernel takes over the application's INET socket.

    But, to implement both the INET and VSOCK personalities, when connect()
    is called on a TSI socket, TSI attempts to connect to the endpoint first
    with the INET personality, falling back to VSOCK only if that one fails.

    For SOCK_DGRAM sockets, a connect() via the INET personality will always
    succeed if there's a route defined that would allow to reach the
    destination address.

    So, with a dummy inteface configured with a 10.0.0.1/8 address,
    attempting to access a DNS server within that range leads to the
    following flow:

    - Userspace creates the AF_INET/SOCK_DGRAM socket.
    - The kernel hijacks the AF_INET returning an AF_TSI socket instead.
    - Userspace calls connect() on the socket.
    - tsi_connect() attemps connecting via the INET personality first, with
      success.
    - For TSI, the socket becomes effectively an AF_INET socket, not
      allowing external communitations via VSOCK.

    To avoid this issue, let's switch to an address from IANA's TEST-NET-3
    block, which shouldn't be used by any network external to the VM.