### PR TITLE
Update build instructions for Debian/Ubuntu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ LIBRARY_DEBUG_Linux = target/debug/$(KRUN_BINARY_Linux)
 LIBRARY_RELEASE_Darwin = target/release/$(KRUN_BINARY_Darwin)
 LIBRARY_DEBUG_Darwin = target/debug/$(KRUN_BINARY_Darwin)
 
-LIBDIR_Linux = lib64
+LIBDIR_Linux = $(shell if [ -e /etc/debian_version ]; then echo 'lib/$(ARCH)-linux-gnu'; else echo lib64; fi)
 LIBDIR_Darwin = lib
 
 ifeq ($(PREFIX),)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ When TSI is enabled, the VMM acts as a proxy for AF_INET, AF_INET6 and AF_UNIX s
 * C Library static libraries, as the [init](init/init.c) binary is statically linked (package ```glibc-static``` in Fedora)
 * patchelf
 
+On Debian/Ubuntu:
+
+```sh
+apt install patchelf build-essential clang libclang-dev libc6-dev
+```
+
 #### Optional features
 
 * **GPU=1**: Enables virtio-gpu. Requires virglrenderer-devel.


### PR DESCRIPTION
And adjust the build output location to something closer to their usual output path.

See Also: https://github.com/libkrun/libkrunfw/pull/133

Assisted-by: Codex:GPT-5