### PR TITLE
virtio/blk: add Windows support for block device

### DIFF
--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -29,6 +29,15 @@ use virtio_bindings::{
 };
 use vm_memory::{ByteValued, GuestMemoryMmap};
 
+#[cfg(target_os = "windows")]
+use std::mem::MaybeUninit;
+#[cfg(target_os = "windows")]
+use std::os::windows::io::AsRawHandle;
+#[cfg(target_os = "windows")]
+use windows_sys::Win32::Storage::FileSystem::{
+    BY_HANDLE_FILE_INFORMATION, GetFileInformationByHandle,
+};
+
 use super::worker::BlockWorker;
 use super::{
     super::{ActivateResult, DeviceQueue, DeviceState, QueueConfig, TYPE_BLOCK, VirtioDevice},
@@ -107,14 +116,32 @@ impl DiskProperties {
     }
 
     fn build_device_id(disk_file: &File) -> result::Result<String, Error> {
-        let blk_metadata = disk_file.metadata().map_err(Error::GetFileMetadata)?;
         // This is how kvmtool does it.
-        let device_id = format!(
-            "{}{}{}",
-            blk_metadata.st_dev(),
-            blk_metadata.st_rdev(),
-            blk_metadata.st_ino()
-        );
+        #[cfg(unix)]
+        let device_id = {
+            let blk_metadata = disk_file.metadata().map_err(Error::GetFileMetadata)?;
+            format!(
+                "{}{}{}",
+                blk_metadata.st_dev(),
+                blk_metadata.st_rdev(),
+                blk_metadata.st_ino()
+            )
+        };
+        #[cfg(target_os = "windows")]
+        let device_id = {
+            let mut info = MaybeUninit::<BY_HANDLE_FILE_INFORMATION>::zeroed();
+            let ret =
+                unsafe { GetFileInformationByHandle(disk_file.as_raw_handle(), info.as_mut_ptr()) };
+            if ret != 0 {
+                let info = unsafe { info.assume_init() };
+                format!(
+                    "{}{}{}",
+                    info.dwVolumeSerialNumber, info.nFileIndexHigh, info.nFileIndexLow
+                )
+            } else {
+                return Err(Error::GetFileMetadata(io::Error::last_os_error()));
+            }
+        };
         Ok(device_id)
     }
 

--- a/src/devices/src/virtio/block/worker.rs
+++ b/src/devices/src/virtio/block/worker.rs
@@ -5,11 +5,14 @@ use super::device::{CacheType, DiskProperties};
 
 use crate::virtio::InterruptTransport;
 use std::io::{self, Write};
+#[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::result;
 use std::thread;
 use utils::epoll::{ControlOperation, Epoll, EpollEvent, EventSet};
 use utils::eventfd::EventFd;
+#[cfg(target_os = "windows")]
+use utils::windows::AsRawFd;
 use virtio_bindings::virtio_blk::*;
 use vm_memory::{ByteValued, GuestMemoryMmap};
 


### PR DESCRIPTION
Port the block device to Windows by providing platform-specific implementations for disk identity and file descriptor access.

On Windows, build_device_id() uses GetFileInformationByHandle to derive a unique device identifier from volume serial number and file index, mirroring the Unix approach that combines st_dev, st_rdev, and st_ino.