### PR TITLE
ci: trust libkrun/krun tap before installing formulae on macOS

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -26,7 +26,7 @@ runs:
     - name: Install packages (macOS)
       if: runner.os == 'macOS'
       shell: bash
-      run: brew tap slp/krun && brew install virglrenderer clang-format llvm
+      run: brew tap libkrun/krun && brew trust libkrun/krun && brew install virglrenderer clang-format llvm
 
     - name: Install packages (Linux)
       if: runner.os == 'Linux'


### PR DESCRIPTION
Homebrew now refuses to install formulae from third-party taps that haven't been explicitly trusted, breaking all macOS CI jobs.

Assisted-by: Claude Code:claude-opus-4-6

(cherry picked from commit ca70dad1a4fba8717dc556601efde7812cdf4d85)