### PR TITLE
init: enforce static linking

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -13,6 +13,16 @@ runs:
         rustup toolchain install nightly
         rustup component add rust-src --toolchain nightly
 
+    - name: Add musl target
+      shell: bash
+      run: |
+        case $(uname -m) in
+          x86_64)  TARGET="x86_64-unknown-linux-musl"  ;;
+          aarch64|arm64) TARGET="aarch64-unknown-linux-musl" ;;
+          *)       echo "unknown arch: $(uname -m)"; exit 1 ;;
+        esac
+        rustup target add "$TARGET"
+
     - name: Cache Cargo dependencies
       uses: actions/cache@v4
       with:

--- a/src/init_blob/build.rs
+++ b/src/init_blob/build.rs
@@ -94,11 +94,9 @@ fn build_rust_init() -> PathBuf {
             (musl_rustc.to_string_lossy().into_owned(), cargo, true)
         }
         None => {
-            println!(
-                "cargo:warning=musl target not available; krun-init will be dynamically linked. \
-                 Run `rustup target add $(uname -m)-unknown-linux-musl` for a static binary."
+            panic!(
+                "musl target not available for krun-init; Run `rustup target add $(uname -m)-unknown-linux-musl` to obtain."
             );
-            (default_rustc, default_cargo, false)
         }
     };
 


### PR DESCRIPTION
change krun-init to require static linking, since dynamic targets are unreliable and inconsistent within container filesystems.

Fixes #724