### PR TITLE
virtio/fs/macos: fix rename whiteout case

### DIFF
--- a/src/devices/src/virtio/fs/linux/passthrough.rs
+++ b/src/devices/src/virtio/fs/linux/passthrough.rs
@@ -292,7 +292,7 @@ pub enum PermissionSemantics {
     ///  - Idmaps are not supported.
     ///  - Ownership bits are ignored, always returning the uid/gid from the process
     ///    requesting the operation within the guest (obtained from `Context`).
-    ///  - Permissions bits are stored in the host, no as extended attributes.
+    ///  - Permissions bits are stored in the host, not as extended attributes.
     LinuxSimplified,
 }
 

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -538,7 +538,7 @@ pub enum PermissionSemantics {
     ///  - Idmaps are not supported.
     ///  - Ownership bits are ignored, always returning the uid/gid from the process
     ///    requesting the operation within the guest (obtained from `Context`).
-    ///  - Permissions bits are stored in the host, no as extended attributes.
+    ///  - Permissions bits are stored in the host, not as extended attributes.
     LinuxSimplified,
 }
 

--- a/src/devices/src/virtio/fs/macos/passthrough.rs
+++ b/src/devices/src/virtio/fs/macos/passthrough.rs
@@ -2001,7 +2001,7 @@ impl FileSystem for PassthroughFs {
                 let (host_mode, complete) = match self.cfg.semantics {
                     PermissionSemantics::LinuxComplete => (0o600, true),
                     PermissionSemantics::LinuxSimplified => {
-                        (((libc::S_IFCHR | 0o600) as u32), true)
+                        (((libc::S_IFCHR | 0o600) as u32), false)
                     }
                 };
                 let fd = unsafe {


### PR DESCRIPTION
If we're using simplified semantics, we don't need to write the permission and ownership bits.