### PR TITLE
virtio/console: fix TX data loss race on shutdown

### DIFF
--- a/src/devices/src/virtio/console/process_tx.rs
+++ b/src/devices/src/virtio/console/process_tx.rs
@@ -64,17 +64,36 @@ fn pop_head_blocking<'mem>(
     stop: &AtomicBool,
 ) -> Option<DescriptorChain<'mem>> {
     loop {
-        match queue.pop(mem) {
-            Some(descriptor) => break Some(descriptor),
-            None => {
-                interrupt.signal_used_queue();
-                if stop.load(Ordering::Acquire) {
-                    break None;
-                }
-                thread::park();
-                log::trace!("tx unparked, queue len {}", queue.len(mem))
-            }
+        // Suppress guest notifications while draining to avoid a TOCTOU race:
+        // without suppression, the guest could add a descriptor and send a
+        // notification between queue.pop() returning None and thread::park(),
+        // and the notification would be lost if the TX thread is stopping.
+        queue.disable_notification(mem).unwrap_or_default();
+
+        // Pop one descriptor if available.
+        if let Some(descriptor) = queue.pop(mem) {
+            return Some(descriptor);
         }
+
+        // Re-enable notifications. enable_notification re-reads avail_idx with
+        // a SeqCst fence; if new entries arrived while we had notifications
+        // suppressed, it returns Ok(true) and we must drain again.  On Err,
+        // treat conservatively as if new entries may have arrived (notifications
+        // may not be fully armed), so also retry the drain.
+        if !matches!(queue.enable_notification(mem), Ok(false)) {
+            continue;
+        }
+
+        // Queue is confirmed empty and notifications are armed.  Check stop
+        // only after the drain+fence: if stop was set while the guest was
+        // writing its final bytes, we still flush them before returning None.
+        if stop.load(Ordering::Acquire) {
+            return None;
+        }
+
+        interrupt.signal_used_queue();
+        thread::park();
+        log::trace!("tx unparked, queue len {}", queue.len(mem));
     }
 }
 


### PR DESCRIPTION
The 'Integration Tests (Linux x86_64)' CI job has been failing on all recent PRs.  The most basic test, configure-vm-2cpu-1GiB, produces an empty stdout.txt despite the VM booting cleanly and the guest-agent running successfully.  The diagnostic log shows:

  TRACE process_tx] tx unparked, queue len 0
  INFO  krun_vmm] Vmm is stopping.

The TX thread woke up, saw an empty queue, and exited — losing the guest's final println!("OK") output.

Root cause: race in pop_head_blocking
--------------------------------------

The TX thread parks via thread::park() when the queue is empty and is woken either by notify_tx() (from the event-manager thread, which fires when the guest writes the virtio queue notification eventfd) or by port::shutdown() (which sets stop=true then calls unpark()).

The old code:
```rust
  loop {
      match queue.pop(mem) {
          Some(d) => break Some(d),
          None => {
              interrupt.signal_used_queue();
              if stop.load(Acquire) { break None; }   // exits here
              thread::park();
          }
      }
  }
```

The race window:

  TX thread               Shutdown thread         Event-manager thread
  ─────────────────────────────────────────────────────
  queue.pop() -> None
  interrupt.signal_used_queue()
  stop.load() -> false    stop.store(true)
  thread::park()          tx_thread.unpark()
  <- wakes
  queue.pop() -> None     (guest wrote "OK\n"; notification in flight)
  stop.load() -> true
  break None <- EXITS                             notify_tx() -> unpark()
                                                  [TX thread already gone]

The guest's final bytes are in the virtio avail ring when the TX thread exits.  The event-manager's notify_tx() arrives after termination.  The stdout.txt file is empty; check() returns TestOutcome::Fail.

Why only x86_64?
-----------------

The aarch64 self-hosted runner sets KRUN_NO_UNSHARE=1, skipping the buildah-unshare + network-namespace wrapper.  Without that wrapper the per-test process lifetime is different (longer VM teardown path), making the race window substantially narrower.  It does not surface in practice on aarch64.

Fix: drain the queue with the disable/enable_notification fence ---------------------------------------------------------------

The correct pattern — already used by the block and net device workers (block/worker.rs, net/worker.rs) — is to suppress guest notifications while draining, then call enable_notification() which does a SeqCst fence and re-reads avail_idx.  If new entries arrived while notifications were suppressed, enable_notification returns true and we drain again.  Only after the fence confirms the queue is empty do we check stop.  If stop is true at that point, no bytes remain unprocessed and we can return None safely.

The stop check is deliberately placed after the drain+fence: if stop was set while the guest was writing its last bytes, we flush them before exiting.


Assisted-by: Claude Code: claude-sonnet-4-6