### PR TITLE
fs/macos: preserve the inode a rename overwrites

### DIFF
--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -826,17 +826,31 @@ impl PassthroughFs {
         Ok(fd)
     }
 
-    fn store_unlinked_fd(&self, unlinked_fd: RawFd) -> io::Result<()> {
+    fn store_unlinked_fd(&self, unlinked_fd: RawFd) -> io::Result<bool> {
         let st = fstat(unlinked_fd, true)?;
         let altkey = InodeAltKey {
             ino: st.st_ino,
             dev: st.st_dev,
         };
-        if let Some(data) = self.inodes.read().unwrap().get_alt(&altkey).cloned() {
-            data.unlinked_fd
-                .store(unlinked_fd as i64, Ordering::Release);
+        // Hold the read lock across the swap: dropping it earlier would let a
+        // concurrent `forget` remove this inode (closing its then-`-1`
+        // `unlinked_fd`) between our lookup and swap, leaking the fd we store.
+        let inodes = self.inodes.read().unwrap();
+        if let Some(data) = inodes.get_alt(&altkey) {
+            // Swap rather than store so that if this inode already had a
+            // preserved fd (e.g. another hard link was unlinked/overwritten
+            // earlier), we recover and close it instead of leaking it.
+            let old_fd = data.unlinked_fd.swap(unlinked_fd as i64, Ordering::AcqRel);
+            if old_fd >= 0 {
+                unsafe { libc::close(old_fd as RawFd) };
+            }
+            // The tracked inode now owns `unlinked_fd` (closed in `forget_one`).
+            Ok(true)
+        } else {
+            // No tracked inode for this (dev, ino): the caller keeps ownership
+            // of `unlinked_fd` and must close it to avoid a leak.
+            Ok(false)
         }
-        Ok(())
     }
 
     fn do_unlink(
@@ -884,11 +898,19 @@ impl PassthroughFs {
         }
 
         if res == 0 {
-            if let Some(unlinked_fd) = unlinked_fd
-                && let Err(err) = self.store_unlinked_fd(unlinked_fd)
-            {
-                unsafe { libc::close(unlinked_fd) };
-                warn!("Couldn't store unlinked fd \"{}\": {err}", unlinked_fd);
+            if let Some(unlinked_fd) = unlinked_fd {
+                match self.store_unlinked_fd(unlinked_fd) {
+                    // The tracked inode took ownership of the fd.
+                    Ok(true) => {}
+                    // No tracked inode: we still own the fd and must close it.
+                    Ok(false) => unsafe {
+                        libc::close(unlinked_fd);
+                    },
+                    Err(err) => {
+                        unsafe { libc::close(unlinked_fd) };
+                        warn!("Couldn't store unlinked fd \"{}\": {err}", unlinked_fd);
+                    }
+                }
             }
             Ok(())
         } else {
@@ -1660,8 +1682,58 @@ impl FileSystem for PassthroughFs {
         let old_cpath = self.name_to_path(olddir, oldname)?;
         let new_cpath = self.name_to_path(newdir, newname)?;
 
+        // macOS addresses inodes by their volfs path ("/.vol/{dev}/{ino}"),
+        // which only resolves while the inode still has a directory entry. A
+        // rename that REPLACES an existing target drops that target's last
+        // link, so any inode the guest still holds open there would afterwards
+        // resolve to a dangling volfs path and fail path-based ops
+        // (getattr/open/setattr/...) with ENOENT (e.g. apt/dpkg's atomic
+        // rewrite of /var/lib/dpkg/status, surfaced as
+        // "close (2: No such file or directory)"). `do_unlink` already guards
+        // the unlink case by stashing an fd to the doomed inode in
+        // `InodeData.unlinked_fd`; mirror that for the overwritten target. Grab
+        // it *before* the rename, while its entry still exists. RENAME_SWAP
+        // keeps both inodes linked and RENAME_EXCL never overwrites, so skip
+        // those; best-effort otherwise (a non-overwriting rename finds nothing).
+        let doomed_fd = if (flags as i32)
+            & (bindings::LINUX_RENAME_EXCHANGE | bindings::LINUX_RENAME_NOREPLACE)
+            == 0
+        {
+            match self.inode_to_handle(newdir, true) {
+                Ok(InodeHandle::Path(newdir_cpath)) => {
+                    let newdir_fd = unsafe {
+                        libc::open(newdir_cpath.as_ptr(), libc::O_NOFOLLOW | libc::O_CLOEXEC)
+                    };
+                    if newdir_fd < 0 {
+                        None
+                    } else {
+                        let grabbed = self.grab_unlinked_fd(newdir_fd, newname).ok();
+                        unsafe { libc::close(newdir_fd) };
+                        grabbed
+                    }
+                }
+                Ok(InodeHandle::Fd(newdir_fd)) => self.grab_unlinked_fd(newdir_fd, newname).ok(),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
         let res = unsafe { libc::renamex_np(old_cpath.as_ptr(), new_cpath.as_ptr(), mflags) };
         if res == 0 {
+            // If the rename overwrote a tracked inode, hand its preserved fd to
+            // the inode store so later ops resolve by fd, not the vanished path.
+            // `store_unlinked_fd` takes ownership only when that inode is
+            // tracked; close the fd ourselves otherwise so it is never leaked.
+            if let Some(fd) = doomed_fd {
+                match self.store_unlinked_fd(fd) {
+                    Ok(true) => {}
+                    Ok(false) | Err(_) => unsafe {
+                        libc::close(fd);
+                    },
+                }
+            }
+
             if ((flags as i32) & bindings::LINUX_RENAME_WHITEOUT) != 0 {
                 let fd = unsafe {
                     libc::open(
@@ -1689,6 +1761,10 @@ impl FileSystem for PassthroughFs {
 
             Ok(())
         } else {
+            if let Some(fd) = doomed_fd {
+                // The rename failed; nothing was overwritten. Drop the fd.
+                unsafe { libc::close(fd) };
+            }
             Err(linux_error(io::Error::last_os_error()))
         }
     }

--- a/tests/test_cases/src/test_virtiofs_misc.rs
+++ b/tests/test_cases/src/test_virtiofs_misc.rs
@@ -465,6 +465,68 @@ mod guest {
         }
     }
 
+    /// Test rename-overwrite with open file descriptors (PR #700 regression test).
+    ///
+    /// This verifies the fix for a macOS-specific fd leak when renaming over
+    /// an existing file. The macOS virtio-fs implementation uses volfs paths
+    /// (/.vol/{dev}/{ino}) which become invalid when the inode's last link is
+    /// removed. When rename() replaces a file, the old target loses its link,
+    /// breaking operations on still-open fds.
+    ///
+    /// This pattern broke apt/dpkg atomic writes:
+    /// "Problem closing the file /var/lib/dpkg/status - close (2: No such file or directory)"
+    fn test_rename_overwrite_fchmod() {
+        let target_path = "/test_rename_fstat_target";
+        let temp_path = "/test_rename_fstat_temp";
+
+        // Create target with initial content
+        let mut target_file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(target_path)
+            .unwrap();
+
+        target_file.write_all(b"data1\n").unwrap();
+        target_file.flush().unwrap();
+
+        // Keep the target file open
+        let open_target = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(target_path)
+            .unwrap();
+
+        // Create temp file
+        let mut temp_file = fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(temp_path)
+            .unwrap();
+
+        temp_file.write_all(b"data2\n").unwrap();
+        temp_file.flush().unwrap();
+        drop(temp_file);
+
+        // Rename temp over target
+        fs::rename(temp_path, target_path).expect("rename failed");
+
+        // Try to get file stats via the still-open file descriptor.
+        // Before PR #700, this would fail with ENOENT on macOS.
+        open_target
+            .metadata()
+            .expect("fstat on open fd after rename failed - PR #700 regression!");
+
+        // Try to change permission bits via the still-open file descriptor.
+        use nix::sys::stat::{Mode, fchmod};
+        fchmod(
+            open_target.as_raw_fd(),
+            Mode::S_IRUSR | Mode::S_IWUSR | Mode::S_IRGRP,
+        )
+        .expect("fchmod on open fd after rename failed - PR #700 regression!");
+    }
+
     /// Test that creating files mid-iteration does not cause duplicates.
     ///
     /// POSIX says readdir behavior is unspecified when the directory is modified
@@ -575,6 +637,7 @@ mod guest {
                     "fallocate_punch_hole_requires_keep_size",
                     test_fallocate_punch_hole_requires_keep_size,
                 ),
+                ("rename_overwrite_fchmod", test_rename_overwrite_fchmod),
                 ("dirstream_create", test_dirstream_create),
                 ("dirstream_unlink", test_dirstream_unlink),
                 ("dirstream_mkdir_rmdir", test_dirstream_mkdir_rmdir),


### PR DESCRIPTION
The macOS virtio-fs passthrough addresses inodes by their volfs path ("/.vol/{dev}/{ino}"), which only resolves while the inode still has a directory entry. A rename that REPLACES an existing target drops that target's last link, but unlike do_unlink -- which stashes an fd to the doomed inode in InodeData.unlinked_fd -- rename never preserved the overwritten inode. Any FUSE op the guest later issues on it then resolves a dangling volfs path and returns ENOENT.

This breaks the common atomic write-new-then-rename-over pattern when the guest still holds the old target open: apt/dpkg rewrite /var/lib/dpkg/status this way while apt holds it open, so apt's final close reports "Problem closing the file /var/lib/dpkg/status - close (2: No such file or directory)" even though the install succeeded. It reproduces on any overlayfs upperdir backed by this server.

Mirror do_unlink: grab an fd to the target before renamex_np (replace case only -- not RENAME_SWAP/RENAME_EXCL) and hand it to the displaced inode on success. store_unlinked_fd now reports whether a tracked inode took ownership so the caller closes the fd otherwise instead of leaking it.

Built on macOS/aarch64 and verified in a downstream consumer — apt-based setup recipes that previously failed at dpkg's close now succeed.