### PR TITLE
init: filter tsi_hijack tokens from kernel cmdline args

### DIFF
--- a/init/src/env.rs
+++ b/init/src/env.rs
@@ -99,8 +99,8 @@ fn setup_dhcp(iface: &str, sock: i32) {
     }
 }
 
-/// Returns true if `tsi_hijack` appears in the kernel command line before any
-/// `--` delimiter. Mirrors `tsi_enabled()` in init.c.
+/// Returns true if any `tsi_hijack` token appears in the kernel command line
+/// before the `--` delimiter.
 #[cfg(target_os = "linux")]
 pub fn tsi_enabled() -> bool {
     let Ok(cmdline) = std::fs::read_to_string("/proc/cmdline") else {
@@ -109,7 +109,7 @@ pub fn tsi_enabled() -> bool {
     cmdline
         .split_whitespace()
         .take_while(|tok| *tok != "--")
-        .any(|tok| tok == "tsi_hijack")
+        .any(|tok| tok.starts_with("tsi_hijack"))
 }
 
 /// Brings up `dummy0` and assigns it 203.0.113.1/24 (IANA TEST-NET-3) so

--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -121,7 +121,16 @@ fn main() -> anyhow::Result<()> {
     // The kernel places everything after `--` in the cmdline as this
     // process's argv[1..].  The C init built exec_argv by replacing argv[0]
     // with KRUN_INIT (or /bin/sh) and keeping argv[1..] in every branch.
-    let proc_args: Vec<String> = std::env::args().collect();
+    //
+    // The kernel also forwards unrecognised bare-word parameters from
+    // *before* `--` as init arguments.  Filter out tokens that libkrun
+    // places on the cmdline for its own use so they don't leak into the
+    // user's command.
+    let proc_args: Vec<String> = std::env::args()
+        .enumerate()
+        .filter(|(i, a)| *i == 0 || !a.starts_with("tsi_hijack"))
+        .map(|(_, a)| a)
+        .collect();
 
     let argv: Vec<String> = if let Ok(init) = std::env::var("KRUN_INIT") {
         // KRUN_INIT holds the binary; kernel cmdline args are the arguments.


### PR DESCRIPTION
The Linux kernel forwards unrecognised bare-word parameters from before the `--` delimiter as init arguments. The vmm places tsi_hijack and tsi_hijack_unix on the kernel cmdline, and these leak into the user's command as spurious arguments, causing errors like "/bin/sh: tsi_hijack_unix: No such file or directory".

Filter out tsi_hijack* tokens from the init's argv before building the exec arguments. Also update tsi_enabled() to match any tsi_hijack prefix so it recognises tsi_hijack_unix.

This issue presented itself once we no longer allowed for implicit resources to be created.