### PR TITLE
virtio-fs: map host process UID/GID to root in guest on macOS (1.19.x)

### DIFF
--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -161,6 +161,16 @@ fn einval() -> io::Error {
     linux_error(io::Error::from_raw_os_error(libc::EINVAL))
 }
 
+fn host_euid() -> u32 {
+    static EUID: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *EUID.get_or_init(|| unsafe { libc::geteuid() })
+}
+
+fn host_egid() -> u32 {
+    static EGID: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
+    *EGID.get_or_init(|| unsafe { libc::getegid() })
+}
+
 fn item_to_value(item: &[u8], radix: u32) -> Option<u32> {
     match std::str::from_utf8(item) {
         Ok(val) => match u32::from_str_radix(val, radix) {
@@ -355,11 +365,21 @@ fn stat_common(
     host: bool,
 ) -> io::Result<bindings::stat64> {
     if !host {
-        if let Some(uid) = uid {
-            st.st_uid = uid;
+        match uid {
+            Some(uid) => st.st_uid = uid,
+            None => {
+                if st.st_uid == host_euid() {
+                    st.st_uid = 0;
+                }
+            }
         }
-        if let Some(gid) = gid {
-            st.st_gid = gid;
+        match gid {
+            Some(gid) => st.st_gid = gid,
+            None => {
+                if st.st_gid == host_egid() {
+                    st.st_gid = 0;
+                }
+            }
         }
         if let Some(mode) = mode {
             if mode as u16 & libc::S_IFMT == 0 {


### PR DESCRIPTION
Here I'm using a PR to 1.19.x branch as krunkit is not really booting using the main branch and I would like to have the fix available in krunkit
backport of https://github.com/libkrun/libkrun/pull/734 to a branch


When using virtiofs on macOS, pre-existing host files that lack the user.containers.override_stat xattr are returned to the guest with the raw host UID/GID (typically 501 on macOS). This causes volume-mounted directories to appear as owned by uid 501 instead of root inside the guest VM, breaking container workloads that expect root ownership.

On macOS, libkrun's virtiofs passthrough stores guest-visible ownership in an xattr (user.containers.override_stat). Files created or chowned by the guest get this xattr set, so subsequent stat() calls return the correct guest UID/GID. However, pre-existing host files never have this xattr, so stat_common() falls through and returns the raw macOS stat values — exposing the host user's UID (e.g. 501) to the guest.

Apple's Virtualization.framework (used by the applehv provider) does not exhibit this problem because it maps the host user's UID to root in the guest. This commit aligns libkrun's behavior: when no xattr override is present and the file's UID/GID matches the host process's EUID/EGID, report it as root (uid/gid 0) to the guest.

Files that already have the override_stat xattr (e.g. files created or chowned by the guest) are unaffected — the xattr values take precedence. Files owned by other users on the host retain their raw UIDs since they don't match the process EUID. The host EUID/EGID values are cached via OnceLock to avoid repeated syscalls on every stat operation.

Fixes: https://github.com/containers/podman/issues/21402