### PR TITLE
docs: add CLAUDE.md as symlink to AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
in my previous PRs some guidelines were not used as it's not read by default. I added a symlink.

Claude Code reads CLAUDE.md, not AGENTS.md. Add a symlink so the existing AGENTS.md content is picked up automatically.
