### PR TITLE
ci: include runner image in cache keys

### DIFF
--- a/.github/actions/setup-build-env/action.yml
+++ b/.github/actions/setup-build-env/action.yml
@@ -20,7 +20,7 @@ runs:
           ~/.cargo/registry
           ~/.cargo/git
           target
-        key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ env.ImageOS }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
     - name: Set up Homebrew (macOS)
       if: runner.os == 'macOS'


### PR DESCRIPTION
The cargo cache key only used runner.os and runner.arch, which don't distinguish between Ubuntu versions (e.g. 24.04 vs 26.04). When switching runner images, stale cached build artifacts (like bindgen's libclang linker flags) would reference libraries from the old image that no longer exist on the new one, causing link failures like 'cannot find -lclang-18.1.3'.

Add env.ImageOS to the cargo cache key so each runner image gets its own cache namespace.

Assisted-by: OpenCode:claude-opus-4.6