### PR TITLE
Fix CLAUDE.md context file path and clarify agent attribution format

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+@../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ Features are additive and controlled at the `libkrun` crate level. Each device f
 - Format: `<subsystem>: <title>` — e.g., `virtio/blk: add print_text() function`
 - Commits must be self-contained, compile, and pass tests independently
 - Sign all commits with `git commit -s` (DCO requirement)
-- Agent attribution format: `Assisted-by: <Agent-tool>: <model-name>` - e.g., `Assisted-by: Claude Code: sonnet-4.6`, `Assisted-by: Cursor: codex-5.3`
+- Agent attribution format: `Assisted-by: <Agent-tool>: <model-name>` - e.g., `Assisted-by: Claude Code: sonnet-4.6`, `Assisted-by: Cursor: codex-5.3`. Do not use `Co-authored-by`.
 - Commit messages should be concise and written in the imperative mood. Small, focused commits are preferred.
 
 ### Rust coding style


### PR DESCRIPTION
  ## Summary
  - Fix the `@AGENTS.md` import in `.claude/CLAUDE.md` to use the correct
    relative path (`@../AGENTS.md`), since imports are resolved relative to the
    file containing the import, not the working directory.
  - Explicitly state in `AGENTS.md` that `Co-authored-by` should not be used for
    agent attribution — only the `Assisted-by:` trailer format.