### PR TITLE
virtio/fs: implement simplified permission semantics

### DIFF
--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -22,6 +22,7 @@ use super::virtual_entry::VirtualDirEntry;
 use super::worker::FsWorker;
 use super::{defs, defs::uapi};
 use crate::virtio::InterruptTransport;
+use crate::virtio::passthrough::PermissionSemantics;
 
 #[derive(Copy, Clone)]
 #[repr(C, packed)]
@@ -46,6 +47,7 @@ pub struct Fs {
     acked_features: u64,
     device_state: DeviceState,
     config: VirtioFsConfig,
+    allow_idmap: bool,
     shm_region: Option<VirtioShmRegion>,
     passthrough_cfg: Option<passthrough::Config>,
     read_only: bool,
@@ -60,6 +62,7 @@ pub struct Fs {
 impl Fs {
     pub fn new(
         fs_id: String,
+        semantics: PermissionSemantics,
         shared_dir: Option<String>,
         exit_code: Arc<AtomicI32>,
         read_only: bool,
@@ -74,14 +77,18 @@ impl Fs {
 
         let fs_cfg = shared_dir.map(|root_dir| passthrough::Config {
             root_dir,
+            semantics,
             ..Default::default()
         });
+
+        let allow_idmap = matches!(semantics, PermissionSemantics::LinuxComplete);
 
         Ok(Fs {
             avail_features,
             acked_features: 0,
             device_state: DeviceState::Inactive,
             config,
+            allow_idmap,
             shm_region: None,
             passthrough_cfg: fs_cfg,
             read_only,
@@ -194,6 +201,7 @@ impl VirtioDevice for Fs {
             queue_evts,
             interrupt.clone(),
             mem.clone(),
+            self.allow_idmap,
             self.shm_region.clone(),
             self.passthrough_cfg.clone(),
             self.read_only,

--- a/src/devices/src/virtio/fs/device.rs
+++ b/src/devices/src/virtio/fs/device.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicI32, AtomicU64, Ordering};
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use utils::eventfd::{EFD_NONBLOCK, EventFd};
 #[cfg(target_os = "macos")]
@@ -75,9 +76,18 @@ impl Fs {
         config.tag[..tag.len()].copy_from_slice(tag.as_slice());
         config.num_request_queues = 1;
 
+        let attr_timeout = if matches!(semantics, PermissionSemantics::LinuxSimplified) {
+            // As uid/gid are context-dependent, attributes can't be cached.
+            Duration::from_secs(0)
+        } else {
+            // The value defined as default in virtio-fs.
+            Duration::from_secs(5)
+        };
+
         let fs_cfg = shared_dir.map(|root_dir| passthrough::Config {
             root_dir,
             semantics,
+            attr_timeout,
             ..Default::default()
         });
 

--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -280,6 +280,22 @@ impl FromStr for CachePolicy {
     }
 }
 
+/// The permission semantics to be emulated by this file system personality.
+#[derive(Debug, Default, Clone, Copy)]
+pub enum PermissionSemantics {
+    /// Be as close as possible to the common semantics of Linux file systems.
+    #[default]
+    LinuxComplete,
+
+    /// As `LinuxComplete`, with the following simplifications:
+    ///  - Extended attributes are not supported.
+    ///  - Idmaps are not supported.
+    ///  - Ownership bits are ignored, always returning the uid/gid from the process
+    ///    requesting the operation within the guest (obtained from `Context`).
+    ///  - Permissions bits are stored in the host, no as extended attributes.
+    LinuxSimplified,
+}
+
 /// Options that configure the behavior of the file system.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -337,8 +353,13 @@ pub struct Config {
 
     /// ID of this filesystem to uniquely identify exports.
     pub export_fsid: u64,
+
     /// Table of exported FDs to share with other subsystems.
     pub export_table: Option<ExportTable>,
+
+    /// The permission semantics to be emulated. See the documentation for `PermissionSemantics` for
+    /// more details.
+    pub semantics: PermissionSemantics,
 }
 
 impl Default for Config {
@@ -353,6 +374,7 @@ impl Default for Config {
             proc_sfd_rawfd: None,
             export_fsid: 0,
             export_table: None,
+            semantics: PermissionSemantics::LinuxComplete,
         }
     }
 }

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -161,16 +161,6 @@ fn einval() -> io::Error {
     linux_error(io::Error::from_raw_os_error(libc::EINVAL))
 }
 
-fn host_euid() -> u32 {
-    static EUID: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
-    *EUID.get_or_init(|| unsafe { libc::geteuid() })
-}
-
-fn host_egid() -> u32 {
-    static EGID: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
-    *EGID.get_or_init(|| unsafe { libc::getegid() })
-}
-
 fn item_to_value(item: &[u8], radix: u32) -> Option<u32> {
     match std::str::from_utf8(item) {
         Ok(val) => match u32::from_str_radix(val, radix) {
@@ -366,21 +356,11 @@ fn stat_common(
     host: bool,
 ) -> io::Result<bindings::stat64> {
     if !host {
-        match uid {
-            Some(uid) => st.st_uid = uid,
-            None => {
-                if st.st_uid == host_euid() {
-                    st.st_uid = 0;
-                }
-            }
+        if let Some(uid) = uid {
+            st.st_uid = uid;
         }
-        match gid {
-            Some(gid) => st.st_gid = gid,
-            None => {
-                if st.st_gid == host_egid() {
-                    st.st_gid = 0;
-                }
-            }
+        if let Some(gid) = gid {
+            st.st_gid = gid;
         }
         if let Some(mode) = mode {
             if mode as u16 & libc::S_IFMT == 0 {

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -928,8 +928,13 @@ impl PassthroughFs {
     }
 
     fn grab_unlinked_fd(&self, parent_fd: RawFd, name: &CStr) -> io::Result<RawFd> {
-        let fd =
-            unsafe { libc::openat(parent_fd, name.as_ptr(), libc::O_NOFOLLOW | libc::O_CLOEXEC) };
+        let fd = unsafe {
+            libc::openat(
+                parent_fd,
+                name.as_ptr(),
+                libc::O_NOFOLLOW | libc::O_CLOEXEC | libc::O_NONBLOCK,
+            )
+        };
         if fd < 0 {
             return Err(io::Error::last_os_error());
         }

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -10,6 +10,8 @@ use std::fs::File;
 use std::io;
 use std::mem::MaybeUninit;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
+use std::os::unix::net::UnixListener;
+use std::path::Path;
 use std::ptr::null_mut;
 use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering};
@@ -263,6 +265,7 @@ fn is_valid_owner(owner: Option<(u32, u32)>) -> bool {
 
     false
 }
+
 // We won't need this once expressions like "if let ... &&" are allowed.
 #[allow(clippy::unnecessary_unwrap)]
 fn set_xattr_stat(
@@ -272,7 +275,7 @@ fn set_xattr_stat(
     owner: Option<(u32, u32)>,
     mode: Option<u32>,
 ) -> io::Result<()> {
-    let st = st.unwrap_or(istat(ctx, file, true)?);
+    let st = st.unwrap_or(istat(ctx, PermissionSemantics::LinuxComplete, file, true)?);
     let options = if (st.st_mode & libc::S_IFMT) == libc::S_IFLNK {
         libc::XATTR_NOFOLLOW
     } else {
@@ -349,9 +352,44 @@ fn set_xattr_stat(
     }
 }
 
-fn stat_common(
-    _ctx: &Context,
-    mut st: bindings::stat64,
+fn set_host_stat(
+    file: &InodeHandle,
+    _owner: Option<(u32, u32)>,
+    mode: Option<u32>,
+) -> io::Result<()> {
+    // We're only using set_host_stat for LinuxSimplified semantics, and in this
+    // mode we ignore the host's owner bits, so don't attempt to write them here.
+
+    if let Some(mode) = mode {
+        let res = match file {
+            InodeHandle::Path(path) => unsafe { libc::chmod(path.as_ptr(), mode as u16) },
+            InodeHandle::Fd(fd) => unsafe { libc::fchmod(*fd, mode as u16) },
+        };
+
+        if res < 0 {
+            return Err(linux_error(io::Error::last_os_error()));
+        }
+    }
+
+    Ok(())
+}
+
+fn set_stat(
+    ctx: &Context,
+    semantics: PermissionSemantics,
+    file: &InodeHandle,
+    st: Option<bindings::stat64>,
+    owner: Option<(u32, u32)>,
+    mode: Option<u32>,
+) -> io::Result<()> {
+    match semantics {
+        PermissionSemantics::LinuxComplete => set_xattr_stat(ctx, file, st, owner, mode),
+        PermissionSemantics::LinuxSimplified => set_host_stat(file, owner, mode),
+    }
+}
+
+fn stat_xattr_common(
+    st: &mut bindings::stat64,
     uid: Option<u32>,
     gid: Option<u32>,
     mode: Option<u32>,
@@ -370,10 +408,15 @@ fn stat_common(
         }
     }
 
-    Ok(st)
+    Ok(*st)
 }
 
-fn fstat(ctx: &Context, fd: RawFd, host: bool) -> io::Result<bindings::stat64> {
+fn fstat(
+    ctx: &Context,
+    semantics: PermissionSemantics,
+    fd: RawFd,
+    host: bool,
+) -> io::Result<bindings::stat64> {
     let mut st = MaybeUninit::<bindings::stat64>::zeroed();
 
     // Safe because the kernel will only write data in `st` and we check the return
@@ -381,10 +424,19 @@ fn fstat(ctx: &Context, fd: RawFd, host: bool) -> io::Result<bindings::stat64> {
     let res = unsafe { libc::fstat(fd, st.as_mut_ptr()) };
     if res >= 0 {
         // Safe because the kernel guarantees that the struct is now fully initialized.
-        let st = unsafe { st.assume_init() };
+        let mut st = unsafe { st.assume_init() };
         if !host {
-            let (uid, gid, mode) = get_xattr_fstat(fd, st)?;
-            stat_common(ctx, st, uid, gid, mode)
+            match semantics {
+                PermissionSemantics::LinuxComplete => {
+                    let (uid, gid, mode) = get_xattr_fstat(fd, st)?;
+                    stat_xattr_common(&mut st, uid, gid, mode)
+                }
+                PermissionSemantics::LinuxSimplified => {
+                    st.st_uid = ctx.uid;
+                    st.st_gid = ctx.gid;
+                    Ok(st)
+                }
+            }
         } else {
             Ok(st)
         }
@@ -393,7 +445,12 @@ fn fstat(ctx: &Context, fd: RawFd, host: bool) -> io::Result<bindings::stat64> {
     }
 }
 
-fn lstat(ctx: &Context, c_path: &CString, host: bool) -> io::Result<bindings::stat64> {
+fn lstat(
+    ctx: &Context,
+    semantics: PermissionSemantics,
+    c_path: &CString,
+    host: bool,
+) -> io::Result<bindings::stat64> {
     let mut st = MaybeUninit::<bindings::stat64>::zeroed();
 
     // Safe because the kernel will only write data in `st` and we check the return
@@ -401,10 +458,19 @@ fn lstat(ctx: &Context, c_path: &CString, host: bool) -> io::Result<bindings::st
     let res = unsafe { libc::lstat(c_path.as_ptr(), st.as_mut_ptr()) };
     if res >= 0 {
         // Safe because the kernel guarantees that the struct is now fully initialized.
-        let st = unsafe { st.assume_init() };
+        let mut st = unsafe { st.assume_init() };
         if !host {
-            let (uid, gid, mode) = get_xattr_lstat(c_path, st)?;
-            stat_common(ctx, st, uid, gid, mode)
+            match semantics {
+                PermissionSemantics::LinuxComplete => {
+                    let (uid, gid, mode) = get_xattr_lstat(c_path, st)?;
+                    stat_xattr_common(&mut st, uid, gid, mode)
+                }
+                PermissionSemantics::LinuxSimplified => {
+                    st.st_uid = ctx.uid;
+                    st.st_gid = ctx.gid;
+                    Ok(st)
+                }
+            }
         } else {
             Ok(st)
         }
@@ -413,10 +479,15 @@ fn lstat(ctx: &Context, c_path: &CString, host: bool) -> io::Result<bindings::st
     }
 }
 
-fn istat(ctx: &Context, ihandle: &InodeHandle, host: bool) -> io::Result<bindings::stat64> {
+fn istat(
+    ctx: &Context,
+    semantics: PermissionSemantics,
+    ihandle: &InodeHandle,
+    host: bool,
+) -> io::Result<bindings::stat64> {
     match ihandle {
-        InodeHandle::Fd(fd) => fstat(ctx, *fd, host),
-        InodeHandle::Path(c_path) => lstat(ctx, c_path, host),
+        InodeHandle::Fd(fd) => fstat(ctx, semantics, *fd, host),
+        InodeHandle::Path(c_path) => lstat(ctx, semantics, c_path, host),
     }
 }
 
@@ -453,6 +524,22 @@ impl FromStr for CachePolicy {
             _ => Err("invalid cache policy"),
         }
     }
+}
+
+/// The permission semantics to be emulated by this file system personality.
+#[derive(Debug, Default, Clone, Copy)]
+pub enum PermissionSemantics {
+    /// Be as close as possible to the common semantics of Linux file systems.
+    #[default]
+    LinuxComplete,
+
+    /// As `LinuxComplete`, with the following simplifications:
+    ///  - Extended attributes are not supported.
+    ///  - Idmaps are not supported.
+    ///  - Ownership bits are ignored, always returning the uid/gid from the process
+    ///    requesting the operation within the guest (obtained from `Context`).
+    ///  - Permissions bits are stored in the host, no as extended attributes.
+    LinuxSimplified,
 }
 
 /// Options that configure the behavior of the file system.
@@ -512,8 +599,13 @@ pub struct Config {
 
     /// ID of this filesystem to uniquely identify exports. Not supported for macos.
     pub export_fsid: u64,
+
     /// Table of exported FDs to share with other subsystems. Not supported for macos.
     pub export_table: Option<ExportTable>,
+
+    /// The permission semantics to be emulated. See the documentation for `PermissionSemantics` for
+    /// more details.
+    pub semantics: PermissionSemantics,
 }
 
 impl Default for Config {
@@ -528,6 +620,7 @@ impl Default for Config {
             proc_sfd_rawfd: None,
             export_fsid: 0,
             export_table: None,
+            semantics: PermissionSemantics::LinuxComplete,
         }
     }
 }
@@ -766,10 +859,17 @@ impl PassthroughFs {
 
             remove_security_capability(&ihandle);
 
-            if let Ok(st) = fstat(ctx, fd, false) {
+            if let Ok(st) = fstat(ctx, self.cfg.semantics, fd, false) {
                 let new_mode = clear_suid_sgid(st.st_mode as u32);
                 if new_mode != st.st_mode as u32
-                    && let Err(err) = set_xattr_stat(ctx, &ihandle, Some(st), None, Some(new_mode))
+                    && let Err(err) = set_stat(
+                        ctx,
+                        self.cfg.semantics,
+                        &ihandle,
+                        Some(st),
+                        None,
+                        Some(new_mode),
+                    )
                 {
                     error!("Couldn't clear suid/sgid for inode {inode}: {err}");
                 }
@@ -820,8 +920,8 @@ impl PassthroughFs {
     fn do_getattr(&self, ctx: &Context, inode: Inode) -> io::Result<(bindings::stat64, Duration)> {
         let ihandle = self.inode_to_handle(inode, true)?;
         let st = match ihandle {
-            InodeHandle::Path(c_path) => lstat(ctx, &c_path, false)?,
-            InodeHandle::Fd(fd) => fstat(ctx, fd, false)?,
+            InodeHandle::Path(c_path) => lstat(ctx, self.cfg.semantics, &c_path, false)?,
+            InodeHandle::Fd(fd) => fstat(ctx, self.cfg.semantics, fd, false)?,
         };
 
         Ok((st, self.cfg.attr_timeout))
@@ -837,7 +937,7 @@ impl PassthroughFs {
     }
 
     fn store_unlinked_fd(&self, ctx: &Context, unlinked_fd: RawFd) -> io::Result<bool> {
-        let st = fstat(ctx, unlinked_fd, true)?;
+        let st = fstat(ctx, self.cfg.semantics, unlinked_fd, true)?;
         let altkey = InodeAltKey {
             ino: st.st_ino,
             dev: st.st_dev,
@@ -929,6 +1029,93 @@ impl PassthroughFs {
             }
             Err(linux_error(err))
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mknod_complete(
+        &self,
+        ctx: Context,
+        parent: Inode,
+        name: &CStr,
+        mode: u32,
+        _rdev: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        let c_path = self.name_to_path(parent, name)?;
+
+        let fd = unsafe {
+            libc::open(
+                c_path.as_ptr(),
+                libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                0o600,
+            )
+        };
+        if fd < 0 {
+            Err(linux_error(io::Error::last_os_error()))
+        } else {
+            let ihandle = InodeHandle::Fd(fd);
+
+            // Set security context
+            if let Some(secctx) = extensions.secctx {
+                set_secctx(&ihandle, secctx, false)?
+            };
+
+            // For mknod, we're forced to store the mode as xattr even in
+            // simplified mode, since macOS doesn't allow unprivileged users
+            // to create special files (such as sockets or fifos) using mknod.
+            if let Err(e) = set_xattr_stat(
+                &ctx,
+                &ihandle,
+                None,
+                Some((ctx.uid, ctx.gid)),
+                Some(mode & !umask),
+            ) {
+                unsafe { libc::close(fd) };
+                return Err(e);
+            }
+
+            unsafe { libc::close(fd) };
+            self.lookup(ctx, parent, name)
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn mknod_simplified(
+        &self,
+        ctx: Context,
+        parent: Inode,
+        name: &CStr,
+        mode: u32,
+        rdev: u32,
+        umask: u32,
+        extensions: Extensions,
+    ) -> io::Result<Entry> {
+        let c_path = self.name_to_path(parent, name)?;
+
+        // macOS doesn't allow us to create UNIX sockets using macOS, so we
+        // have to resort to actually creating the socket ourselves and
+        // dropping it.
+        if (mode as u16 & libc::S_IFMT) == libc::S_IFSOCK {
+            let path = c_path.to_str().map_err(|_| einval())?;
+            let listener = UnixListener::bind(Path::new(path)).map_err(|_| einval())?;
+            // Explicitly drop the listener to make it clear we aren't going
+            // to use it. UnixListener's Drop doesn't remove the socket it
+            // created, so we can reuse for the guest.
+            drop(listener);
+        } else {
+            let res = unsafe { libc::mknod(c_path.as_ptr(), (mode & !umask) as u16, rdev as i32) };
+            if res < 0 {
+                return Err(linux_error(io::Error::last_os_error()));
+            }
+        }
+
+        // Set security context
+        if let Some(secctx) = extensions.secctx {
+            let ihandle = InodeHandle::Path(c_path);
+            set_secctx(&ihandle, secctx, false)?
+        };
+        self.lookup(ctx, parent, name)
     }
 
     fn parse_open_flags(&self, flags: i32) -> i32 {
@@ -1100,7 +1287,7 @@ impl FileSystem for PassthroughFs {
             gid: 0,
             pid: 0,
         };
-        let st = fstat(&ctx, f.as_raw_fd(), true)?;
+        let st = fstat(&ctx, self.cfg.semantics, f.as_raw_fd(), true)?;
 
         // Safe because this doesn't modify any memory and there is no need to check the return
         // value because this system call always succeeds. We need to clear the umask here because
@@ -1171,7 +1358,7 @@ impl FileSystem for PassthroughFs {
             .ok_or_else(ebadf)?;
 
         let c_path = self.name_to_path(parent, name)?;
-        let st = lstat(&ctx, &c_path, false)?;
+        let st = lstat(&ctx, self.cfg.semantics, &c_path, false)?;
 
         debug!(
             "lookup: inode={} path={}",
@@ -1275,8 +1462,13 @@ impl FileSystem for PassthroughFs {
     ) -> io::Result<Entry> {
         let c_path = self.name_to_path(parent, name)?;
 
+        let (host_mode, complete) = match self.cfg.semantics {
+            PermissionSemantics::LinuxComplete => (0o700, true),
+            PermissionSemantics::LinuxSimplified => ((mode & !umask) as u16, false),
+        };
+
         // Safe because this doesn't modify any memory and we check the return value.
-        let res = unsafe { libc::mkdir(c_path.as_ptr(), 0o700) };
+        let res = unsafe { libc::mkdir(c_path.as_ptr(), host_mode) };
         if res == 0 {
             let ihandle = InodeHandle::Path(c_path);
             // Set security context
@@ -1284,13 +1476,16 @@ impl FileSystem for PassthroughFs {
                 set_secctx(&ihandle, secctx, false)?
             };
 
-            set_xattr_stat(
-                &ctx,
-                &ihandle,
-                None,
-                Some((ctx.uid, ctx.gid)),
-                Some(mode & !umask),
-            )?;
+            if complete {
+                set_stat(
+                    &ctx,
+                    self.cfg.semantics,
+                    &ihandle,
+                    None,
+                    Some((ctx.uid, ctx.gid)),
+                    Some(mode & !umask),
+                )?;
+            }
             self.lookup(ctx, parent, name)
         } else {
             Err(linux_error(io::Error::last_os_error()))
@@ -1379,10 +1574,16 @@ impl FileSystem for PassthroughFs {
         let c_path = self.name_to_path(parent, name)?;
 
         let flags = self.parse_open_flags(flags as i32);
-        let hostmode = if (flags & libc::O_DIRECTORY) != 0 {
-            0o700
-        } else {
-            0o600
+        let (host_mode, complete) = match self.cfg.semantics {
+            PermissionSemantics::LinuxComplete => {
+                let mode = if (flags & libc::O_DIRECTORY) != 0 {
+                    0o700
+                } else {
+                    0o600
+                };
+                (mode, true)
+            }
+            PermissionSemantics::LinuxSimplified => (mode & !(umask & 0o777), false),
         };
 
         // Safe because this doesn't modify any memory and we check the return value. We don't
@@ -1392,7 +1593,7 @@ impl FileSystem for PassthroughFs {
             libc::open(
                 c_path.as_ptr(),
                 flags | libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-                hostmode,
+                host_mode,
             )
         };
         if fd < 0 {
@@ -1400,13 +1601,16 @@ impl FileSystem for PassthroughFs {
         }
         let ihandle = InodeHandle::Fd(fd);
 
-        if let Err(e) = set_xattr_stat(
-            &ctx,
-            &ihandle,
-            None,
-            Some((ctx.uid, ctx.gid)),
-            Some(libc::S_IFREG as u32 | (mode & !(umask & 0o777))),
-        ) {
+        if complete
+            && let Err(e) = set_stat(
+                &ctx,
+                self.cfg.semantics,
+                &ihandle,
+                None,
+                Some((ctx.uid, ctx.gid)),
+                Some(libc::S_IFREG as u32 | (mode & !(umask & 0o777))),
+            )
+        {
             unsafe { libc::close(fd) };
             return Err(e);
         }
@@ -1512,12 +1716,18 @@ impl FileSystem for PassthroughFs {
 
             remove_security_capability(&ihandle);
 
-            if let Ok(st) = fstat(&ctx, fd, false) {
+            if let Ok(st) = fstat(&ctx, self.cfg.semantics, fd, false) {
                 let new_mode = clear_suid_sgid(st.st_mode as u32);
                 if new_mode != st.st_mode as u32 {
                     // Update mode in xattr
-                    if let Err(err) = set_xattr_stat(&ctx, &ihandle, Some(st), None, Some(new_mode))
-                    {
+                    if let Err(err) = set_stat(
+                        &ctx,
+                        self.cfg.semantics,
+                        &ihandle,
+                        Some(st),
+                        None,
+                        Some(new_mode),
+                    ) {
                         error!("Couldn't clear suid/sgid for inode {inode}: {err}");
                     }
                 }
@@ -1562,7 +1772,14 @@ impl FileSystem for PassthroughFs {
         };
 
         if valid.contains(SetattrValid::MODE) {
-            set_xattr_stat(&ctx, &ihandle, None, None, Some(attr.st_mode as u32))?
+            set_stat(
+                &ctx,
+                self.cfg.semantics,
+                &ihandle,
+                None,
+                None,
+                Some(attr.st_mode as u32),
+            )?
         }
 
         if valid.intersects(SetattrValid::UID | SetattrValid::GID) {
@@ -1580,7 +1797,7 @@ impl FileSystem for PassthroughFs {
             };
 
             remove_security_capability(&ihandle);
-            let st = istat(&ctx, &ihandle, false)?;
+            let st = istat(&ctx, self.cfg.semantics, &ihandle, false)?;
 
             // Clear suid/sgid if UID or GID is being changed
             let new_mode = clear_suid_sgid(st.st_mode as u32);
@@ -1589,7 +1806,14 @@ impl FileSystem for PassthroughFs {
             } else {
                 None
             };
-            set_xattr_stat(&ctx, &ihandle, Some(st), Some((uid, gid)), new_mode)?;
+            set_stat(
+                &ctx,
+                self.cfg.semantics,
+                &ihandle,
+                Some(st),
+                Some((uid, gid)),
+                new_mode,
+            )?;
         }
 
         if valid.contains(SetattrValid::SIZE) {
@@ -1603,10 +1827,17 @@ impl FileSystem for PassthroughFs {
 
                     // Clear security.capability on truncate unconditionally
                     remove_security_capability(&ihandle);
-                    let st = fstat(&ctx, fd, false)?;
+                    let st = fstat(&ctx, self.cfg.semantics, fd, false)?;
                     let new_mode = clear_suid_sgid(st.st_mode as u32);
                     if new_mode != st.st_mode as u32 {
-                        set_xattr_stat(&ctx, &ihandle, Some(st), None, Some(new_mode))?;
+                        set_stat(
+                            &ctx,
+                            self.cfg.semantics,
+                            &ihandle,
+                            Some(st),
+                            None,
+                            Some(new_mode),
+                        )?;
                     }
                 }
                 InodeHandle::Path(_) => {
@@ -1623,10 +1854,17 @@ impl FileSystem for PassthroughFs {
                     // reuse the FD we just opened, thus reducing the number of syscalls.
                     let ihandle = InodeHandle::Fd(f.as_raw_fd());
                     remove_security_capability(&ihandle);
-                    let st = istat(&ctx, &ihandle, false)?;
+                    let st = istat(&ctx, self.cfg.semantics, &ihandle, false)?;
                     let new_mode = clear_suid_sgid(st.st_mode as u32);
                     if new_mode != st.st_mode as u32 {
-                        set_xattr_stat(&ctx, &ihandle, Some(st), None, Some(new_mode))?;
+                        set_stat(
+                            &ctx,
+                            self.cfg.semantics,
+                            &ihandle,
+                            Some(st),
+                            None,
+                            Some(new_mode),
+                        )?;
                     }
                 }
             };
@@ -1755,24 +1993,34 @@ impl FileSystem for PassthroughFs {
             }
 
             if ((flags as i32) & bindings::LINUX_RENAME_WHITEOUT) != 0 {
+                let (host_mode, complete) = match self.cfg.semantics {
+                    PermissionSemantics::LinuxComplete => (0o600, true),
+                    PermissionSemantics::LinuxSimplified => {
+                        (((libc::S_IFCHR | 0o600) as u32), true)
+                    }
+                };
                 let fd = unsafe {
                     libc::open(
                         old_cpath.as_ptr(),
                         libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-                        0o600,
+                        host_mode,
                     )
                 };
                 if fd > 0 {
-                    if let Err(e) = set_xattr_stat(
-                        &ctx,
-                        &InodeHandle::Fd(fd),
-                        None,
-                        None,
-                        Some((libc::S_IFCHR | 0o600) as u32),
-                    ) {
+                    if complete
+                        && let Err(e) = set_stat(
+                            &ctx,
+                            self.cfg.semantics,
+                            &InodeHandle::Fd(fd),
+                            None,
+                            None,
+                            Some((libc::S_IFCHR | 0o600) as u32),
+                        )
+                    {
                         unsafe { libc::close(fd) };
                         return Err(e);
                     }
+
                     unsafe { libc::close(fd) };
                 }
             }
@@ -1796,42 +2044,17 @@ impl FileSystem for PassthroughFs {
         parent: Inode,
         name: &CStr,
         mode: u32,
-        _rdev: u32,
+        rdev: u32,
         umask: u32,
         extensions: Extensions,
     ) -> io::Result<Entry> {
-        let c_path = self.name_to_path(parent, name)?;
-
-        let fd = unsafe {
-            libc::open(
-                c_path.as_ptr(),
-                libc::O_CREAT | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-                0o600,
-            )
-        };
-        if fd < 0 {
-            Err(linux_error(io::Error::last_os_error()))
-        } else {
-            let ihandle = InodeHandle::Fd(fd);
-
-            // Set security context
-            if let Some(secctx) = extensions.secctx {
-                set_secctx(&ihandle, secctx, false)?
-            };
-
-            if let Err(e) = set_xattr_stat(
-                &ctx,
-                &ihandle,
-                None,
-                Some((ctx.uid, ctx.gid)),
-                Some(mode & !umask),
-            ) {
-                unsafe { libc::close(fd) };
-                return Err(e);
+        match self.cfg.semantics {
+            PermissionSemantics::LinuxComplete => {
+                self.mknod_complete(ctx, parent, name, mode, rdev, umask, extensions)
             }
-
-            unsafe { libc::close(fd) };
-            self.lookup(ctx, parent, name)
+            PermissionSemantics::LinuxSimplified => {
+                self.mknod_simplified(ctx, parent, name, mode, rdev, umask, extensions)
+            }
         }
     }
 
@@ -1878,17 +2101,20 @@ impl FileSystem for PassthroughFs {
             };
 
             let mut entry = self.lookup(ctx, parent, name)?;
-            let mode = libc::S_IFLNK | 0o777;
-            set_xattr_stat(
-                &ctx,
-                &ihandle,
-                None,
-                Some((ctx.uid, ctx.gid)),
-                Some(mode as u32),
-            )?;
-            entry.attr.st_uid = ctx.uid;
-            entry.attr.st_gid = ctx.gid;
-            entry.attr.st_mode = mode;
+            if matches!(self.cfg.semantics, PermissionSemantics::LinuxComplete) {
+                let mode = libc::S_IFLNK | 0o777;
+                set_stat(
+                    &ctx,
+                    self.cfg.semantics,
+                    &ihandle,
+                    None,
+                    Some((ctx.uid, ctx.gid)),
+                    Some(mode as u32),
+                )?;
+                entry.attr.st_uid = ctx.uid;
+                entry.attr.st_gid = ctx.gid;
+                entry.attr.st_mode = mode;
+            }
             Ok(entry)
         } else {
             Err(linux_error(io::Error::last_os_error()))
@@ -1991,8 +2217,8 @@ impl FileSystem for PassthroughFs {
 
     fn access(&self, ctx: Context, inode: Inode, mask: u32) -> io::Result<()> {
         let st = match self.inode_to_handle(inode, true)? {
-            InodeHandle::Path(c_path) => lstat(&ctx, &c_path, false)?,
-            InodeHandle::Fd(fd) => fstat(&ctx, fd, false)?,
+            InodeHandle::Path(c_path) => lstat(&ctx, self.cfg.semantics, &c_path, false)?,
+            InodeHandle::Fd(fd) => fstat(&ctx, self.cfg.semantics, fd, false)?,
         };
 
         let mode = mask as i32 & (libc::R_OK | libc::W_OK | libc::X_OK);
@@ -2298,7 +2524,7 @@ impl FileSystem for PassthroughFs {
                 // The best thing we can do here is extend the file to (offset + length).
                 // This doesn't adhere to the same semantics, but should work fine (albeit
                 // less performant) for most guest applications.
-                let st = fstat(&ctx, fd, true)?;
+                let st = fstat(&ctx, self.cfg.semantics, fd, true)?;
                 let new_length = (offset + length) as i64;
 
                 if keep_size {

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -266,12 +266,13 @@ fn is_valid_owner(owner: Option<(u32, u32)>) -> bool {
 // We won't need this once expressions like "if let ... &&" are allowed.
 #[allow(clippy::unnecessary_unwrap)]
 fn set_xattr_stat(
+    ctx: &Context,
     file: &InodeHandle,
     st: Option<bindings::stat64>,
     owner: Option<(u32, u32)>,
     mode: Option<u32>,
 ) -> io::Result<()> {
-    let st = st.unwrap_or(istat(file, true)?);
+    let st = st.unwrap_or(istat(ctx, file, true)?);
     let options = if (st.st_mode & libc::S_IFMT) == libc::S_IFLNK {
         libc::XATTR_NOFOLLOW
     } else {
@@ -349,32 +350,30 @@ fn set_xattr_stat(
 }
 
 fn stat_common(
+    _ctx: &Context,
     mut st: bindings::stat64,
     uid: Option<u32>,
     gid: Option<u32>,
     mode: Option<u32>,
-    host: bool,
 ) -> io::Result<bindings::stat64> {
-    if !host {
-        if let Some(uid) = uid {
-            st.st_uid = uid;
-        }
-        if let Some(gid) = gid {
-            st.st_gid = gid;
-        }
-        if let Some(mode) = mode {
-            if mode as u16 & libc::S_IFMT == 0 {
-                st.st_mode = (st.st_mode & libc::S_IFMT) | mode as u16;
-            } else {
-                st.st_mode = mode as u16;
-            }
+    if let Some(uid) = uid {
+        st.st_uid = uid;
+    }
+    if let Some(gid) = gid {
+        st.st_gid = gid;
+    }
+    if let Some(mode) = mode {
+        if mode as u16 & libc::S_IFMT == 0 {
+            st.st_mode = (st.st_mode & libc::S_IFMT) | mode as u16;
+        } else {
+            st.st_mode = mode as u16;
         }
     }
 
     Ok(st)
 }
 
-fn fstat(fd: RawFd, host: bool) -> io::Result<bindings::stat64> {
+fn fstat(ctx: &Context, fd: RawFd, host: bool) -> io::Result<bindings::stat64> {
     let mut st = MaybeUninit::<bindings::stat64>::zeroed();
 
     // Safe because the kernel will only write data in `st` and we check the return
@@ -385,7 +384,7 @@ fn fstat(fd: RawFd, host: bool) -> io::Result<bindings::stat64> {
         let st = unsafe { st.assume_init() };
         if !host {
             let (uid, gid, mode) = get_xattr_fstat(fd, st)?;
-            stat_common(st, uid, gid, mode, host)
+            stat_common(ctx, st, uid, gid, mode)
         } else {
             Ok(st)
         }
@@ -394,7 +393,7 @@ fn fstat(fd: RawFd, host: bool) -> io::Result<bindings::stat64> {
     }
 }
 
-fn lstat(c_path: &CString, host: bool) -> io::Result<bindings::stat64> {
+fn lstat(ctx: &Context, c_path: &CString, host: bool) -> io::Result<bindings::stat64> {
     let mut st = MaybeUninit::<bindings::stat64>::zeroed();
 
     // Safe because the kernel will only write data in `st` and we check the return
@@ -405,7 +404,7 @@ fn lstat(c_path: &CString, host: bool) -> io::Result<bindings::stat64> {
         let st = unsafe { st.assume_init() };
         if !host {
             let (uid, gid, mode) = get_xattr_lstat(c_path, st)?;
-            stat_common(st, uid, gid, mode, host)
+            stat_common(ctx, st, uid, gid, mode)
         } else {
             Ok(st)
         }
@@ -414,10 +413,10 @@ fn lstat(c_path: &CString, host: bool) -> io::Result<bindings::stat64> {
     }
 }
 
-fn istat(ihandle: &InodeHandle, host: bool) -> io::Result<bindings::stat64> {
+fn istat(ctx: &Context, ihandle: &InodeHandle, host: bool) -> io::Result<bindings::stat64> {
     match ihandle {
-        InodeHandle::Fd(fd) => fstat(*fd, host),
-        InodeHandle::Path(c_path) => lstat(c_path, host),
+        InodeHandle::Fd(fd) => fstat(ctx, *fd, host),
+        InodeHandle::Path(c_path) => lstat(ctx, c_path, host),
     }
 }
 
@@ -751,6 +750,7 @@ impl PassthroughFs {
 
     fn do_open(
         &self,
+        ctx: &Context,
         inode: Inode,
         kill_priv: bool,
         flags: u32,
@@ -766,10 +766,10 @@ impl PassthroughFs {
 
             remove_security_capability(&ihandle);
 
-            if let Ok(st) = fstat(fd, false) {
+            if let Ok(st) = fstat(ctx, fd, false) {
                 let new_mode = clear_suid_sgid(st.st_mode as u32);
                 if new_mode != st.st_mode as u32
-                    && let Err(err) = set_xattr_stat(&ihandle, Some(st), None, Some(new_mode))
+                    && let Err(err) = set_xattr_stat(ctx, &ihandle, Some(st), None, Some(new_mode))
                 {
                     error!("Couldn't clear suid/sgid for inode {inode}: {err}");
                 }
@@ -817,11 +817,11 @@ impl PassthroughFs {
         Err(ebadf())
     }
 
-    fn do_getattr(&self, inode: Inode) -> io::Result<(bindings::stat64, Duration)> {
+    fn do_getattr(&self, ctx: &Context, inode: Inode) -> io::Result<(bindings::stat64, Duration)> {
         let ihandle = self.inode_to_handle(inode, true)?;
         let st = match ihandle {
-            InodeHandle::Path(c_path) => lstat(&c_path, false)?,
-            InodeHandle::Fd(fd) => fstat(fd, false)?,
+            InodeHandle::Path(c_path) => lstat(ctx, &c_path, false)?,
+            InodeHandle::Fd(fd) => fstat(ctx, fd, false)?,
         };
 
         Ok((st, self.cfg.attr_timeout))
@@ -836,8 +836,8 @@ impl PassthroughFs {
         Ok(fd)
     }
 
-    fn store_unlinked_fd(&self, unlinked_fd: RawFd) -> io::Result<bool> {
-        let st = fstat(unlinked_fd, true)?;
+    fn store_unlinked_fd(&self, ctx: &Context, unlinked_fd: RawFd) -> io::Result<bool> {
+        let st = fstat(ctx, unlinked_fd, true)?;
         let altkey = InodeAltKey {
             ino: st.st_ino,
             dev: st.st_dev,
@@ -865,7 +865,7 @@ impl PassthroughFs {
 
     fn do_unlink(
         &self,
-        _ctx: Context,
+        ctx: Context,
         parent: Inode,
         name: &CStr,
         flags: libc::c_int,
@@ -909,7 +909,7 @@ impl PassthroughFs {
 
         if res == 0 {
             if let Some(unlinked_fd) = unlinked_fd {
-                match self.store_unlinked_fd(unlinked_fd) {
+                match self.store_unlinked_fd(&ctx, unlinked_fd) {
                     // The tracked inode took ownership of the fd.
                     Ok(true) => {}
                     // No tracked inode: we still own the fd and must close it.
@@ -1093,7 +1093,14 @@ impl FileSystem for PassthroughFs {
         // Safe because we just opened this fd above.
         let f = unsafe { File::from_raw_fd(fd) };
 
-        let st = fstat(f.as_raw_fd(), true)?;
+        // Build a fake Context for fstat, it won't be using it anyways
+        // as it'll be only looking at the host's bits.
+        let ctx = Context {
+            uid: 0,
+            gid: 0,
+            pid: 0,
+        };
+        let st = fstat(&ctx, f.as_raw_fd(), true)?;
 
         // Safe because this doesn't modify any memory and there is no need to check the return
         // value because this system call always succeeds. We need to clear the umask here because
@@ -1154,7 +1161,7 @@ impl FileSystem for PassthroughFs {
         }
     }
 
-    fn lookup(&self, _ctx: Context, parent: Inode, name: &CStr) -> io::Result<Entry> {
+    fn lookup(&self, ctx: Context, parent: Inode, name: &CStr) -> io::Result<Entry> {
         let parent_data = self
             .inodes
             .read()
@@ -1164,7 +1171,7 @@ impl FileSystem for PassthroughFs {
             .ok_or_else(ebadf)?;
 
         let c_path = self.name_to_path(parent, name)?;
-        let st = lstat(&c_path, false)?;
+        let st = lstat(&ctx, &c_path, false)?;
 
         debug!(
             "lookup: inode={} path={}",
@@ -1240,11 +1247,11 @@ impl FileSystem for PassthroughFs {
 
     fn opendir(
         &self,
-        _ctx: Context,
+        ctx: Context,
         inode: Inode,
         flags: u32,
     ) -> io::Result<(Option<Handle>, OpenOptions)> {
-        self.do_open(inode, false, flags | libc::O_DIRECTORY as u32)
+        self.do_open(&ctx, inode, false, flags | libc::O_DIRECTORY as u32)
     }
 
     fn releasedir(
@@ -1278,6 +1285,7 @@ impl FileSystem for PassthroughFs {
             };
 
             set_xattr_stat(
+                &ctx,
                 &ihandle,
                 None,
                 Some((ctx.uid, ctx.gid)),
@@ -1336,12 +1344,12 @@ impl FileSystem for PassthroughFs {
 
     fn open(
         &self,
-        _ctx: Context,
+        ctx: Context,
         inode: Inode,
         kill_priv: bool,
         flags: u32,
     ) -> io::Result<(Option<Handle>, OpenOptions)> {
-        self.do_open(inode, kill_priv, flags)
+        self.do_open(&ctx, inode, kill_priv, flags)
     }
 
     fn release(
@@ -1393,6 +1401,7 @@ impl FileSystem for PassthroughFs {
         let ihandle = InodeHandle::Fd(fd);
 
         if let Err(e) = set_xattr_stat(
+            &ctx,
             &ihandle,
             None,
             Some((ctx.uid, ctx.gid)),
@@ -1471,7 +1480,7 @@ impl FileSystem for PassthroughFs {
 
     fn write<R: io::Read + ZeroCopyReader>(
         &self,
-        _ctx: Context,
+        ctx: Context,
         inode: Inode,
         handle: Handle,
         mut r: R,
@@ -1503,11 +1512,12 @@ impl FileSystem for PassthroughFs {
 
             remove_security_capability(&ihandle);
 
-            if let Ok(st) = fstat(fd, false) {
+            if let Ok(st) = fstat(&ctx, fd, false) {
                 let new_mode = clear_suid_sgid(st.st_mode as u32);
                 if new_mode != st.st_mode as u32 {
                     // Update mode in xattr
-                    if let Err(err) = set_xattr_stat(&ihandle, Some(st), None, Some(new_mode)) {
+                    if let Err(err) = set_xattr_stat(&ctx, &ihandle, Some(st), None, Some(new_mode))
+                    {
                         error!("Couldn't clear suid/sgid for inode {inode}: {err}");
                     }
                 }
@@ -1519,16 +1529,16 @@ impl FileSystem for PassthroughFs {
 
     fn getattr(
         &self,
-        _ctx: Context,
+        ctx: Context,
         inode: Inode,
         _handle: Option<Handle>,
     ) -> io::Result<(bindings::stat64, Duration)> {
-        self.do_getattr(inode)
+        self.do_getattr(&ctx, inode)
     }
 
     fn setattr(
         &self,
-        _ctx: Context,
+        ctx: Context,
         inode: Inode,
         attr: bindings::stat64,
         handle: Option<Handle>,
@@ -1552,7 +1562,7 @@ impl FileSystem for PassthroughFs {
         };
 
         if valid.contains(SetattrValid::MODE) {
-            set_xattr_stat(&ihandle, None, None, Some(attr.st_mode as u32))?
+            set_xattr_stat(&ctx, &ihandle, None, None, Some(attr.st_mode as u32))?
         }
 
         if valid.intersects(SetattrValid::UID | SetattrValid::GID) {
@@ -1570,7 +1580,7 @@ impl FileSystem for PassthroughFs {
             };
 
             remove_security_capability(&ihandle);
-            let st = istat(&ihandle, false)?;
+            let st = istat(&ctx, &ihandle, false)?;
 
             // Clear suid/sgid if UID or GID is being changed
             let new_mode = clear_suid_sgid(st.st_mode as u32);
@@ -1579,7 +1589,7 @@ impl FileSystem for PassthroughFs {
             } else {
                 None
             };
-            set_xattr_stat(&ihandle, Some(st), Some((uid, gid)), new_mode)?;
+            set_xattr_stat(&ctx, &ihandle, Some(st), Some((uid, gid)), new_mode)?;
         }
 
         if valid.contains(SetattrValid::SIZE) {
@@ -1593,10 +1603,10 @@ impl FileSystem for PassthroughFs {
 
                     // Clear security.capability on truncate unconditionally
                     remove_security_capability(&ihandle);
-                    let st = fstat(fd, false)?;
+                    let st = fstat(&ctx, fd, false)?;
                     let new_mode = clear_suid_sgid(st.st_mode as u32);
                     if new_mode != st.st_mode as u32 {
-                        set_xattr_stat(&ihandle, Some(st), None, Some(new_mode))?;
+                        set_xattr_stat(&ctx, &ihandle, Some(st), None, Some(new_mode))?;
                     }
                 }
                 InodeHandle::Path(_) => {
@@ -1613,10 +1623,10 @@ impl FileSystem for PassthroughFs {
                     // reuse the FD we just opened, thus reducing the number of syscalls.
                     let ihandle = InodeHandle::Fd(f.as_raw_fd());
                     remove_security_capability(&ihandle);
-                    let st = istat(&ihandle, false)?;
+                    let st = istat(&ctx, &ihandle, false)?;
                     let new_mode = clear_suid_sgid(st.st_mode as u32);
                     if new_mode != st.st_mode as u32 {
-                        set_xattr_stat(&ihandle, Some(st), None, Some(new_mode))?;
+                        set_xattr_stat(&ctx, &ihandle, Some(st), None, Some(new_mode))?;
                     }
                 }
             };
@@ -1663,7 +1673,7 @@ impl FileSystem for PassthroughFs {
             }
         }
 
-        self.do_getattr(inode)
+        self.do_getattr(&ctx, inode)
     }
 
     fn rename(
@@ -1736,7 +1746,7 @@ impl FileSystem for PassthroughFs {
             // `store_unlinked_fd` takes ownership only when that inode is
             // tracked; close the fd ourselves otherwise so it is never leaked.
             if let Some(fd) = doomed_fd {
-                match self.store_unlinked_fd(fd) {
+                match self.store_unlinked_fd(&ctx, fd) {
                     Ok(true) => {}
                     Ok(false) | Err(_) => unsafe {
                         libc::close(fd);
@@ -1754,6 +1764,7 @@ impl FileSystem for PassthroughFs {
                 };
                 if fd > 0 {
                     if let Err(e) = set_xattr_stat(
+                        &ctx,
                         &InodeHandle::Fd(fd),
                         None,
                         None,
@@ -1809,6 +1820,7 @@ impl FileSystem for PassthroughFs {
             };
 
             if let Err(e) = set_xattr_stat(
+                &ctx,
                 &ihandle,
                 None,
                 Some((ctx.uid, ctx.gid)),
@@ -1867,7 +1879,13 @@ impl FileSystem for PassthroughFs {
 
             let mut entry = self.lookup(ctx, parent, name)?;
             let mode = libc::S_IFLNK | 0o777;
-            set_xattr_stat(&ihandle, None, Some((ctx.uid, ctx.gid)), Some(mode as u32))?;
+            set_xattr_stat(
+                &ctx,
+                &ihandle,
+                None,
+                Some((ctx.uid, ctx.gid)),
+                Some(mode as u32),
+            )?;
             entry.attr.st_uid = ctx.uid;
             entry.attr.st_gid = ctx.gid;
             entry.attr.st_mode = mode;
@@ -1973,8 +1991,8 @@ impl FileSystem for PassthroughFs {
 
     fn access(&self, ctx: Context, inode: Inode, mask: u32) -> io::Result<()> {
         let st = match self.inode_to_handle(inode, true)? {
-            InodeHandle::Path(c_path) => lstat(&c_path, false)?,
-            InodeHandle::Fd(fd) => fstat(fd, false)?,
+            InodeHandle::Path(c_path) => lstat(&ctx, &c_path, false)?,
+            InodeHandle::Fd(fd) => fstat(&ctx, fd, false)?,
         };
 
         let mode = mask as i32 & (libc::R_OK | libc::W_OK | libc::X_OK);
@@ -2242,7 +2260,7 @@ impl FileSystem for PassthroughFs {
 
     fn fallocate(
         &self,
-        _ctx: Context,
+        ctx: Context,
         inode: Inode,
         handle: Handle,
         mode: u32,
@@ -2280,7 +2298,7 @@ impl FileSystem for PassthroughFs {
                 // The best thing we can do here is extend the file to (offset + length).
                 // This doesn't adhere to the same semantics, but should work fine (albeit
                 // less performant) for most guest applications.
-                let st = fstat(fd, true)?;
+                let st = fstat(&ctx, fd, true)?;
                 let new_length = (offset + length) as i64;
 
                 if keep_size {

--- a/src/devices/src/virtio/fs/server.rs
+++ b/src/devices/src/virtio/fs/server.rs
@@ -86,6 +86,7 @@ impl<F: FileSystem + Sync> Server<F> {
         &self,
         mut r: Reader,
         w: Writer,
+        allow_idmap: bool,
         shm_region: &Option<VirtioShmRegion>,
         exit_code: &Arc<AtomicI32>,
         #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
@@ -124,7 +125,7 @@ impl<F: FileSystem + Sync> Server<F> {
             x if x == Opcode::Listxattr as u32 => self.listxattr(in_header, r, w),
             x if x == Opcode::Removexattr as u32 => self.removexattr(in_header, r, w),
             x if x == Opcode::Flush as u32 => self.flush(in_header, r, w),
-            x if x == Opcode::Init as u32 => self.init(in_header, r, w),
+            x if x == Opcode::Init as u32 => self.init(in_header, r, w, allow_idmap),
             x if x == Opcode::Opendir as u32 => self.opendir(in_header, r, w),
             x if x == Opcode::Readdir as u32 => self.readdir(in_header, r, w),
             x if x == Opcode::Releasedir as u32 => self.releasedir(in_header, r, w),
@@ -842,7 +843,13 @@ impl<F: FileSystem + Sync> Server<F> {
         }
     }
 
-    fn init(&self, in_header: InHeader, mut r: Reader, w: Writer) -> Result<usize> {
+    fn init(
+        &self,
+        in_header: InHeader,
+        mut r: Reader,
+        w: Writer,
+        allow_idmap: bool,
+    ) -> Result<usize> {
         let InitInCompat {
             major,
             minor,
@@ -898,8 +905,11 @@ impl<F: FileSystem + Sync> Server<F> {
             | FsOptions::MAX_PAGES
             | FsOptions::SUBMOUNTS
             | FsOptions::HANDLE_KILLPRIV_V2
-            | FsOptions::INIT_EXT
-            | FsOptions::ALLOW_IDMAP;
+            | FsOptions::INIT_EXT;
+
+        if allow_idmap {
+            supported |= FsOptions::ALLOW_IDMAP;
+        }
 
         if cfg!(target_os = "macos") {
             supported |= FsOptions::SECURITY_CTX;

--- a/src/devices/src/virtio/fs/worker.rs
+++ b/src/devices/src/virtio/fs/worker.rs
@@ -39,6 +39,7 @@ impl FsServer {
         &self,
         r: Reader,
         w: Writer,
+        allow_idmap: bool,
         shm_region: &Option<VirtioShmRegion>,
         exit_code: &Arc<AtomicI32>,
         #[cfg(target_os = "macos")] map_sender: &Option<Sender<WorkerMessage>>,
@@ -47,6 +48,7 @@ impl FsServer {
             FsServer::ReadWrite(s) => s.handle_message(
                 r,
                 w,
+                allow_idmap,
                 shm_region,
                 exit_code,
                 #[cfg(target_os = "macos")]
@@ -55,6 +57,7 @@ impl FsServer {
             FsServer::ReadOnly(s) => s.handle_message(
                 r,
                 w,
+                allow_idmap,
                 shm_region,
                 exit_code,
                 #[cfg(target_os = "macos")]
@@ -63,6 +66,7 @@ impl FsServer {
             FsServer::Null(s) => s.handle_message(
                 r,
                 w,
+                allow_idmap,
                 shm_region,
                 exit_code,
                 #[cfg(target_os = "macos")]
@@ -77,6 +81,7 @@ pub struct FsWorker {
     queue_evts: Vec<Arc<EventFd>>,
     interrupt: InterruptTransport,
     mem: GuestMemoryMmap,
+    allow_idmap: bool,
     shm_region: Option<VirtioShmRegion>,
     server: FsServer,
     stop_fd: EventFd,
@@ -92,6 +97,7 @@ impl FsWorker {
         queue_evts: Vec<Arc<EventFd>>,
         interrupt: InterruptTransport,
         mem: GuestMemoryMmap,
+        allow_idmap: bool,
         shm_region: Option<VirtioShmRegion>,
         passthrough_cfg: Option<passthrough::Config>,
         read_only: bool,
@@ -129,6 +135,7 @@ impl FsWorker {
             queue_evts,
             interrupt,
             mem,
+            allow_idmap,
             shm_region,
             server,
             stop_fd,
@@ -237,6 +244,7 @@ impl FsWorker {
             let len = match self.server.handle_message(
                 reader,
                 writer,
+                self.allow_idmap,
                 &self.shm_region,
                 &self.exit_code,
                 #[cfg(target_os = "macos")]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -58,6 +58,8 @@ use devices::legacy::{IoApic, IrqChipT};
 use devices::legacy::{IrqChip, IrqChipDevice};
 #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 use devices::legacy::{KvmGicV2, KvmGicV3};
+#[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
+use devices::virtio::passthrough::PermissionSemantics;
 use devices::virtio::{MmioTransport, PortDescription, VirtioDevice, Vsock, port_io};
 
 #[cfg(feature = "tee")]
@@ -2132,6 +2134,7 @@ fn attach_fs_devices(
         let fs = Arc::new(Mutex::new(
             devices::virtio::Fs::new(
                 config.fs_id.clone(),
+                PermissionSemantics::LinuxComplete,
                 config.shared_dir.clone(),
                 exit_code.clone(),
                 config.read_only,


### PR DESCRIPTION
So far, we were always trying to be as close as possible to the common
Linux file system semantics. But, there are certain scenarios (namely,
acting as a container volume) in which simplified semantics may be
preferable.

To address that need, let's introduce configurable permission semantics,
with two initial modes: LinuxComplete and LinuxSimplified. The first is
exactly the same we had until 1.18.0. The second, is a simplified
version with this differences:

- Idmaps are not supported.
- Ownership bits are ignored, always returning the uid/gid from the
  process requesting the operation within the guest (obtained from
  `Context`).
- Permissions bits are stored in the host, no as extended attributes.