### PR TITLE
[stable-1.19.x] deps: fix vm-memory version conflict when used as a Rust dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,9 +478,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "imago"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e8e4b92aa0dd860579cfba776dbf0918a3a7ac5cb601af7d3fc835e71592a5b"
+checksum = "ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c"
 dependencies = [
  "async-trait",
  "bincode",
@@ -492,7 +492,6 @@ dependencies = [
  "rustc_version",
  "tokio",
  "tracing",
- "vm-memory",
  "windows-sys",
 ]
 
@@ -786,7 +785,7 @@ dependencies = [
  "serde_json",
  "tdx",
  "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vmm-sys-util 0.15.0",
  "zstd",
 ]
 
@@ -1699,6 +1698,16 @@ name = "vmm-sys-util"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -33,7 +33,7 @@ pw = { package = "pipewire", version = "0.9.2", optional = true }
 rand = "0.9.2"
 thiserror = { version = "2.0", optional = true }
 virtio-bindings = "0.2.0"
-vm-memory = { version = "0.17", features = ["backend-mmap"] }
+vm-memory = { version = "=0.17.1", features = ["backend-mmap"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", features = ["bindgen_clang_runtime"], optional = true }
@@ -42,7 +42,7 @@ arch = { package = "krun-arch", version = "=0.1.0-1.19.0", path = "../arch" }
 utils = { package = "krun-utils", version = "=0.1.0-1.19.0", path = "../utils" }
 polly = { package = "krun-polly", version = "=0.1.0-1.19.0", path = "../polly" }
 rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-1.19.0", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
-imago = { version = "0.2.2", features = ["sync-wrappers", "vm-memory"] }
+imago = { version = "0.2.2", features = ["sync-wrappers"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { package = "krun-hvf", version = "=0.1.0-1.19.0", path = "../hvf" }

--- a/src/devices/src/virtio/file_traits.rs
+++ b/src/devices/src/virtio/file_traits.rs
@@ -8,6 +8,8 @@ use std::os::unix::io::AsRawFd;
 
 #[cfg(feature = "blk")]
 use imago::io_buffers::{IoVector, IoVectorMut};
+#[cfg(feature = "blk")]
+use std::io::{IoSlice, IoSliceMut};
 use vm_memory::VolatileSlice;
 
 use libc::{c_int, c_void, read, readv, size_t, write, writev};
@@ -427,7 +429,19 @@ impl FileReadWriteAtVolatile for DiskProperties {
             return Ok(0);
         }
 
-        let (iovec, _guard) = IoVectorMut::from_volatile_slice(bufs);
+        let guards: Vec<_> = bufs.iter().map(|s| s.ptr_guard_mut()).collect();
+        let slices: Vec<_> = guards
+            .iter()
+            .map(|g| {
+                let slice = if g.len() == 0 {
+                    &mut []
+                } else {
+                    unsafe { std::slice::from_raw_parts_mut(g.as_ptr(), g.len()) }
+                };
+                IoSliceMut::new(slice)
+            })
+            .collect();
+        let iovec = IoVectorMut::from(slices);
         let full_length = iovec
             .len()
             .try_into()
@@ -445,7 +459,19 @@ impl FileReadWriteAtVolatile for DiskProperties {
             return Ok(0);
         }
 
-        let (iovec, _guard) = IoVector::from_volatile_slice(bufs);
+        let guards: Vec<_> = bufs.iter().map(|s| s.ptr_guard()).collect();
+        let slices: Vec<_> = guards
+            .iter()
+            .map(|g| {
+                let slice = if g.len() == 0 {
+                    &[]
+                } else {
+                    unsafe { std::slice::from_raw_parts(g.as_ptr(), g.len()) }
+                };
+                IoSlice::new(slice)
+            })
+            .collect();
+        let iovec = IoVector::from(slices);
         let full_length = iovec
             .len()
             .try_into()

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"
 
 [dependencies]
-vm-memory = { version = "0.17", features = ["backend-mmap"] }
+vm-memory = { version = "=0.17.1", features = ["backend-mmap"] }
 
 utils = { package = "krun-utils", version = "=0.1.0-1.19.0", path = "../utils" }

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -7,4 +7,4 @@ license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"
 
 [dependencies]
-vm-memory = { version = "0.17", features = ["backend-mmap"] }
+vm-memory = { version = "=0.17.1", features = ["backend-mmap"] }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -27,8 +27,8 @@ libc = ">=0.2.39"
 linux-loader = { version = "0.13.2", features = ["bzimage", "elf", "pe"] }
 log = "0.4.0"
 nix = { version = "0.30.1", features = ["fs", "term"] }
-vm-memory = { version = "0.17.0", features = ["backend-mmap"] }
-vmm-sys-util = "0.14"
+vm-memory = { version = "=0.17.1", features = ["backend-mmap"] }
+vmm-sys-util = "0.15"
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", optional = true, features = ["bindgen_clang_runtime"] }
 


### PR DESCRIPTION
When libkrun is added as a Rust crate dependency, Cargo resolves two incompatible versions of vm-memory (0.17.1 and 0.18.0), causing compilation failures. The root cause is imago's wide vm-memory constraint (>=0.16, <0.19) which lets Cargo pick 0.18.0 for imago while everything else resolves to 0.17.1. Within the workspace this is hidden by Cargo.lock, but external consumers don't inherit it.

Drop imago's vm-memory feature and manually convert VolatileSlice to IoVector/IoVectorMut using ptr_guard()/ptr_guard_mut(). Pin all vm-memory dependencies to =0.17.1 to prevent version splits from newly published semver-compatible releases (e.g., 0.17.2).

Fixes: #726 