### PR TITLE
[RFC] ci: skip build and test workflows for docs-only PRs

### DIFF
--- a/.github/workflows/cross-compilation.yml
+++ b/.github/workflows/cross-compilation.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   cross-compile-macos:
+    if: ${{ !contains(github.event.pull_request.title, '[CI:docs]') }}
     name: Cross-compilation (macOS)
     runs-on: macos-latest
     env:
@@ -24,6 +25,7 @@ jobs:
         run: make BUILD_BSD_INIT=1 -- init/init-freebsd
 
   cross-compile-linux:
+    if: ${{ !contains(github.event.pull_request.title, '[CI:docs]') }}
     name: Cross-compilation (Linux x86_64 -> FreeBSD)
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +43,7 @@ jobs:
         run: make BUILD_BSD_INIT=1 -- init/init-freebsd
 
   cross-compile-linux-aarch64:
+    if: ${{ !contains(github.event.pull_request.title, '[CI:docs]') }}
     name: Cross-compilation (Linux aarch64 -> FreeBSD)
     runs-on: ubuntu-24.04-arm
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   integration-tests-x86_64:
+    if: ${{ !contains(github.event.pull_request.title, '[CI:docs]') }}
     name: Integration Tests (Linux x86_64)
     runs-on: ubuntu-latest
     steps:
@@ -92,6 +93,7 @@ jobs:
           if-no-files-found: ignore
 
   integration-tests-aarch64:
+    if: ${{ !contains(github.event.pull_request.title, '[CI:docs]') }}
     name: Integration Tests (Linux aarch64)
     runs-on: self-hosted
     steps:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 jobs:
   unit-tests-linux-x86_64:
+    if: ${{ !contains(github.event.pull_request.title, '[CI:docs]') }}
     name: Unit tests (Linux x86_64)
     runs-on: ubuntu-latest
     steps:
@@ -25,6 +26,7 @@ jobs:
         run: cargo test
 
   unit-tests-linux-aarch64:
+    if: ${{ !contains(github.event.pull_request.title, '[CI:docs]') }}
     name: Unit tests (Linux aarch64)
     runs-on: self-hosted
     steps:


### PR DESCRIPTION
Skip cross-compilation, integration tests, and unit tests when the PR title contains [CI:docs]. Formatting and code-quality checks still run.
