### PR TITLE
vmm/snapshot: snapshot/restore seam skeleton (M0, WIP)

### DIFF
--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -21,6 +21,8 @@ pub mod resources;
 /// Signal handling utilities.
 #[cfg(target_os = "linux")]
 pub mod signal_handler;
+/// VM snapshot/restore seam (M0 skeleton).
+pub mod snapshot;
 /// Wrappers over structures used to configure the VMM.
 pub mod vmm_config;
 

--- a/src/vmm/src/snapshot/mod.rs
+++ b/src/vmm/src/snapshot/mod.rs
@@ -1,0 +1,89 @@
+//! VM snapshot/restore seam (M0 skeleton).
+//!
+//! This module defines the *shared* types every backend fills in. The whole
+//! point of the seam is that nothing here names a hypervisor: KVM and HVF both
+//! produce the same [`VcpuState`], the same opaque device/GIC blobs, and the
+//! same on-disk layout. See the M0 design note for the rationale.
+//!
+//! ponytail: skeleton only. Capture/restore bodies land in M1 (`todo!()` here).
+
+use std::io::Write;
+use std::path::Path;
+
+use vm_memory::GuestMemoryMmap;
+
+/// Failure modes for save/restore. Maps to negative errno at the C API edge.
+#[derive(Debug)]
+pub enum SnapErr {
+    /// Underlying I/O on the snapshot files.
+    Io(std::io::Error),
+    /// `manifest`/`vmstate` version the loader cannot handle. Never half-loads.
+    Version { expected: u32, found: u32 },
+    /// A device or vCPU rejected the state it was handed.
+    State(String),
+}
+
+impl From<std::io::Error> for SnapErr {
+    fn from(e: std::io::Error) -> Self {
+        SnapErr::Io(e)
+    }
+}
+
+/// Opaque, independently-versioned per-device state. The device owns the byte
+/// layout; the orchestrator only length-prefixes and version-checks it.
+pub struct DeviceState {
+    pub version: u8,
+    pub bytes: Vec<u8>,
+}
+
+/// Per-vCPU register file — **arch-keyed, hypervisor-neutral**. KVM and HVF map
+/// their own ioctls/hypercalls onto the same variant. No backend name appears.
+pub enum VcpuState {
+    #[cfg(target_arch = "aarch64")]
+    Aarch64(Box<Aarch64VcpuState>),
+    // x86_64 variant lands with the KVM backend series.
+}
+
+/// aarch64 capture set (mirrors the registers a true PC-resume needs).
+#[cfg(target_arch = "aarch64")]
+pub struct Aarch64VcpuState {
+    /// X0..X30, PC, CPSR.
+    pub gp: [u64; 33],
+    /// (sys_reg id, value) — incl. pointer-auth keys, or `autiasp` faults on resume.
+    pub sysregs: Vec<(u32, u64)>,
+    /// Q0..Q31 NEON/FP.
+    pub simd: [u128; 32],
+    /// Per-vCPU GIC CPU-interface (ICC) regs.
+    pub icc: Vec<(u32, u64)>,
+    /// Virtual timer mask + offset (offset recomputed on restore for CNTVCT continuity).
+    pub vtimer: VtimerState,
+}
+
+#[cfg(target_arch = "aarch64")]
+pub struct VtimerState {
+    pub mask: bool,
+    pub offset: u64,
+}
+
+/// The one polymorphic seam: virtio/legacy devices are iterated as trait
+/// objects, so they earn a trait. Everything else (vCPU, memory, GIC) has a
+/// single or cfg-split impl and is a plain method / free fn instead.
+pub trait Snapshottable {
+    fn id(&self) -> &str;
+    fn save(&self) -> Result<DeviceState, SnapErr>;
+    fn restore(&mut self, state: &DeviceState) -> Result<(), SnapErr>;
+}
+
+/// Serialize guest RAM to the snapshot's `memory.img`. Restore is
+/// construction-time (a `MAP_PRIVATE` mapping of the image), so only capture is
+/// a function here.
+pub fn write_mem_image(_mem: &GuestMemoryMmap, _out: &mut dyn Write) -> Result<(), SnapErr> {
+    todo!("M1: write guest RAM regions to memory.img")
+}
+
+/// Copy-on-write clone of a backing file (disk image). The CoW primitive is a
+/// platform detail hidden here — macOS `clonefile`, Linux `FICLONE` with a
+/// plain-copy fallback — so callers never see a backend-specific call.
+pub fn cow_clone(_src: &Path, _dst: &Path) -> Result<(), SnapErr> {
+    todo!("M1: clonefile (macos) / FICLONE+copy fallback (linux)")
+}


