### PR TITLE
AGENTS.md: ask agents to add fewer comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,7 @@ Features are additive and controlled at the `libkrun` crate level. Each device f
 - Commit messages should be concise and written in the imperative mood. Small, focused commits are preferred.
 
 ### Rust coding style
+- Code must be self-explanatory and the main source of reference. Do not write comments unless the code is counter-intuitive and cannot be clarified through better naming or structure. When a comment is necessary, it must explain *why*, never *what*.
 - No error handling for impossible scenarios.
 - Avoid checking for empty input when calling a function if the function already handles the base case well (e.g. empty input is noop).
 - Use `use` imports instead of inline full paths. One level of qualitifation is fine when it clarifies what something is (e.g., `log::trace!`, `fs::read_to_string()`), but don't use longer paths like `std::process::Command::new(...)` or `crate::foo::bar::baz()` -- import with `use` instead.


### PR DESCRIPTION
As a reviewer, I've been fooled a couple times by comments in code that provided a convincing explanation, but were ultimately wrong.

Let's ask agents to use the same policy we use for humans: code must be self-explanatory and the main source of reference. Only counter-intuitive code should be commented.

This should help reviewers to be less distracted by the comments and focus on the actual code produced by the agents.