### PR TITLE
virtio/balloon: add Windows support for free-page reporting

### DIFF
--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -65,5 +65,6 @@ windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_Storage_FileSystem",
     "Win32_System_Console",
+    "Win32_System_Memory",
     "Win32_System_Threading",
 ] }

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -11,6 +11,8 @@ use super::super::{
 };
 use super::{defs, defs::uapi};
 use crate::virtio::InterruptTransport;
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::System::Memory::DiscardVirtualMemory;
 
 // Inflate queue.
 pub(crate) const IFQ_INDEX: usize = 0;
@@ -97,12 +99,17 @@ impl Balloon {
                 let advice = libc::MADV_DONTNEED;
                 #[cfg(target_os = "macos")]
                 let advice = libc::MADV_FREE;
+                #[cfg(unix)]
                 unsafe {
                     libc::madvise(
                         host_addr as *mut libc::c_void,
                         desc.len.try_into().unwrap(),
                         advice,
                     )
+                };
+                #[cfg(target_os = "windows")]
+                unsafe {
+                    DiscardVirtualMemory(host_addr as *mut core::ffi::c_void, desc.len as usize)
                 };
             }
 

--- a/src/devices/src/virtio/balloon/event_handler.rs
+++ b/src/devices/src/virtio/balloon/event_handler.rs
@@ -1,4 +1,7 @@
+#[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(windows)]
+use utils::windows::AsRawFd;
 
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};


### PR DESCRIPTION
Use DiscardVirtualMemory as the Windows equivalent of madvise for releasing guest memory in the balloon free-page reporting queue. Gate the unix AsRawFd import and add the Windows shim for the event handler.