### PR TITLE
vmm,hvf,libkrun: add krun_vm_pause / krun_vm_resume

### DIFF
--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -1300,6 +1300,42 @@ int32_t krun_set_root_disk_remount(uint32_t ctx_id, const char *device, const ch
  */
 int32_t krun_start_enter(uint32_t ctx_id);
 
+/**
+ * Pause a running VM: freeze every vCPU at an instruction boundary. Thread-safe
+ * and out-of-band -- call it from a thread other than the one blocked in
+ * krun_start_enter(). The freeze completes asynchronously in the VM's event
+ * loop; this returns as soon as the request is signalled. Idempotent. Device
+ * worker threads are notification-driven, so they idle on their own while the
+ * guest is frozen. Currently macOS/HVF only; returns -ENOTSUP elsewhere.
+ *
+ * Arguments:
+ *  "ctx_id" - the configuration context ID of the running VM.
+ *
+ * Returns:
+ *  0        - the pause request was signalled.
+ *  -ENOENT  - no running VM is registered for this ctx_id.
+ *  -EIO     - failed to signal the VM.
+ *  -ENOTSUP - pause is unsupported on this platform.
+ */
+int32_t krun_vm_pause(uint32_t ctx_id);
+
+/**
+ * Resume a VM previously paused with krun_vm_pause(). The guest's virtual timer
+ * is advanced by the time spent paused so armed timers do not fire en masse on
+ * wake. Thread-safe, out-of-band, and idempotent. Currently macOS/HVF only;
+ * returns -ENOTSUP elsewhere.
+ *
+ * Arguments:
+ *  "ctx_id" - the configuration context ID of the paused VM.
+ *
+ * Returns:
+ *  0        - the resume request was signalled.
+ *  -ENOENT  - no running VM is registered for this ctx_id.
+ *  -EIO     - failed to signal the VM.
+ *  -ENOTSUP - resume is unsupported on this platform.
+ */
+int32_t krun_vm_resume(uint32_t ctx_id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/hvf/src/lib.rs
+++ b/src/hvf/src/lib.rs
@@ -16,6 +16,7 @@ use bindings::*;
 
 #[cfg(target_arch = "aarch64")]
 use std::arch::asm;
+use std::cell::Cell;
 
 use std::convert::TryInto;
 use std::fmt::{Display, Formatter};
@@ -328,6 +329,9 @@ pub struct HvfVcpu<'a> {
     pending_advance_pc: bool,
     vtimer_masked: bool,
     nested_enabled: bool,
+    // Cached copy of the HVF vtimer offset (0 until a live pause advances it),
+    // so the WFE deadline check doesn't issue a syscall on every wait.
+    vtimer_offset: Cell<u64>,
 }
 
 impl HvfVcpu<'_> {
@@ -375,6 +379,7 @@ impl HvfVcpu<'_> {
             pending_advance_pc: false,
             vtimer_masked: false,
             nested_enabled,
+            vtimer_offset: Cell::new(0),
         })
     }
 
@@ -504,6 +509,22 @@ impl HvfVcpu<'_> {
         } else {
             Ok(val)
         }
