### PR TITLE
docs: fix libkrun.h self-containment and net API refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <picture>
    <source media="(prefers-color-scheme: dark)" srcset="docs/images/libkrun_logo_horizontal_darkmode.png">
    <source media="(prefers-color-scheme: light)" srcset="docs/images/libkrun_logo_horizontal.png">
-   <img alt="libkrun logo" src="docs/images/libkrun_logo_horizontal_200.png">
+   <img alt="libkrun logo" src="docs/images/libkrun_logo_horizontal.png">
 </picture>
 
 # libkrun
@@ -80,7 +80,7 @@ A conventional virtual interface that allows the guest to communicate with the o
 
 #### Enabling virtio-net
 
-Use `krun_add_net_unixstream` and/or `krun_add_net_unixdgram` to add a virtio-net interface connected to the userspace network proxy.
+Use `krun_add_net_unixstream` and/or `krun_add_net_unixgram` to add a virtio-net interface connected to the userspace network proxy.
 
 ## Security model
 
@@ -216,7 +216,7 @@ This is a simple example providing ```chroot```-like functionality using ```libk
 
 #### Building chroot_vm
 
-To be able to ```chroot_vm```, you need need to build libkrun with the `virtio-block` and `virtio-net` optional features:
+To be able to ```chroot_vm```, you need to build libkrun with the `virtio-block` and `virtio-net` optional features:
 
 ```
 make BLK=1 NET=1

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -8,6 +8,7 @@ extern "C" {
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 /**
@@ -391,10 +392,10 @@ int32_t krun_add_virtiofs3(uint32_t ctx_id,
  * Arguments:
  *  "ctx_id"   - the configuration context ID.
  *  "c_path"   - a null-terminated string representing the path
- *               for the unixstream socket where the userspace
+ *               for the Unix domain stream socket where the userspace
  *               network proxy is listening. Must be NULL if "fd"
  *               is not -1.
- *  "fd"       - a file descriptor for an already open unixstream
+ *  "fd"       - a file descriptor for an already open Unix domain stream
  *               connection to the userspace network proxy. Must
  *               be -1 if "c_path" is not NULL.
  *  "c_mac"    - MAC address as an array of 6 uint8_t entries.
@@ -433,10 +434,10 @@ int32_t krun_add_net_unixstream(uint32_t ctx_id,
  * Arguments:
  *  "ctx_id"   - the configuration context ID.
  *  "c_path"   - a null-terminated string representing the path
- *               for the unixstream socket where the userspace
+ *               for the Unix domain datagram socket where the userspace
  *               network proxy is listening. Must be NULL if "fd"
  *               is not -1.
- *  "fd"       - a file descriptor for an already open unixstream
+ *  "fd"       - a file descriptor for an already open Unix domain datagram
  *               connection to the userspace network proxy. Must
  *               be -1 if "c_path" is not NULL.
  *  "c_mac"    - MAC address as an array of 6 uint8_t entries.
@@ -520,7 +521,7 @@ int32_t krun_set_passt_fd(uint32_t ctx_id, int fd);
  * Arguments:
  *  "ctx_id"  - the configuration context ID.
  *  "c_path"  - a null-terminated string representing the path for
- *              gvproxy's listen-vfkit unixdgram socket.
+ *              gvproxy's listen-vfkit Unix domain datagram socket.
  *
  * Notes:
  * If you never call this function, networking uses the TSI backend.


### PR DESCRIPTION
`libkrun.h` was not self-contained, so a normal C file that only includes the public header failed on `uid_t` and `gid_t`.
README also pointed to `krun_add_net_unixdgram`, but the exported API is `krun_add_net_unixgram`, so copy paste code just blows up.

Repro for the header bug:

```c
#include "include/libkrun.h"
int main(void) { return 0; }
```

```sh
cc -std=c11 -Werror -I. /tmp/t.c -c
```

Repro for the README typo:

```c
#include "include/libkrun.h"
#include <stdint.h>
int main(void) {
    uint8_t mac[6] = {0};
    return krun_add_net_unixdgram(1, 0, -1, mac, 0, 0);
}
```

This adds `<sys/types.h>`, fixes the README API name, and cleans the nearby unixgram docs. Small paper cut, but pretty real.
