### PR TITLE
balloon: use MADV_FREE to reclaim memory on macOS

### DIFF
--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -93,11 +93,15 @@ impl Balloon {
                     "balloon: should release guest_addr={:?} host_addr={:p} len={}",
                     desc.addr, host_addr, desc.len
                 );
+                #[cfg(target_os = "linux")]
+                let advice = libc::MADV_DONTNEED;
+                #[cfg(target_os = "macos")]
+                let advice = libc::MADV_FREE;
                 unsafe {
                     libc::madvise(
                         host_addr as *mut libc::c_void,
                         desc.len.try_into().unwrap(),
-                        libc::MADV_DONTNEED,
+                        advice,
                     )
                 };
             }


### PR DESCRIPTION
The current implementation of balloon on macOS is not working correctly, because it is using the wrong flag for madvise.

The MADV_DONTNEED flag is no-op on macOS because it preserves the data, so the OS cannot discard the pages. MADV_FREE flag actually frees the memory under pressure, which is what we need for balloon.

How to test this:
1. Inside the VM fill the whole memory with incompressible data:
```bash
mount -t tmpfs -o size=90% none /tmp
dd if=/dev/urandom of=/tmp/data bs=1M
```
2. Observe on the host the memory pressure is high (run some background apps to make it even higher if needed).
3. Remove the data in the VM
```bash
rm /tmp/data
```
4. Observe any change in memory pressure

With MADV_DONTNEED flag nothing changes, balloon is not working:
<img width="626" height="130" alt="Screenshot 2026-05-31 at 10 45 49" src="https://github.com/user-attachments/assets/5e81aaaf-9944-4f20-93cd-1212a23da022" />

With MADV_FREE the pressure drops right away:
<img width="631" height="128" alt="Screenshot 2026-05-31 at 10 52 53" src="https://github.com/user-attachments/assets/788742b4-27aa-4633-81b7-645b4879dcaf" />

Notably the per process memory usage in Activity Monitor still reports 8GB in both cases, however this numbers are not accurate, so the only way to test is to observe the pressure and total RAM usage.