### PR DESCRIPTION
**WIP / draft — M0 of VM snapshot & restore (HVF-first). Tracking #748.**

This opens the snapshot/restore work for review at the **M0 design gate**. It
contains the backend-neutral seam only — no capture or restore logic yet (every
body is `todo!()`). I'd like sign-off on the design below before writing M1
capture code.

## What's in this PR

`src/vmm/src/snapshot/mod.rs` (+ a one-line module decl). 

- **One** polymorphic trait, `Snapshottable`, for devices (the only genuinely
  polymorphic case — iterated as trait objects).
- A shared, **arch-keyed** `VcpuState` that KVM and HVF both fill in — no
  hypervisor name appears in the type. This is the "seam must not leak HVF
  specifics" bar from #748.
- Free fns `write_mem_image` / `cow_clone` for guest RAM and disk CoW, hiding
  the platform primitive (`MAP_PRIVATE` / `clonefile` / `FICLONE`) from callers.
- GIC + per-vCPU capture attach to existing types (`IrqChipT`, the per-backend
  `Vcpu`) rather than new traits. Those KVM-side stubs follow on a Linux host
  where the KVM path compiles.

## Design note (M0 deliverable)

### Seam 
One new trait; everything else is an inherent method, a free fn, or an extension
of an existing trait, because everything else has a single or cfg-split impl. No
`Snapshottable`-style interface with one implementation.
- vCPU state is **arch-keyed, not hypervisor-keyed** — `VcpuState::Aarch64{ gp,
  sysregs, simd, icc, vtimer }` is identical whether KVM or HVF fills it.
- GIC is an opaque `Vec<u8>` blob on the existing `IrqChipT` — whether the bytes
  came from `hv_gic_state_get_data` or a KVM VGIC dev-attr dump is invisible.
- Memory is `MAP_PRIVATE` of a file — a POSIX primitive, not macOS-specific.

### On-disk format
Directory: `manifest.json` (serde_json, the contract) + `memory.img` (raw guest
RAM, `MAP_PRIVATE` base on restore) + `vmstate` (hand-rolled versioned binary:
vCPU regs/sysregs/SIMD/ICC/vtimer, GIC blob, per-device state). `manifest` and
`vmstate` versioned independently; loader rejects mismatches with a clear errno,
never half-loads. vmstate is hand-rolled because it's a register dump — never
JSON.

### Minimal device set (M1)
virtio-blk, virtio-vsock, virtio-rng, RTC (PL031), console. Each captures its
virtqueue indices (`next_avail`/`next_used`/`ready`) + MMIO transport state at a
quiescent point. Host fds/threads are rebuilt on restore (re-open image, restart
workers); vsock seeds an `OP_RST` per live connection (ignition's model).

### Memory model
`MAP_PRIVATE` of `memory.img`, MAP_PRIVATE` of a file is demand-paged by the kernel,
so idle RSS stays well below full RAM without userfaultfd. (Note: the ignition
reference uses `MAP_PRIVATE` + eager diff overlay, not `MAP_SHARED`/UFFD as #748
loosely describes.)

### Capture trigger
`krun_start_enter` stays **blocking** — its main thread is the live device
backend event loop, not idle; returning would strand it, and it's the 2.0
lifetime contract embedders depend on.
- **Model A (default, M1):** host-driven. Embedder runs the blocking enter on a
  thread it owns and calls `krun_snapshot_request` out-of-band (or
  `krun_snapshot_create`, the blocking enter-wait-serialize-exit flavor).
  Readiness detection is the embedder's. Zero core change.
- **Model B (deferred):** guest-signaled via a reserved vsock port. Needs a
  libkrunfw/init convention — kept pluggable behind an internal
  `CaptureTrigger` 

### Clone safety (M3, ships with restore)
vmgenid-style generation bump on restore + `krun_set_entropy_seed`, so two clones
from one base diverge in RNG/identity. Not deferred past restore.

### Out of scope
KVM backend (design-compatible, later series), virtio-fs/gpu/TSI.

## Open question for maintainers
The **capture-readiness trigger** (Model A vs adding B, and whether B's vsock
convention is acceptable in the libkrunfw init path) — @mtjhrc's call per #748.
Everything else above I believe is settled; happy to adjust.

## Milestones
M0 seam (this PR) → M1 HVF capture + minimal devices → M2 restore + lazy CoW +
reconfig whitelist → M3 clone safety → M4 hardening/tests/docs. 
