### PR TITLE
virtio/net: fix ENAMETOOLONG on long gvproxy socket paths (macOS)

### DIFF
--- a/src/devices/src/virtio/net/unixgram.rs
+++ b/src/devices/src/virtio/net/unixgram.rs
@@ -6,6 +6,8 @@ use nix::sys::socket::{
 use nix::unistd::unlink;
 use std::os::fd::{AsRawFd, OwnedFd, RawFd};
 use std::path::PathBuf;
+use std::process;
+use std::sync::atomic::{AtomicU32, Ordering};
 
 use super::backend::{ConnectError, NetBackend, ReadError, WriteError};
 use super::write_virtio_net_hdr;
@@ -13,6 +15,15 @@ use super::write_virtio_net_hdr;
 use super::{MAX_BUFFER_SIZE, VNET_HDR_LEN};
 
 const VFKIT_MAGIC: [u8; 4] = *b"VFKT";
+
+/// Per-process counter to generate unique local unixgram socket filenames.
+///
+/// The local socket is placed in the same directory as the peer using a short
+/// PID+counter name. The peer filename always contains the machine name, so it
+/// is longer than our fixed-format name for any reasonably-named machine, keeping
+/// the local path within macOS's 104-byte unix socket limit.
+static NET_SOCK_COUNTER: AtomicU32 = AtomicU32::new(0);
+
 const DEFAULT_SOCKET_BUF_SIZE: usize = 7 * 1024 * 1024;
 
 // On macOS, with UNIX datagram sockets the send buffer is not used for queuing;
@@ -76,8 +87,13 @@ impl Unixgram {
         )
         .map_err(ConnectError::CreateSocket)?;
         let peer_addr = UnixAddr::new(&path).map_err(ConnectError::InvalidAddress)?;
-        let local_addr = UnixAddr::new(&PathBuf::from(format!("{}-krun.sock", path.display())))
-            .map_err(ConnectError::InvalidAddress)?;
+        let socket_name = format!(
+            "krun-net-{}-{}.sock",
+            process::id(),
+            NET_SOCK_COUNTER.fetch_add(1, Ordering::Relaxed),
+        );
+        let local_path = std::env::temp_dir().join(&socket_name);
+        let local_addr = UnixAddr::new(&local_path).map_err(ConnectError::InvalidAddress)?;
         if let Some(path) = local_addr.path() {
             _ = unlink(path);
         }

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -105,6 +105,10 @@ pub fn test_cases() -> Vec<TestCase> {
         TestCase::new("net-passt", Box::new(TestNet::new_passt())),
         TestCase::new("net-tap", Box::new(TestNet::new_tap())),
         TestCase::new("net-gvproxy", Box::new(TestNet::new_gvproxy())),
+        TestCase::new(
+            "net-gvproxy-long-path",
+            Box::new(TestNet::new_gvproxy_long_path()),
+        ),
         TestCase::new("net-vmnet-helper", Box::new(TestNet::new_vmnet_helper())),
         TestCase::new("multiport-console", Box::new(TestMultiportConsole)),
         #[cfg(any(feature = "host", target_os = "linux"))]

--- a/tests/test_cases/src/test_net/gvproxy.rs
+++ b/tests/test_cases/src/test_net/gvproxy.rs
@@ -135,13 +135,18 @@ pub(crate) fn should_run() -> ShouldRun {
     }
 }
 
-pub(crate) fn setup_backend(ctx: u32, test_setup: &TestSetup) -> anyhow::Result<()> {
+fn setup_backend_with_socket(
+    ctx: u32,
+    test_setup: &TestSetup,
+    socket_name: &str,
+    log_name: &str,
+) -> anyhow::Result<()> {
     let tmp_dir = test_setup
         .tmp_dir
         .canonicalize()
         .unwrap_or_else(|_| test_setup.tmp_dir.clone());
-    let socket_path = tmp_dir.join("gvproxy.sock");
-    let gvproxy_log = tmp_dir.join("gvproxy.log");
+    let socket_path = tmp_dir.join(socket_name);
+    let gvproxy_log = tmp_dir.join(log_name);
 
     let socket_path_str = socket_path
         .to_str()
@@ -168,4 +173,34 @@ pub(crate) fn setup_backend(ctx: u32, test_setup: &TestSetup) -> anyhow::Result<
         ))?;
     }
     Ok(())
