### PR TITLE
init: tolerate closed stdio when the console is not yet ready

### DIFF
--- a/init/src/main.rs
+++ b/init/src/main.rs
@@ -10,6 +10,50 @@ mod fs;
 #[cfg(feature = "timesync")]
 mod timesync;
 
+/// Ensure init has open stdin/stdout/stderr.
+///
+/// The kernel hands init closed fds 0/1/2 when the console (hvc0) is not yet
+/// registered as it execs init, and Rust std's sanitize_standard_fds() aborts on
+/// that before main() runs. Open them first (the console, else /dev/null);
+/// setup_redirects() rewires them to the krun ports later.
+#[cfg(target_os = "linux")]
+extern "C" fn ensure_stdio() {
+    use nix::fcntl::{self, OFlag};
+    use nix::mount::{self, MsFlags};
+    use nix::sys::stat::Mode;
+    use nix::unistd;
+    use std::os::fd::AsRawFd;
+
+    if unsafe { libc::fcntl(libc::STDIN_FILENO, libc::F_GETFD) } >= 0 {
+        return;
+    }
+    let _ = std::fs::create_dir_all("/dev");
+    let _ = mount::mount(
+        Some("devtmpfs"),
+        "/dev",
+        Some("devtmpfs"),
+        MsFlags::empty(),
+        None::<&str>,
+    );
+
+    let Ok(fd) = fcntl::open(c"/dev/console", OFlag::O_RDWR, Mode::empty())
+        .or_else(|_| fcntl::open(c"/dev/null", OFlag::O_RDWR, Mode::empty()))
+    else {
+        return;
+    };
+    let _ = unistd::dup2_stdin(&fd);
+    let _ = unistd::dup2_stdout(&fd);
+    let _ = unistd::dup2_stderr(&fd);
+    if fd.as_raw_fd() <= libc::STDERR_FILENO {
+        // fd is a stdio slot that dup2 just wrote to — don't close it.
+        std::mem::forget(fd);
+    }
+}
+#[cfg(target_os = "linux")]
+#[used]
+#[unsafe(link_section = ".init_array")]
+static ENSURE_STDIO_CTOR: extern "C" fn() = ensure_stdio;
+
 fn main() -> anyhow::Result<()> {
     #[cfg(target_os = "freebsd")]
     freebsd::open_console();


### PR DESCRIPTION
Disclaimer: I'm out of my depth here and had Claude Code do most of the research and experimentation. After I saw the CI failing yesterday on my PR (https://github.com/libkrun/libkrun/pull/741) I wanted to understand why it was flaky and since I was able to reproduce the flakiness locally, had Claude Code trace it and it came to a different conclusion than (https://github.com/libkrun/libkrun/pull/739). With this change the flakiness is gone. But as I said, I'm out of my depth here and cannot assess whether this is the right fix or AI slop, so feel free to close.

---

The kernel's handoff of stdin/stdout/stderr to PID 1 is best-effort: if hvc0 is not registered when the kernel execs init, init inherits closed fds 0/1/2 ("unable to open an initial console" in the kernel log). Rust std's sanitize_standard_fds() then runs before main(), cannot backfill /dev/null (devtmpfs is unmounted), and aborts -- rebooting before the workload runs.

This is the flaky configure-vm-2cpu-1GiB failure (empty output): boot timing intermittently delays hvc0 (gated on the secondary vCPU) past the kernel's initial-console-open. KRUN_ENOMEM_WORKAROUND widens the window; the race is latent without it.

A C init tolerates closed stdio. Restore that with an .init_array constructor that reopens 0/1/2 (console, else /dev/null) before the runtime check; setup_redirects() rewires them to the krun ports as before.

Based on: https://github.com/libkrun/libkrun/blob/89aaaa828f447688f8832e985aa8d134ace3d0ef/init/src/freebsd.rs#L58-L89

<details>
<summary>Here's a condensed summary of how we got here</summary>

- Ran configure-vm-2cpu-1GiB in a loop with KRUN_ENOMEM_WORKAROUND on; the empty-output failure recurred. A clean checkout of the unmodified base, and other PRs, flaked the same way — so it predates our change.
- Instrumented the guest's stdout console port: its transmit ring was empty at shutdown, and adding PR #739's drain fix changed nothing — the guest emits no output, so nothing is lost host-side.
- Traced init with durable progress markers (written through a virtiofs ioctl): execution does not reach main. A verbose kernel log showed a general-protection fault at a fixed code offset; disassembly placed that offset at the hlt inside musl's abort() — a raw abort (the panic hook does not run) during Rust's runtime startup, after the .init_array constructors.
- Stack-walked from the abort to its caller: Rust std's sanitize_standard_fds(), which opens /dev/null for each closed standard descriptor and aborts when that open fails.
- Probed init's standard descriptors with fcntl(F_GETFD) at the first constructor: closed (EBADF) on failing boots, open on passing ones. A direct /dev/kmsg read showed "unable to open an initial console", with hvc0 registering just after — the console loses the race to the kernel's initial-console step, so init inherits closed stdio and sanitize cannot backfill /dev/null (devtmpfs not yet mounted).
- Throttled KVM_RUN to find the trigger: toggling the workaround's per-vmexit sleep switched the failure on and off (on non-#314 kernels); throttling only the secondary vCPU reproduced it, the boot vCPU did not; a busy-spin matched the sleep, so the delay is the cause, not the syscall; a vCPU-by-RAM matrix tied it to vCPU count, not memory; a delay sweep showed a bounded window, not "slower is worse".
- Tested and dropped competing causes: a pre-reboot flush delay did nothing; waiting on console-port readiness did nothing; the #314 guest ENOMEM bug left no ENOMEM in the ring buffer and the host/CI kernels sit outside its range; a Rust panic was excluded by the silent hook; clock distortion by the monotonic guest clock at the abort.
- Validated the fix (an .init_array constructor reopening 0/1/2 before the runtime check): the deterministic case flipped to passing and held across vCPU counts, delay magnitudes, and the wider suite with no happy-path regression; a kernel-log probe confirmed init still receives closed stdio and tolerates it, leaving boot timing unchanged.

</details>