### PR TITLE
virtio/fs: report actual bytes written in used ring len

### DIFF
--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -231,7 +231,7 @@ impl FsWorker {
                 .map_err(FsError::QueueWriter)
                 .unwrap();
 
-            if let Err(e) = self.server.handle_message(
+            let len = match self.server.handle_message(
                 reader,
                 writer,
                 &self.shm_region,
@@ -239,10 +239,14 @@ impl FsWorker {
                 #[cfg(target_os = "macos")]
                 &self.map_sender,
             ) {
-                error!("error handling message: {e:?}");
-            }
+                Ok(len) => len,
+                Err(e) => {
+                    error!("error handling message: {e:?}");
+                    0
+                }
+            };
 
-            if let Err(e) = queue.add_used(&self.mem, head.index, 0) {
+            if let Err(e) = queue.add_used(&self.mem, head.index, len as u32) {
                 error!("failed to add used elements to the queue: {e:?}");
             }
 


### PR DESCRIPTION
The virtio used ring's len field must reflect the number of bytes the
device wrote into the writable descriptor chain. libkrun was hard-coding
0, which broke FUSE protocol validation added in Linux kernel commit
68b69fa0edb (virtiofs: add FUSE protocol validation).

Resolves: https://github.com/containers/libkrun/issues/695