+}
+
+pub(crate) fn setup_backend(ctx: u32, test_setup: &TestSetup) -> anyhow::Result<()> {
+    setup_backend_with_socket(ctx, test_setup, "gvproxy.sock", "gvproxy.log")
+}
+
+/// Backend setup with a peer socket path long enough to have previously
+/// triggered ENAMETOOLONG on macOS when the local bind address was derived
+/// from the peer path by appending a suffix.
+pub(crate) fn setup_backend_long_path(ctx: u32, test_setup: &TestSetup) -> anyhow::Result<()> {
+    // Build a peer socket filename so that the full path approaches the
+    // 104-byte macOS unix socket limit. Use base_len measured at runtime so
+    // the padding is correct regardless of the exact tmp_dir length.
+    // tmp_dir is typically "/tmp/libkrun-tests.XXXXXXXX" (~27 chars), or
+    // "/private/tmp/libkrun-tests.XXXXXXXX" (~35 chars) after canonicalize on macOS.
+    let tmp_dir = test_setup
+        .tmp_dir
+        .canonicalize()
+        .unwrap_or_else(|_| test_setup.tmp_dir.clone());
+    let base_len = tmp_dir.to_str().map(|s| s.len()).unwrap_or(0);
+    const TARGET_PATH_LEN: usize = 96;
+    let prefix = "gvp-";
+    let suffix = ".sock";
+    let name_needed = TARGET_PATH_LEN.saturating_sub(base_len + 1);
+    let pad_len = name_needed
+        .saturating_sub(prefix.len() + suffix.len())
+        .max(1);
+    let socket_name = format!("{}{}{}", prefix, "x".repeat(pad_len), suffix);
+
+    setup_backend_with_socket(ctx, test_setup, &socket_name, "gvproxy-long-path.log")
 }

--- a/tests/test_cases/src/test_net/mod.rs
+++ b/tests/test_cases/src/test_net/mod.rs
@@ -84,6 +84,20 @@ impl TestNet {
             cleanup: None,
         }
     }
+
+    /// Gvproxy backend variant with a socket path ≥ 96 bytes, triggering the
+    /// ENAMETOOLONG bug when the local socket was derived from the peer path.
+    pub fn new_gvproxy_long_path() -> Self {
+        Self {
+            tcp_tester: TcpTester::new([192, 168, 127, 254].into(), 9004),
+            #[cfg(feature = "host")]
+            should_run: gvproxy::should_run,
+            #[cfg(feature = "host")]
+            setup_backend: gvproxy::setup_backend_long_path,
+            #[cfg(feature = "host")]
+            cleanup: None,
+        }
+    }
 }
 
 #[host]


### PR DESCRIPTION
Assisted-by: Claude Code (Sonnet 4.6)

## Problem

On macOS, `Unixgram::open` derives the local bind address by appending `-krun.sock` to the peer (gvproxy) socket path:

```rust
let local_addr = UnixAddr::new(&PathBuf::from(format!("{}-krun.sock", path.display())))
```

macOS enforces a 104-byte unix socket path limit. The gvproxy peer path can be long enough that appending any suffix pushes the local path over this limit. `UnixAddr::new` returns `ENAMETOOLONG`, which propagates as `BadActivate` and panics the vCPU thread. krunkit stays alive but the VM is frozen at 0% CPU indefinitely.

This affects any deployment where the gvproxy socket path is long enough that a 9-byte suffix would exceed the limit — common with default podman machine naming on macOS.

## Fix

Place the local bind socket in the OS temporary directory, using a short PID + per-process atomic counter filename (`krun-net-<pid>-<n>.sock`). PID ensures uniqueness across concurrent krunkit processes; the counter handles multiple virtio-net devices within a single process. The existing `unlink()` before `bind()` handles stale sockets from crashed previous runs.

## Test

Adds `net-gvproxy-long-path`: exercises the gvproxy backend with a peer socket path long enough that the old suffix-based approach would have exceeded the 104-byte macOS limit. Verifies the VM starts and achieves network connectivity.

Fixes: https://github.com/containers/libkrun/issues/689