### PR TITLE
devices: declare the vm-memory rawfd feature it relies on

### DIFF
--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = { version = "2.0", optional = true }
 vhost = { version = "0.15", optional = true, features = ["vhost-user-frontend"] }
 vmm-sys-util = { version = "0.15", optional = true }
 virtio-bindings = "0.2.0"
-vm-memory = { version = "0.17", default-features = false, features = ["backend-mmap"] }
+vm-memory = { version = "0.17", default-features = false, features = ["backend-mmap", "rawfd"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", features = ["bindgen_clang_runtime"], optional = true }


### PR DESCRIPTION
## Problem

`cargo test -p krun-devices` fails standalone on macOS:

```
error[E0599]: no method named `write_volatile` found for struct `OwnedFd`
   --> src/devices/src/virtio/console/console/port_io/unix.rs:139
```

`unix.rs` calls `WriteVolatile::write_volatile` on an `OwnedFd` — an impl behind
vm-memory's `rawfd` feature, which the crate never declares. Full builds work
only by accident: a sibling crate pulls vm-memory with default features (incl.
`rawfd`) and feature unification leaks it in.

## Fix

Declare the `rawfd` feature `krun-devices` actually uses. `Cargo.lock` unchanged.

## Verification

`cargo test -p krun-devices` compiles and passes standalone on macOS (49 tests).