### PR TITLE
virtio/gpu: complete macOS blob mapping (populate map_ptr, allow export-less blobs)

### DIFF
--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -905,11 +905,6 @@ impl VirtioGpu {
         let map_ptr = self.rutabaga.map_ptr(resource_id).map_err(|_| ErrUnspec)?;
 
         if let Ok(export) = self.rutabaga.export_blob(resource_id) {
-            debug!(
-                "resource_map_blob: export handle_type={} map_ptr={:x}",
-                export.handle_type, map_ptr
-            );
-
             if export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_APPLE
                 || export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_SHM
             {

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -905,7 +905,14 @@ impl VirtioGpu {
         let map_ptr = self.rutabaga.map_ptr(resource_id).map_err(|_| ErrUnspec)?;
 
         if let Ok(export) = self.rutabaga.export_blob(resource_id) {
-            if export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_APPLE {
+            debug!(
+                "resource_map_blob: export handle_type={} map_ptr={:x}",
+                export.handle_type, map_ptr
+            );
+
+            if export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_APPLE
+                || export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_SHM
+            {
                 if offset + resource.size > shm_region.size as u64 {
                     error!("mapping DOES NOT FIT");
                     return Err(ErrUnspec);

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -20,6 +20,8 @@ use krun_display::{
 use libc::c_void;
 #[cfg(target_os = "macos")]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_APPLE;
+#[cfg(target_os = "macos")]
+use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_SHM;
 #[cfg(all(feature = "virgl_resource_map2", target_os = "linux"))]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_DMABUF;
 #[cfg(all(not(feature = "virgl_resource_map2"), target_os = "linux"))]
@@ -901,40 +903,60 @@ impl VirtioGpu {
             .get_mut(&resource_id)
             .ok_or(ErrInvalidResourceId)?;
 
-        let map_info = self.rutabaga.map_info(resource_id).map_err(|_| ErrUnspec)?;
-        let map_ptr = self.rutabaga.map_ptr(resource_id).map_err(|_| ErrUnspec)?;
+        let map_info = self.rutabaga.map_info(resource_id).map_err(|e| {
+            error!("resource_map_blob: map_info failed for resource {resource_id}: {e:?}");
+            ErrUnspec
+        })?;
+        let map_ptr = self.rutabaga.map_ptr(resource_id).map_err(|e| {
+            error!("resource_map_blob: map_ptr failed for resource {resource_id}: {e:?}");
+            ErrUnspec
+        })?;
 
-        if let Ok(export) = self.rutabaga.export_blob(resource_id) {
-            if export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_APPLE
-                || export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_SHM
+        // The mapping below only consumes the host pointer (map_ptr) plus the
+        // hypervisor aliasing into the guest shm window; the export handle is
+        // never used. Blobs backed by memory with no exportable descriptor
+        // (e.g. host-visible VkDeviceMemory under MoltenVK) still have a valid
+        // map_ptr, so a failed export must not veto the mapping; only a handle
+        // of a genuinely unsupported type does.
+        match self.rutabaga.export_blob(resource_id) {
+            Ok(export)
+                if export.handle_type != RUTABAGA_MEM_HANDLE_TYPE_APPLE
+                    && export.handle_type != RUTABAGA_MEM_HANDLE_TYPE_SHM =>
             {
-                if offset + resource.size > shm_region.size as u64 {
-                    error!("mapping DOES NOT FIT");
-                    return Err(ErrUnspec);
-                }
-
-                let guest_addr = shm_region.guest_addr + offset;
-                debug!(
-                    "mapping: map_ptr={:x}, guest_addr={:x}, size={}",
-                    map_ptr, guest_addr, resource.size
+                error!(
+                    "resource_map_blob: unsupported export handle_type={} for resource {}",
+                    export.handle_type, resource_id
                 );
-
-                let (reply_sender, reply_receiver) = unbounded();
-                self.map_sender
-                    .send(WorkerMessage::GpuAddMapping(
-                        reply_sender,
-                        map_ptr,
-                        guest_addr,
-                        resource.size,
-                    ))
-                    .unwrap();
-                if !reply_receiver.recv().unwrap() {
-                    return Err(ErrUnspec);
-                }
-            } else {
                 return Err(ErrUnspec);
             }
-        } else {
+            _ => {}
+        }
+
+        if offset + resource.size > shm_region.size as u64 {
+            error!("mapping DOES NOT FIT");
+            return Err(ErrUnspec);
+        }
+
+        let guest_addr = shm_region.guest_addr + offset;
+        debug!(
+            "mapping: map_ptr={:x}, guest_addr={:x}, size={}",
+            map_ptr, guest_addr, resource.size
+        );
+
+        let (reply_sender, reply_receiver) = unbounded();
+        self.map_sender
+            .send(WorkerMessage::GpuAddMapping(
+                reply_sender,
+                map_ptr,
+                guest_addr,
+                resource.size,
+            ))
+            .unwrap();
+        if !reply_receiver.recv().unwrap() {
+            error!(
+                "resource_map_blob: hypervisor mapping failed for resource {} (ptr={:x} size={})",
+                resource_id, map_ptr, resource.size
+            );
             return Err(ErrUnspec);
         }
 

--- a/src/rutabaga_gfx/src/gfxstream.rs
+++ b/src/rutabaga_gfx/src/gfxstream.rs
@@ -28,6 +28,8 @@ use crate::renderer_utils::*;
 use crate::rutabaga_core::RutabagaComponent;
 use crate::rutabaga_core::RutabagaContext;
 use crate::rutabaga_core::RutabagaResource;
+#[cfg(target_os = "macos")]
+use crate::rutabaga_os::AsRawDescriptor;
 use crate::rutabaga_os::FromRawDescriptor;
 use crate::rutabaga_os::IntoRawDescriptor;
 use crate::rutabaga_os::RawDescriptor;
@@ -91,7 +93,7 @@ pub type stream_renderer_fence = RutabagaFence;
 #[allow(non_camel_case_types)]
 pub type stream_renderer_debug = RutabagaDebug;
 
-extern "C" {
+unsafe extern "C" {
     // Entry point for the stream renderer.
     fn stream_renderer_init(
         stream_renderer_params: *mut stream_renderer_param,
@@ -457,6 +459,8 @@ impl RutabagaComponent for Gfxstream {
             blob_mem: 0,
             blob_flags: 0,
             map_info: None,
+            #[cfg(target_os = "macos")]
+            map_ptr: None,
             info_2d: None,
             info_3d: None,
             vulkan_info: None,
@@ -630,13 +634,68 @@ impl RutabagaComponent for Gfxstream {
 
         ret_to_res(ret)?;
 
+        // NOTE: `export_blob()` goes through gfxstream's `releaseHandle()`,
+        // which is a one-shot `std::exchange(mFd, invalid)` on the host side;
+        // calling it twice would hand back an invalid descriptor on the second
+        // call. Compute the handle once and derive `map_ptr` from it below so
+        // the same descriptor backs both fields.
+        let handle = self.export_blob(resource_id).ok();
+
+        // The macOS mapping path (RESOURCE_MAP_BLOB -> hypervisor mapping)
+        // needs a host pointer for the resource, matching what the
+        // virglrenderer component provides via
+        // virgl_renderer_resource_get_map_ptr():
+        //  - SHM-backed blobs: map the exported descriptor.
+        //  - blobs without an exportable descriptor (e.g. host-visible
+        //    VkDeviceMemory, which MoltenVK cannot export): fall back to
+        //    gfxstream's own mapping, a vkMapMemory wrapper it keeps alive
+        //    for the resource's lifetime.
+        // Blobs that support neither stay unmapped (None), as before.
+        #[cfg(target_os = "macos")]
+        let map_ptr = {
+            let shm_ptr = handle.as_ref().and_then(|h| {
+                if h.handle_type == RUTABAGA_MEM_HANDLE_TYPE_SHM {
+                    let addr = unsafe {
+                        libc::mmap(
+                            null_mut(),
+                            resource_create_blob.size as usize,
+                            libc::PROT_READ | libc::PROT_WRITE,
+                            libc::MAP_SHARED,
+                            h.os_handle.as_raw_descriptor(),
+                            0,
+                        )
+                    };
+                    if addr == libc::MAP_FAILED {
+                        None
+                    } else {
+                        Some(addr as u64)
+                    }
+                } else {
+                    None
+                }
+            });
+            shm_ptr.or_else(|| {
+                let mut map: *mut c_void = null_mut();
+                let mut size: u64 = 0;
+                let ret =
+                    unsafe { stream_renderer_resource_map(resource_id, &mut map, &mut size) };
+                if ret == 0 && !map.is_null() {
+                    Some(map as u64)
+                } else {
+                    None
+                }
+            })
+        };
+
         Ok(RutabagaResource {
             resource_id,
-            handle: self.export_blob(resource_id).ok(),
+            handle,
             blob: true,
             blob_mem: resource_create_blob.blob_mem,
             blob_flags: resource_create_blob.blob_flags,
             map_info: self.map_info(resource_id).ok(),
+            #[cfg(target_os = "macos")]
+            map_ptr,
             info_2d: None,
             info_3d: None,
             vulkan_info: self.vulkan_info(resource_id).ok(),


### PR DESCRIPTION
## Summary
- Populate `RutabagaResource::map_ptr` for gfxstream blob resources, which the macOS `resource_map_blob` path requires to install a hypervisor mapping (SHM exports via `mmap`; host-visible blobs with no exportable descriptor via gfxstream's own `stream_renderer_resource_map`).
- Don't require a successful blob export to install the mapping: the export handle was only inspected as a validity gate and is never used by the mapping itself, so host-visible `VkDeviceMemory` (which MoltenVK can't export) can still be mapped via its `map_ptr`.
- Accept the `SHM` handle type in addition to `APPLE`, and log a reason on every failure path instead of a bare `ERR_UNSPEC`.

## Why
On macOS, gfxstream returns SHM-backed and host-visible blob exports. Upstream `resource_map_blob` now maps via `rutabaga.map_ptr()`, but the gfxstream component never set it, so every `RESOURCE_MAP_BLOB` failed with "no map ptr available". This completes the path so blob-backed GPU resources actually map during initialization. Companion to google/gfxstream#151 (the host-renderer side); together they build and run gfxstream as the virtio-gpu backend on Apple Silicon.

## Validation
- `krun-rutabaga-gfx --features gfxstream` builds; `krun-devices --features gpu` type-checks on macOS/AArch64.
- This is the distilled, upstream form of the mapping code we run to reach Android `boot_completed` and drive four concurrent virtual displays under load on macOS/HVF.