+    }
+
+    /// Freeze the guest's CNTVCT across a live pause. The guest virtual counter
+    /// is `mach_absolute_time() - vtimer_offset`; while paused the host counter
+    /// keeps advancing, so on resume we add the ticks spent paused to the offset.
+    /// The guest's counter then resumes where it stopped and armed deadlines stay
+    /// in the near future instead of firing en masse to catch up the gap.
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    pub fn advance_vtimer_offset(&self, paused_ticks: u64) -> Result<(), Error> {
+        let offset = self.vtimer_offset.get().wrapping_add(paused_ticks);
+        let ret = unsafe { hv_vcpu_set_vtimer_offset(self.vcpuid, offset) };
+        if ret != HV_SUCCESS {
+            return Err(Error::VcpuSetRegister);
+        }
+        self.vtimer_offset.set(offset);
+        Ok(())
     }
 
     fn hvf_sync_vtimer(&mut self, vcpu_list: Arc<dyn Vcpus>) {
@@ -712,7 +733,15 @@ impl HvfVcpu<'_> {
 
                 // Also CNTV_CVAL & CNTV_CVAL_EL0
                 let cval = self.read_sys_reg(hv_sys_reg_t_HV_SYS_REG_CNTV_CVAL_EL0)?;
-                let now = unsafe { mach_absolute_time() };
+                // The guest's deadline `cval` is in the CNTVCT domain, where
+                // CNTVCT = mach_absolute_time() - vtimer_offset. The offset is 0
+                // on a fresh boot but nonzero after a live pause (it keeps CNTVCT
+                // continuous across the paused interval). Compare against the
+                // corrected counter, not raw mach time — otherwise after a pause
+                // `now` runs ahead of every armed deadline and the vCPU busy-loops
+                // on WaitForEventExpired instead of parking, so the guest's virtual
+                // timer never fires and timed sleeps hang.
+                let now = unsafe { mach_absolute_time() }.saturating_sub(self.vtimer_offset.get());
                 if now > cval {
                     return Ok(VcpuExit::WaitForEventExpired);
                 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -39,10 +39,14 @@ use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicI32, Ordering};
 use utils::eventfd::EventFd;
+#[cfg(target_os = "macos")]
+use utils::pollable_channel::PollableChannelSender;
 #[cfg(target_os = "windows")]
 use utils::windows::AsRawFd;
 #[cfg(target_os = "windows")]
 use utils::windows::SendHandle;
+#[cfg(target_os = "macos")]
+use vmm::VmCtl;
 use vmm::resources::{
     DefaultVirtioConsoleConfig, PortConfig, SerialConsoleConfig, TsiFlags, VirtioConsoleConfigMode,
     VmResources, VsockConfig,
@@ -425,6 +429,13 @@ fn with_cfg(ctx_id: u32, f: impl FnOnce(&mut ContextConfig) -> i32) -> i32 {
 
 static CTX_MAP: Lazy<Mutex<HashMap<u32, ContextConfig>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 static CTX_IDS: AtomicI32 = AtomicI32::new(0);
+
+/// Out-of-band control channel for running VMs, keyed by ctx id. Populated by
+/// `krun_start_enter` for every macOS VM so `krun_vm_pause` / `krun_vm_resume`
+/// can reach it from another thread.
+#[cfg(target_os = "macos")]
+static VM_CTL: Lazy<Mutex<HashMap<u32, PollableChannelSender<VmCtl>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 fn log_level_to_filter_str(level: u32) -> &'static str {
     match level {
@@ -2965,6 +2976,14 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
     #[cfg(any(feature = "amd-sev", feature = "tdx"))]
     vmm::worker::start_worker_thread(_vmm.clone(), _receiver.clone()).unwrap();
 
+    // Register the control channel for every macOS VM so another thread can
+    // freeze/wake this guest while `krun_start_enter` blocks here.
+    #[cfg(target_os = "macos")]
+    VM_CTL
+        .lock()
+        .unwrap()
+        .insert(ctx_id, _vmm.lock().unwrap().vm_ctl_sender());
+
     loop {
         match event_manager.run() {
             Ok(_) => {}
@@ -2974,6 +2993,51 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
             }
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+fn send_vm_ctl(ctx_id: u32, req: VmCtl) -> i32 {
+    let map = VM_CTL.lock().unwrap();
+    let Some(tx) = map.get(&ctx_id) else {
+        return -libc::ENOENT;
+    };
+    if let Err(e) = tx.send(req) {
+        error!("Failed to send vm control request: {e:?}");
+        return -libc::EIO;
+    }
+    KRUN_SUCCESS
+}
+
+/// Thread-safe out-of-band freeze of a VM running under `krun_start_enter` on
+/// another thread: every vCPU stops at an instruction boundary. Returns once the
+/// request is signalled (the freeze completes asynchronously in the VM's event
+/// loop). Idempotent. Device worker threads are notify-driven, so they idle on
+/// their own while the guest is frozen.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub extern "C" fn krun_vm_pause(ctx_id: u32) -> i32 {
+    send_vm_ctl(ctx_id, VmCtl::Pause)
+}
+
+/// Thread-safe out-of-band wake of a VM previously frozen with `krun_vm_pause`.
+/// The guest's virtual timer is advanced by the time spent paused so armed
+/// timers don't fire en masse. Idempotent.
+#[cfg(target_os = "macos")]
+#[unsafe(no_mangle)]
+pub extern "C" fn krun_vm_resume(ctx_id: u32) -> i32 {
+    send_vm_ctl(ctx_id, VmCtl::Resume)
+}
+
+#[cfg(not(target_os = "macos"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn krun_vm_pause(_ctx_id: u32) -> i32 {
+    -libc::ENOTSUP
+}
+
+#[cfg(not(target_os = "macos"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn krun_vm_resume(_ctx_id: u32) -> i32 {
+    -libc::ENOTSUP
 }
 
 #[cfg(feature = "aws-nitro")]

--- a/src/utils/src/macos/eventfd.rs
+++ b/src/utils/src/macos/eventfd.rs
@@ -38,7 +38,7 @@ impl EventFd {
     pub fn new(flag: i32) -> result::Result<EventFd, io::Error> {
         let (read_fd, write_fd) = pipe()?;
 
-        if flag == EFD_NONBLOCK {
+        if flag & EFD_NONBLOCK != 0 {
             set_nonblock(&read_fd)?;
             set_nonblock(&write_fd)?;
         }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -988,6 +988,11 @@ pub fn build_microvm(
     // We use this atomic to record the exit code set by init/init.c in the VM.
     let exit_code = Arc::new(AtomicI32::new(i32::MAX));
 
+    #[cfg(target_os = "macos")]
+    let (vm_ctl_tx, vm_ctl_rx) = utils::pollable_channel::pollable_channel()
+        .map_err(Error::EventFd)
+        .map_err(StartMicrovmError::Internal)?;
+
     let mut vmm = Vmm {
         guest_memory,
         arch_memory_info,
@@ -1000,6 +1005,14 @@ pub fn build_microvm(
         mmio_device_manager,
         #[cfg(target_arch = "x86_64")]
         pio_device_manager,
+        #[cfg(target_os = "macos")]
+        vm_ctl_tx,
+        #[cfg(target_os = "macos")]
+        vm_ctl_rx,
+        #[cfg(target_os = "macos")]
+        paused: false,
+        #[cfg(target_os = "macos")]
+        paused_at: 0,
     };
 
     // Set raw mode for FDs that are connected to legacy serial devices.

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -63,6 +63,8 @@ use kernel::cmdline::Cmdline as KernelCmdline;
 use polly::event_manager::{self, EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};
 use utils::eventfd::EventFd;
+#[cfg(target_os = "macos")]
+use utils::pollable_channel::{PollableChannelReciever, PollableChannelSender};
 use vm_memory::GuestMemoryMmap;
 
 /// Success exit code.
@@ -209,6 +211,29 @@ pub struct Vmm {
     mmio_device_manager: MMIODeviceManager,
     #[cfg(target_arch = "x86_64")]
     pio_device_manager: PortIODeviceManager,
+
+    // Out-of-band live pause/resume requests: the C API sends `VmCtl` from
+    // another thread; the event loop freezes or wakes the vCPUs. A single
+    // channel rather than one eventfd per operation, so the event loop observes
+    // the requests in the order they were made. Device worker threads are
+    // notify-driven, so a frozen guest leaves them idle without explicit
+    // handling.
+    #[cfg(target_os = "macos")]
+    vm_ctl_tx: PollableChannelSender<VmCtl>,
+    #[cfg(target_os = "macos")]
+    vm_ctl_rx: PollableChannelReciever<VmCtl>,
+    #[cfg(target_os = "macos")]
+    paused: bool,
+    #[cfg(target_os = "macos")]
+    paused_at: u64,
+}
+
+/// Out-of-band request to the running VM's event loop.
+#[cfg(target_os = "macos")]
+#[derive(Debug, Clone)]
+pub enum VmCtl {
+    Pause,
+    Resume,
 }
 
 impl Vmm {
@@ -264,6 +289,64 @@ impl Vmm {
 
     #[cfg(target_os = "macos")]
     pub fn resume_vcpus(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Sender for live [`VmCtl`] requests. The event loop runs [`Vmm::pause`] /
+    /// [`Vmm::resume`] in response.
+    #[cfg(target_os = "macos")]
+    pub fn vm_ctl_sender(&self) -> PollableChannelSender<VmCtl> {
+        self.vm_ctl_tx.clone()
+    }
+
+    /// Freeze every vCPU at an instruction boundary. Reversible via [`Vmm::resume`];
+    /// the guest's virtual counter is held so timers don't fire en masse on wake.
+    /// Idempotent: pausing an already-paused VM is a no-op.
+    #[cfg(target_os = "macos")]
+    pub fn pause(&mut self) -> std::result::Result<(), String> {
+        use crate::vstate::{VcpuEvent, VcpuResponse};
+        if self.paused {
+            return Ok(());
+        }
+        for h in &self.vcpus_handles {
+            h.send_event(VcpuEvent::Pause)
+                .map_err(|e| format!("vcpu pause event: {e:?}"))?;
+            hvf::vcpu_request_exit(h.hvf_id()).map_err(|e| format!("vcpu_request_exit: {e:?}"))?;
+        }
+        for h in &self.vcpus_handles {
+            match h.response_receiver().recv() {
+                Ok(VcpuResponse::Paused) => {}
+                Ok(other) => return Err(format!("unexpected vcpu response: {other:?}")),
+                Err(e) => return Err(format!("vcpu response: {e:?}")),
+            }
+        }
+        self.paused_at = unsafe { hvf::mach_absolute_time() };
+        self.paused = true;
+        Ok(())
+    }
+
+    /// Wake every vCPU previously frozen by [`Vmm::pause`], advancing the vtimer
+    /// offset by the time spent paused. Idempotent: resuming a running VM is a
+    /// no-op.
+    #[cfg(target_os = "macos")]
+    pub fn resume(&mut self) -> std::result::Result<(), String> {
+        use crate::vstate::{VcpuEvent, VcpuResponse};
+        if !self.paused {
+            return Ok(());
+        }
+        let paused_ticks = unsafe { hvf::mach_absolute_time() }.saturating_sub(self.paused_at);
+        for h in &self.vcpus_handles {
+            h.send_event(VcpuEvent::Resume(paused_ticks))
+                .map_err(|e| format!("vcpu resume event: {e:?}"))?;
+        }
+        for h in &self.vcpus_handles {
+            match h.response_receiver().recv() {
+                Ok(VcpuResponse::Resumed) => {}
+                Ok(other) => return Err(format!("unexpected vcpu response: {other:?}")),
+                Err(e) => return Err(format!("vcpu response: {e:?}")),
+            }
+        }
+        self.paused = false;
         Ok(())
     }
 
@@ -404,6 +487,20 @@ impl Subscriber for Vmm {
         let source = event.fd();
         let event_set = event.event_set();
 
+        #[cfg(target_os = "macos")]
+        if source == self.vm_ctl_rx.as_raw_fd() && event_set == EventSet::IN {
+            while let Ok(Some(req)) = self.vm_ctl_rx.try_recv() {
+                let res = match req {
+                    VmCtl::Pause => self.pause(),
+                    VmCtl::Resume => self.resume(),
+                };
+                if let Err(e) = res {
+                    error!("vm {req:?} failed: {e}");
+                }
+            }
+            return;
+        }
+
         if source == self.exit_evt.as_raw_fd() && event_set == EventSet::IN {
             let _ = self.exit_evt.read();
             // Query each vcpu for the exit_code.
@@ -436,9 +533,17 @@ impl Subscriber for Vmm {
     }
 
     fn interest_list(&self) -> Vec<EpollEvent> {
-        vec![EpollEvent::new(
+        // `vm_ctl_rx` is pushed only on macOS, so `mut` is unused elsewhere.
+        #[allow(unused_mut)]
+        let mut list = vec![EpollEvent::new(
             EventSet::IN,
             self.exit_evt.as_raw_fd() as u64,
-        )]
+        )];
+        #[cfg(target_os = "macos")]
+        list.push(EpollEvent::new(
+            EventSet::IN,
+            self.vm_ctl_rx.as_raw_fd() as u64,
+        ));
+        list
     }
 }

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -18,7 +18,7 @@ use super::super::{FC_EXIT_CODE_GENERIC_ERROR, FC_EXIT_CODE_OK};
 use crate::vmm_config::machine_config::CpuFeaturesTemplate;
 
 use arch::ArchMemoryInfo;
-use crossbeam_channel::{Receiver, RecvTimeoutError, Sender, unbounded};
+use crossbeam_channel::{Receiver, Sender, after, select, unbounded};
 use devices::legacy::VcpuList;
 use hvf::{HvfVcpu, HvfVm, VcpuExit, Vcpus};
 use utils::eventfd::EventFd;
@@ -37,6 +37,8 @@ pub enum Error {
     REGSConfiguration(arch::aarch64::regs::Error),
     /// Cannot set the memory regions.
     SetUserMemoryRegion(hvf::Error),
+    /// The vCPU event channel was closed (the vCPU thread has exited).
+    VcpuChannelClosed,
     /// Failed to signal Vcpu.
     SignalVcpu(utils::errno::Error),
     /// Error doing Vcpu Init on Arm.
@@ -84,6 +86,7 @@ impl Display for Error {
             VcpuUnhandledKvmExit => write!(f, "Unexpected KVM_RUN exit reason"),
             VcpuArmPreferredTarget => write!(f, "Error getting the Vcpu preferred target on Arm"),
             VcpuArmInit => write!(f, "Error doing Vcpu Init on Arm"),
+            VcpuChannelClosed => write!(f, "vCPU event channel closed"),
         }
     }
 }
@@ -189,7 +192,6 @@ pub struct Vcpu {
     #[cfg(target_arch = "aarch64")]
     mpidr: u64,
 
-    #[allow(unused)]
     event_receiver: Receiver<VcpuEvent>,
     // The transmitting end of the events channel which will be given to the handler.
     event_sender: Option<Sender<VcpuEvent>>,
@@ -343,13 +345,14 @@ impl Vcpu {
             })
             .map_err(Error::VcpuSpawn)?;
 
-        init_tls_receiver
+        let hvf_id = init_tls_receiver
             .recv()
             .expect("Error waiting for TLS initialization.");
 
         Ok(VcpuHandle::new(
             event_sender,
             response_receiver,
+            hvf_id,
             vcpu_thread,
         ))
     }
@@ -435,13 +438,15 @@ impl Vcpu {
     }
 
     /// Main loop of the vCPU thread.
-    pub fn run(&mut self, init_tls_sender: Sender<bool>) {
+    pub fn run(&mut self, init_tls_sender: Sender<u64>) {
         let mut hvf_vcpu =
             HvfVcpu::new(self.mpidr, self.nested_enabled).expect("Can't create HVF vCPU");
         let hvf_vcpuid = hvf_vcpu.id();
 
+        // Report the HVF-assigned vCPU id (creation order is not deterministic)
+        // so the coordinator can break this vCPU out of HVF to pause it.
         init_tls_sender
-            .send(true)
+            .send(hvf_vcpuid)
             .expect("Cannot notify vcpu TLS initialization.");
 
         let (wfe_sender, wfe_receiver) = unbounded();
@@ -458,6 +463,12 @@ impl Vcpu {
             .unwrap_or_else(|_| panic!("Can't set HVF vCPU {hvf_vcpuid} initial state"));
 
         loop {
+            // An out-of-band pause request breaks the vCPU out of HVF via
+            // `vcpu_request_exit` (-> Canceled), so we observe it here between
+            // guest runs and freeze on this thread, where the HvfVcpu lives.
+            if let Ok(VcpuEvent::Pause) = self.event_receiver.try_recv() {
+                self.pause_and_park(&hvf_vcpu);
+            }
             match self.run_emulation(&mut hvf_vcpu) {
                 // Emulation ran successfully, continue.
                 Ok(VcpuEmulation::Handled) => (),
@@ -465,11 +476,11 @@ impl Vcpu {
                 Ok(VcpuEmulation::Interrupted) => self.wait_for_resume(),
                 // Wait for an external event.
                 Ok(VcpuEmulation::WaitForEvent) => {
-                    self.wait_for_event(hvf_vcpuid, &wfe_receiver, None)
+                    self.wait_for_event(hvf_vcpuid, &wfe_receiver, None, &hvf_vcpu)
                 }
                 Ok(VcpuEmulation::WaitForEventExpired) => (),
                 Ok(VcpuEmulation::WaitForEventTimeout(timeout)) => {
-                    self.wait_for_event(hvf_vcpuid, &wfe_receiver, Some(timeout))
+                    self.wait_for_event(hvf_vcpuid, &wfe_receiver, Some(timeout), &hvf_vcpu)
                 }
                 // The guest was rebooted or halted.
                 Ok(VcpuEmulation::Stopped) => {
@@ -485,28 +496,67 @@ impl Vcpu {
         }
     }
 
+    /// Park until woken by a device IRQ (`receiver`), the optional vtimer
+    /// `timeout`, or an out-of-band [`VcpuEvent::Pause`]. Watching the pause
+    /// channel here too is load-bearing: an idle vCPU blocks in this recv (not
+    /// in HVF), so `vcpu_request_exit` can't break it out — without this arm a
+    /// pause request would hang forever.
     fn wait_for_event(
         &mut self,
         hvf_vcpuid: u64,
         receiver: &Receiver<u32>,
         timeout: Option<Duration>,
+        hvf_vcpu: &HvfVcpu,
     ) {
-        if self.vcpu_list.should_wait(hvf_vcpuid) {
-            if let Some(timeout) = timeout {
-                match receiver.recv_timeout(timeout) {
-                    Ok(_) => {}
-                    Err(e) => match e {
-                        RecvTimeoutError::Timeout => {}
-                        RecvTimeoutError::Disconnected => panic!("WFE channel closed unexpectedly"),
-                    },
-                }
-            } else {
-                receiver.recv().unwrap();
+        if !self.vcpu_list.should_wait(hvf_vcpuid) {
+            return;
+        }
+        let paused = if let Some(timeout) = timeout {
+            select! {
+                recv(receiver) -> r => { r.expect("WFE channel closed unexpectedly"); false }
+                recv(self.event_receiver) -> ev => matches!(ev, Ok(VcpuEvent::Pause)),
+                recv(after(timeout)) -> _ => false,
             }
+        } else {
+            select! {
+                recv(receiver) -> r => { r.expect("WFE channel closed unexpectedly"); false }
+                recv(self.event_receiver) -> ev => matches!(ev, Ok(VcpuEvent::Pause)),
+            }
+        };
+        if paused {
+            self.pause_and_park(hvf_vcpu);
         }
     }
 
     fn wait_for_resume(&mut self) {}
+
+    /// Freeze this vCPU in response to a `Pause` event and block until `Resume`,
+    /// which carries the paused tick count. Advancing the vtimer offset by it
+    /// keeps the guest's CNTVCT continuous so armed timers don't fire en masse
+    /// to catch up the gap. The coordinator computes the tick count once for the
+    /// whole VM, so multi-vCPU offsets stay in lockstep.
+    fn pause_and_park(&mut self, hvf_vcpu: &HvfVcpu) {
+        self.response_sender
+            .send(VcpuResponse::Paused)
+            .expect("failed to send Paused status");
+        loop {
+            match self.event_receiver.recv() {
+                Ok(VcpuEvent::Resume(paused_ticks)) => {
+                    hvf_vcpu
+                        .advance_vtimer_offset(paused_ticks)
+                        .unwrap_or_else(|e| {
+                            panic!("vCPU {} vtimer advance failed: {e:?}", self.id)
+                        });
+                    self.response_sender
+                        .send(VcpuResponse::Resumed)
+                        .expect("failed to send Resumed status");
+                    return;
+                }
+                Ok(_) => {}
+                Err(_) => return,
+            }
+        }
+    }
 
     fn exit(&mut self, exit_code: u8) {
         self.response_sender
@@ -525,16 +575,15 @@ impl Drop for Vcpu {
     }
 }
 
-// Allow currently unused Pause and Exit events. These will be used by the vmm later on.
-#[allow(unused)]
 #[derive(Debug)]
 /// List of events that the Vcpu can receive.
 pub enum VcpuEvent {
     /// Pause the Vcpu.
     Pause,
-    /// Event that should resume the Vcpu.
-    Resume,
-    // Serialize and Deserialize to follow after we get the support from kvm-ioctls.
+    /// Resume the Vcpu, advancing its vtimer offset by this many host ticks
+    /// (the wall-clock time the VM spent paused). The coordinator sends the
+    /// same value to every vCPU so their counters stay synchronized.
+    Resume(u64),
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -552,35 +601,33 @@ pub enum VcpuResponse {
 pub struct VcpuHandle {
     event_sender: Sender<VcpuEvent>,
     response_receiver: Receiver<VcpuResponse>,
+    hvf_id: u64,
 }
 
 impl VcpuHandle {
     pub fn new(
         event_sender: Sender<VcpuEvent>,
         response_receiver: Receiver<VcpuResponse>,
+        hvf_id: u64,
         _vcpu_thread: thread::JoinHandle<()>,
     ) -> Self {
         Self {
             event_sender,
             response_receiver,
+            hvf_id,
         }
     }
 
+    /// HVF-assigned vCPU id, reported by the thread at boot. Used to break the
+    /// vCPU out of HVF (`vcpu_request_exit`) when pausing.
+    pub fn hvf_id(&self) -> u64 {
+        self.hvf_id
+    }
+
     pub fn send_event(&self, event: VcpuEvent) -> Result<()> {
-        // Use expect() to crash if the other thread closed this channel.
         self.event_sender
             .send(event)
-            .expect("event sender channel closed on vcpu end.");
-        // Kick the vcpu so it picks up the message.
-        /*
-        self.vcpu_thread
-            .as_ref()
-            // Safe to unwrap since constructor make this 'Some'.
-            .unwrap()
-            .kill(sigrtmin() + VCPU_RTSIG_OFFSET)
-            .map_err(Error::SignalVcpu)?;
-        */
-        Ok(())
+            .map_err(|_| Error::VcpuChannelClosed)
     }
 
     pub fn response_receiver(&self) -> &Receiver<VcpuResponse> {

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -1,6 +1,9 @@
 mod test_vm_config;
 use test_vm_config::TestVmConfig;
 
+mod test_vm_pause;
+use test_vm_pause::TestVmPause;
+
 #[cfg(any(feature = "host", target_os = "linux"))]
 mod test_vsock_guest_connect;
 #[cfg(any(feature = "host", target_os = "linux"))]
@@ -92,6 +95,7 @@ pub fn test_cases() -> Vec<TestCase> {
                 ram_mib: 1024,
             }),
         ),
+        TestCase::new("vm-pause", Box::new(TestVmPause)),
         #[cfg(any(feature = "host", target_os = "linux"))]
         TestCase::new("vsock-guest-connect", Box::new(TestVsockGuestConnect)),
         TestCase::new(

--- a/tests/test_cases/src/test_vm_pause.rs
+++ b/tests/test_cases/src/test_vm_pause.rs
@@ -1,0 +1,227 @@
+//! Live pause/resume test. macOS/HVF only (the mechanism is HVF for now).
+//!
+//! Boots a 2-vCPU microVM running a fixed monotonic-clock workload, then from
+//! another thread pauses and resumes it across several cycles while asserting:
+//!   - `DONE` present  -> every resume woke the guest (otherwise it hangs paused
+//!     forever and the runner times out).
+//!   - exactly `WORKLOAD_ITERS` heartbeats -> the guest ran to completion, no
+//!     work lost or duplicated across the pauses.
+//!   - guest's own elapsed ms stays near the workload length -> the virtual timer
+//!     was frozen across each pause (no en-masse catch-up on wake), and the
+//!     per-vCPU offsets stayed in lockstep.
+//!   - a `resumed` marker file written only after the final `krun_vm_resume` ->
+//!     the pauses held the guest well past its natural completion time. A no-op
+//!     pause lets the guest power off (which `libc::exit`s the whole process,
+//!     killing the pause thread) before the marker is ever written.
+//!
+//! Two properties are checked by construction rather than by assertion, because
+//! a regression makes the whole run hang and trips the timeout:
+//!   - With 2 vCPUs, the core not running the workload is parked in WFE at pause
+//!     time. It can only acknowledge the pause if the park point also watches the
+//!     pause channel -- otherwise `Vmm::pause` blocks forever awaiting its ack.
+//!   - The second `krun_vm_pause`/`krun_vm_resume` in each cycle is a no-op that
+//!     must return without re-signalling the (already parked) vCPUs; a missing
+//!     idempotency guard deadlocks the event loop.
+//!   - A pause immediately followed by a resume reaches the event loop in a
+//!     single wakeup. Observing them out of order would no-op the resume and
+//!     leave the guest frozen.
+//!
+//! The process exits on guest poweroff, so host timing can't be measured around
+//! `krun_start_enter` (it never returns) -- hence the marker rather than a timer.
+
+use macros::{guest, host};
+
+pub struct TestVmPause;
+
+const WORKLOAD_ITERS: u32 = 50;
+const WORKLOAD_INTERVAL_MS: u64 = 100;
+
+#[host]
+mod host {
+    use super::*;
+
+    const NUM_CPUS: u8 = 2;
+    const WORKLOAD_MS: u64 = WORKLOAD_ITERS as u64 * WORKLOAD_INTERVAL_MS;
+    const CYCLES: u32 = 2;
+    // Each pause must outlast the guest's remaining run so the guest can't power
+    // off (and exit the process) before the post-resume marker is written.
+    const SETTLE_MS: u64 = 1_500;
+    const PAUSE_MS: u64 = 5_000;
+    const GAP_MS: u64 = 1_500;
+    // Long enough that the doubled pause/resume below land as distinct event-loop
+    // wakeups rather than coalescing into one, so they exercise the no-op guard.
+    const IDEM_GAP_MS: u64 = 200;
+
+    use crate::common::setup_rootfs;
+    use crate::{ShouldRun, Test, TestOutcome, TestSetup};
+    use crate::{krun_call, krun_call_u32};
+    use krun_sys::*;
+    use std::ffi::{CString, c_char};
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::Path;
+    use std::ptr::null;
+    use std::time::Duration;
+
+    fn sleep_ms(ms: u64) {
+        std::thread::sleep(Duration::from_millis(ms));
+    }
+
+    unsafe fn configure_vm(ctx: u32, root: &Path, test_case: &str) -> anyhow::Result<()> {
+        let root_cstr = CString::new(root.as_os_str().as_bytes())?;
+        let test_case_cstr = CString::new(test_case.to_owned())?;
+        unsafe {
+            krun_call!(krun_set_vm_config(ctx, NUM_CPUS, 512))?;
+            krun_call!(krun_add_virtio_console_default(
+                ctx,
+                std::io::stdin().as_raw_fd(),
+                std::io::stdout().as_raw_fd(),
+                std::io::stderr().as_raw_fd(),
+            ))?;
+            krun_call!(krun_add_virtiofs3(
+                ctx,
+                c"/dev/root".as_ptr(),
+                root_cstr.as_ptr(),
+                0,
+                false,
+            ))?;
+            krun_call!(krun_set_workdir(ctx, c"/".as_ptr()))?;
+            let argv: [*const c_char; 2] = [test_case_cstr.as_ptr(), null()];
+            let envp: [*const c_char; 1] = [null()];
+            krun_call!(krun_set_exec(
+                ctx,
+                c"/guest-agent".as_ptr(),
+                argv.as_ptr(),
+                envp.as_ptr(),
+            ))?;
+        }
+        Ok(())
+    }
+
+    impl Test for TestVmPause {
+        fn should_run(&self) -> ShouldRun {
+            if cfg!(target_os = "macos") {
+                ShouldRun::Yes
+            } else {
+                ShouldRun::No("pause/resume is macOS/HVF only")
+            }
+        }
+
+        fn timeout_secs(&self) -> u64 {
+            60
+        }
+
+        fn start_vm(self: Box<Self>, test_setup: TestSetup) -> anyhow::Result<()> {
+            let root_dir = setup_rootfs(&test_setup)?;
+            let ctx = unsafe { krun_call_u32!(krun_create_ctx())? };
+            unsafe { configure_vm(ctx, &root_dir, &test_setup.test_case)? };
+
+            // Pause/resume the guest several times from another thread, each pause
+            // outlasting the guest's remaining run, then drop a marker. The control
+            // channel isn't registered until the VM's event loop starts, so retry
+            // the first pause past the initial -ENOENT.
+            let marker = test_setup.tmp_dir.join("resumed");
+            std::thread::spawn(move || {
+                sleep_ms(SETTLE_MS);
+                while unsafe { krun_vm_pause(ctx) } != 0 {
+                    sleep_ms(50);
+                }
+                // Resume with no sleep in between, so both requests reach the event
+                // loop in one wakeup: if it observed them out of order the guest
+                // would stay frozen and the runner would time out.
+                assert_eq!(unsafe { krun_vm_resume(ctx) }, 0, "tight resume");
+
+                for cycle in 0..CYCLES {
+                    assert_eq!(unsafe { krun_vm_pause(ctx) }, 0, "pause");
+                    // Pausing an already-paused VM is a no-op; it deadlocks the
+                    // event loop if the idempotency guard is missing.
+                    sleep_ms(IDEM_GAP_MS);
+                    assert_eq!(unsafe { krun_vm_pause(ctx) }, 0, "redundant pause");
+
+                    sleep_ms(PAUSE_MS);
+
+                    assert_eq!(unsafe { krun_vm_resume(ctx) }, 0, "resume");
+                    sleep_ms(IDEM_GAP_MS);
+                    assert_eq!(unsafe { krun_vm_resume(ctx) }, 0, "redundant resume");
+
+                    if cycle + 1 < CYCLES {
+                        sleep_ms(GAP_MS);
+                    }
+                }
+                // Reached only if the guest was still alive after the last resume,
+                // i.e. the pauses actually held it; a no-op pause exits first.
+                let _ = std::fs::write(&marker, "1");
+            });
+
+            let rc = unsafe { krun_start_enter(ctx) };
+            if rc < 0 {
+                anyhow::bail!("krun_start_enter failed: {rc}");
+            }
+            Ok(())
+        }
+
+        fn check(self: Box<Self>, stdout: Vec<u8>, test_setup: TestSetup) -> TestOutcome {
+            let out = String::from_utf8_lossy(&stdout);
+
+            let done = out.lines().find_map(|l| {
+                l.strip_prefix("DONE ")
+                    .and_then(|ms| ms.trim().parse::<u64>().ok())
+            });
+            let Some(guest_done_ms) = done else {
+                return TestOutcome::Fail(format!(
+                    "restored guest never finished; stdout: {out:?}"
+                ));
+            };
+
+            let beats = out.lines().filter(|l| l.contains("HEARTBEAT")).count();
+            if beats != WORKLOAD_ITERS as usize {
+                return TestOutcome::Fail(format!(
+                    "expected {WORKLOAD_ITERS} heartbeats, got {beats}"
+                ));
+            }
+
+            // The guest's own clock must not have absorbed the host pauses: it
+            // should report roughly the workload length, not workload + pauses.
+            if guest_done_ms > WORKLOAD_MS + PAUSE_MS / 2 {
+                return TestOutcome::Fail(format!(
+                    "guest clock jumped across pause: {guest_done_ms}ms (workload ~{WORKLOAD_MS}ms)"
+                ));
+            }
+
+            // The pause thread reaches the marker write only if the guest was
+            // still alive long after its natural completion -- i.e. the pauses
+            // really halted it. A no-op pause exits the process first.
+            if !test_setup.tmp_dir.join("resumed").exists() {
+                return TestOutcome::Fail(
+                    "no resume marker; pause did not hold the guest past its workload".into(),
+                );
+            }
+
+            TestOutcome::Pass
+        }
+    }
+}
+
+#[guest]
+mod guest {
+    use super::*;
+    use crate::Test;
+
+    impl Test for TestVmPause {
+        fn in_guest(self: Box<Self>) {
+            use std::io::Write;
+            use std::time::Instant;
+
+            // Monotonic clock derives from the guest virtual counter, which the
+            // host freezes while paused — so this elapsed time excludes the pauses.
+            let start = Instant::now();
+            for i in 0..WORKLOAD_ITERS {
+                println!("HEARTBEAT {i}");
+                let _ = std::io::stdout().flush();
+                std::thread::sleep(std::time::Duration::from_millis(WORKLOAD_INTERVAL_MS));
+            }
+            println!("DONE {}", start.elapsed().as_millis());
+            let _ = std::io::stdout().flush();
+        }
+    }
+}


### PR DESCRIPTION
Live, thread-safe pause/resume for a running VM on macOS/HVF. Suggested by @mtjhrc in #762 — the snapshot path needs this freeze primitive anyway, so it's split out to land first.

**API**
- `krun_vm_pause(ctx_id)` — freeze every vCPU at an instruction boundary.
- `krun_vm_resume(ctx_id)` — wake them.

Out-of-band (call from another thread while `krun_start_enter` blocks), idempotent, `-ENOTSUP` off macOS.

**How**
Per-VM eventfds signalled by the C API; the VM event loop runs the freeze/wake. Pause breaks each vCPU out of HVF (`vcpu_request_exit`) and parks it; resume advances the vtimer offset by the time spent paused, so the guest's CNTVCT stays continuous and armed timers don't fire en masse on wake. Device worker threads are notification-driven, so a frozen guest leaves them idle — no per-device handling.

**Test**
`vm-pause` (macOS/HVF): pauses a running guest mid-workload from another thread, holds past its natural completion, resumes. Asserts the guest woke and finished, its virtual clock stayed continuous across the pause, and the pause actually held it. Passes locally; `clippy -D warnings` and `fmt` clean.

Follow-up: #762 rebases on top and drops the now-shared primitives.
