### PR TITLE
 macOS: fix musl cross-linking and remove stale Linux sysroot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ make install
 make PREFIX=$HOME/.local install
 ```
 
-The Makefile exports `CC_LINUX` for Rust build scripts that compile C code targeting Linux. On macOS it auto-downloads a Debian sysroot; on Linux it uses the host toolchain.
+On macOS the Makefile exports `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER` and `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS` to configure clang+lld as the cross-linker for musl targets.
 
 ## Lint and format
 
@@ -91,11 +91,11 @@ The workspace (`Cargo.toml`) contains these crates under `src/`:
    - Loads the kernel via **kernel**
    - Instantiates virtio devices from **devices**
    - Starts vCPU threads (KVM ioctls on Linux, HVF on macOS)
-   - The guest boots, the C init binary runs as PID 1, reads `.krun_config.json` from the virtiofs overlay, and execs the workload
+   - The guest boots, the init binary runs as PID 1, reads `.krun_config.json` from the virtiofs overlay, and execs the workload
 
-### The init binary (`init/init.c`)
+### The init binary (`init/`)
 
-The guest PID-1 is a statically-linked C binary (`init/init.c`) compiled by `src/devices/build.rs` via `CC_LINUX`. The compiled binary path is set in the `KRUN_INIT_BINARY_PATH` env var at build time and embedded into the devices crate via `include_bytes!`. The passthrough fs backend exposes it as a virtual read-only file named `init.krun` (inode defined in `src/devices/src/virtio/fs/linux/passthrough.rs`) — the real host filesystem never sees it.
+The guest PID-1 is a statically-linked Rust binary (`init/src/main.rs`). It is built by `src/init_blob/build.rs` as a separate cargo invocation targeting musl. The compiled binary is embedded into the `init_blob` crate via `include_bytes!` and exposed by the passthrough fs backend as a virtual read-only file named `init.krun`.
 
 AWS Nitro uses a separate C init (`init/aws-nitro/`) built by the Makefile when `AWS_NITRO=1`.
 

--- a/Makefile
+++ b/Makefile
@@ -107,28 +107,15 @@ all: $(LIBRARY_RELEASE_$(OS)) libkrun.pc
 debug: $(LIBRARY_DEBUG_$(OS)) libkrun.pc
 
 ifeq ($(OS),Darwin)
-# If SYSROOT_LINUX is not set and we're on macOS, generate sysroot automatically
-ifeq ($(SYSROOT_LINUX),)
-    SYSROOT_LINUX = $(ROOTFS_DIR)
-    SYSROOT_TARGET = $(ROOTFS_DIR)/.sysroot_ready
+    # Cross-linker for musl targets on macOS (brew install llvm for lld).
+    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER = $(CLANG)
+    export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = \
+        -C link-arg=-target -C link-arg=aarch64-linux-gnu \
+        -C link-arg=-fuse-ld=lld -C link-arg=-Wl,-strip-debug
+    SYSROOT_TARGET =
 else
     SYSROOT_TARGET =
 endif
-    # The GCC runtime dir (e.g. usr/lib/gcc/aarch64-linux-gnu/12) holds crtbeginT.o,
-    # crtend.o, libgcc.a and libgcc_eh.a. Apple clang does not search it
-    # automatically, so we pass it via -B (startup files) and -L (libraries).
-    GCC_TRIPLET = $(subst arm64,aarch64,$(ARCH))-linux-gnu
-    GCC_LIB_DIR = $(abspath $(SYSROOT_LINUX))/usr/lib/gcc/$(GCC_TRIPLET)/$(GCC_VERSION)
-    # Cross-compile on macOS with the LLVM linker (brew install lld)
-    CC_LINUX=$(CLANG) -target $(GCC_TRIPLET) -fuse-ld=lld -Wl,-strip-debug --sysroot $(abspath $(SYSROOT_LINUX)) -B$(GCC_LIB_DIR) -L$(GCC_LIB_DIR) -Wno-c23-extensions
-else
-    # Build on Linux host
-    CC_LINUX=$(CC)
-    SYSROOT_TARGET =
-endif
-
-# Make the variable available to Rust build scripts.
-export CC_LINUX
 
 AWS_NITRO_INIT_BINARY= init/aws-nitro/init
 $(AWS_NITRO_INIT_BINARY): $(AWS_NITRO_INIT_SRC)

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,6 @@ CLANG = /usr/bin/clang
 
 OS = $(shell uname -s)
 ARCH = $(shell uname -m)
-DEBIAN_DIST ?= bookworm
-ROOTFS_DIR = linux-sysroot
-GCC_VERSION ?= 12
 FREEBSD_VERSION ?= 14.3-RELEASE
 FREEBSD_ROOTFS_DIR = freebsd-sysroot
 
@@ -112,9 +109,6 @@ ifeq ($(OS),Darwin)
     export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS = \
         -C link-arg=-target -C link-arg=aarch64-linux-gnu \
         -C link-arg=-fuse-ld=lld -C link-arg=-Wl,-strip-debug
-    SYSROOT_TARGET =
-else
-    SYSROOT_TARGET =
 endif
 
 AWS_NITRO_INIT_BINARY= init/aws-nitro/init
@@ -172,34 +166,6 @@ $(INIT_BINARY_BSD): $(shell find init/src -name '*.rs') init/Cargo.toml $(SYSROO
 	cp target/$(FREEBSD_RUST_TARGET)/release/krun-init $@
 endif
 
-# Sysroot preparation rules for cross-compilation on macOS
-DEBIAN_PACKAGES = libc6 libc6-dev libgcc-$(GCC_VERSION)-dev linux-libc-dev
-ROOTFS_TMP = $(ROOTFS_DIR)/.tmp
-PACKAGES_FILE = $(ROOTFS_TMP)/Packages.xz
-
-.INTERMEDIATE: $(PACKAGES_FILE)
-
-$(ROOTFS_DIR)/.sysroot_ready: $(PACKAGES_FILE)
-	@echo "Extracting Debian packages to $(ROOTFS_DIR)..."
-	@for pkg in $(DEBIAN_PACKAGES); do \
-		DEB_PATH=$$(xzcat $(PACKAGES_FILE) | sed '1,/Package: '$$pkg'$$/d' | grep Filename: | sed 's/^Filename: //' | head -n1); \
-		DEB_URL="https://deb.debian.org/debian/$$DEB_PATH"; \
-		DEB_NAME=$$(basename "$$DEB_PATH"); \
-		if [ ! -f "$(ROOTFS_TMP)/$$DEB_NAME" ]; then \
-			echo "Downloading $$DEB_URL"; \
-			curl -fL -o "$(ROOTFS_TMP)/$$DEB_NAME" "$$DEB_URL"; \
-		fi; \
-		cd $(ROOTFS_TMP) && ar x "$$DEB_NAME" && cd ../..; \
-		tar xf $(ROOTFS_TMP)/data.tar.* -C $(ROOTFS_DIR); \
-		rm -f $(ROOTFS_TMP)/*.deb $(ROOTFS_TMP)/data.tar.* $(ROOTFS_TMP)/control.tar.* $(ROOTFS_TMP)/debian-binary; \
-	done
-	@touch $@
-
-$(PACKAGES_FILE):
-	@echo "Downloading Debian package index for $(DEBIAN_DIST)/$(ARCH)..."
-	@mkdir -p $(ROOTFS_TMP)
-	@curl -fL -o $@ https://deb.debian.org/debian/dists/$(DEBIAN_DIST)/main/binary-$(ARCH)/Packages.xz
-
 # FreeBSD sysroot preparation rules for cross-compilation on macOS
 FREEBSD_BASE_TXZ = $(FREEBSD_ROOTFS_DIR)/base.txz
 
@@ -218,11 +184,10 @@ $(FREEBSD_BASE_TXZ):
 	@curl -fL -o $@ https://download.freebsd.org/releases/$(BSD_ARCH)/$(FREEBSD_VERSION)/base.txz
 
 clean-sysroot:
-	rm -rf $(ROOTFS_DIR)
 	rm -rf $(FREEBSD_ROOTFS_DIR)
 
 
-$(LIBRARY_RELEASE_$(OS)): $(SYSROOT_TARGET) $(INIT_BINARY_BSD)
+$(LIBRARY_RELEASE_$(OS)): $(INIT_BINARY_BSD)
 	cargo build --release $(FEATURE_FLAGS)
 ifeq ($(SEV),1)
 	mv target/release/libkrun.so target/release/$(KRUN_BASE_$(OS))
@@ -238,7 +203,7 @@ ifeq ($(OS),Darwin)
 endif
 	cp target/release/$(KRUN_BASE_$(OS)) $(LIBRARY_RELEASE_$(OS))
 
-$(LIBRARY_DEBUG_$(OS)): $(SYSROOT_TARGET) $(INIT_BINARY_BSD)
+$(LIBRARY_DEBUG_$(OS)): $(INIT_BINARY_BSD)
 	cargo build $(FEATURE_FLAGS)
 ifeq ($(SEV),1)
 	mv target/debug/libkrun.so target/debug/$(KRUN_BASE_$(OS))

--- a/src/init_blob/build.rs
+++ b/src/init_blob/build.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 fn musl_target_for_host() -> &'static str {
-    let host = env::var("HOST").unwrap_or_default();
+    let host = env::var("TARGET").unwrap_or_default();
     if host.starts_with("aarch64") {
         "aarch64-unknown-linux-musl"
     } else {

--- a/src/init_blob/build.rs
+++ b/src/init_blob/build.rs
@@ -116,6 +116,13 @@ fn build_rust_init() -> PathBuf {
 
     if use_musl {
         cmd.arg("--target").arg(musl_target);
+
+        // The parent cargo sets CARGO_ENCODED_RUSTFLAGS="" for build scripts.
+        // The child cargo we spawn inherits it, and since that env var has
+        // higher precedence than CARGO_TARGET_*_RUSTFLAGS, the cross-linker
+        // flags from the Makefile would be silently ignored. Remove it so
+        // the per-target env vars take effect.
+        cmd.env_remove("CARGO_ENCODED_RUSTFLAGS");
     }
 
     let mut features: Vec<&str> = Vec::new();

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -39,8 +39,6 @@ if [ "$OS" = "Darwin" ]; then
 		exit 1
 	fi
 
-	export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER="clang"
-	export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_RUSTFLAGS="-C link-arg=-target -C link-arg=aarch64-linux-gnu -C link-arg=-fuse-ld=lld -C link-arg=--sysroot=$SYSROOT -C link-arg=-static"
 	echo "Cross-compiling guest-agent for $GUEST_TARGET"
 
 	# e2fsprogs is keg-only on macOS; add it to PATH for mke2fs.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -32,13 +32,6 @@ fi
 
 # On macOS, we need to cross-compile for Linux musl
 if [ "$OS" = "Darwin" ]; then
-	SYSROOT="../linux-sysroot"
-	if [ ! -d "$SYSROOT" ]; then
-		echo "ERROR: Linux sysroot not found at $SYSROOT"
-		echo "Run 'make' in the libkrun root directory first to create it."
-		exit 1
-	fi
-
 	echo "Cross-compiling guest-agent for $GUEST_TARGET"
 
 	# e2fsprogs is keg-only on macOS; add it to PATH for mke2fs.


### PR DESCRIPTION
On macOS, building the init binary for aarch64-unknown-linux-musl failed because no cross-linker was configured — the Apple system linker doesn't understand GNU ld flags emitted by rustc for musl targets.

This PR configures the env vars in the Makefile instead and uses it for both guest-agent in tests and init.