### PR TITLE
clippy: fix new -D warnings lints (byte_char_slices, redundant_reference)

### DIFF
--- a/src/devices/src/virtio/input/worker.rs
+++ b/src/devices/src/virtio/input/worker.rs
@@ -240,7 +240,7 @@ impl InputWorker {
             let mut buffer: [u8; size_of::<virtio_input::virtio_input_event>()] =
                 [0; size_of::<virtio_input::virtio_input_event>()];
             reader.read_exact(&mut buffer)?;
-            debug!("Not implemented status queue request: {:?}", &buffer);
+            debug!("Not implemented status queue request: {buffer:?}");
             // For now, we don't send events back to the input source
             // This would be used for things like setting LEDs on keyboards, haptic feedback, etc.
         }

--- a/src/rutabaga_gfx/src/rutabaga_gralloc/formats.rs
+++ b/src/rutabaga_gfx/src/rutabaga_gralloc/formats.rs
@@ -21,26 +21,26 @@ use crate::rutabaga_utils::*;
  * used by guest userspace (i.e, DRM_FORMAT_RGB332) are left out for simplicity.
  */
 
-pub const DRM_FORMAT_R8: [u8; 4] = [b'R', b'8', b' ', b' '];
+pub const DRM_FORMAT_R8: [u8; 4] = *b"R8  ";
 
-pub const DRM_FORMAT_RGB565: [u8; 4] = [b'R', b'G', b'1', b'6'];
-pub const DRM_FORMAT_BGR888: [u8; 4] = [b'B', b'G', b'2', b'4'];
+pub const DRM_FORMAT_RGB565: [u8; 4] = *b"RG16";
+pub const DRM_FORMAT_BGR888: [u8; 4] = *b"BG24";
 
-pub const DRM_FORMAT_XRGB8888: [u8; 4] = [b'X', b'R', b'2', b'4'];
-pub const DRM_FORMAT_XBGR8888: [u8; 4] = [b'X', b'B', b'2', b'4'];
+pub const DRM_FORMAT_XRGB8888: [u8; 4] = *b"XR24";
+pub const DRM_FORMAT_XBGR8888: [u8; 4] = *b"XB24";
 
-pub const DRM_FORMAT_ARGB8888: [u8; 4] = [b'A', b'R', b'2', b'4'];
-pub const DRM_FORMAT_ABGR8888: [u8; 4] = [b'A', b'B', b'2', b'4'];
+pub const DRM_FORMAT_ARGB8888: [u8; 4] = *b"AR24";
+pub const DRM_FORMAT_ABGR8888: [u8; 4] = *b"AB24";
 
-pub const DRM_FORMAT_XRGB2101010: [u8; 4] = [b'X', b'R', b'3', b'0'];
-pub const DRM_FORMAT_XBGR2101010: [u8; 4] = [b'X', b'B', b'3', b'0'];
-pub const DRM_FORMAT_ARGB2101010: [u8; 4] = [b'A', b'R', b'3', b'0'];
-pub const DRM_FORMAT_ABGR2101010: [u8; 4] = [b'A', b'B', b'3', b'0'];
+pub const DRM_FORMAT_XRGB2101010: [u8; 4] = *b"XR30";
+pub const DRM_FORMAT_XBGR2101010: [u8; 4] = *b"XB30";
+pub const DRM_FORMAT_ARGB2101010: [u8; 4] = *b"AR30";
+pub const DRM_FORMAT_ABGR2101010: [u8; 4] = *b"AB30";
 
-pub const DRM_FORMAT_ABGR16161616F: [u8; 4] = [b'A', b'B', b'4', b'H'];
+pub const DRM_FORMAT_ABGR16161616F: [u8; 4] = *b"AB4H";
 
-pub const DRM_FORMAT_NV12: [u8; 4] = [b'N', b'V', b'1', b'2'];
-pub const DRM_FORMAT_YVU420: [u8; 4] = [b'Y', b'V', b'1', b'2'];
+pub const DRM_FORMAT_NV12: [u8; 4] = *b"NV12";
+pub const DRM_FORMAT_YVU420: [u8; 4] = *b"YV12";
 
 /// A [fourcc](https://en.wikipedia.org/wiki/FourCC) format identifier.
 #[derive(Copy, Clone, Eq, PartialEq, Default)]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1252,10 +1252,7 @@ fn load_external_kernel(
         KernelFormat::ImageBz2 => {
             let data: Vec<u8> = std::fs::read(external_kernel.path.clone())
                 .map_err(StartMicrovmError::ImageBz2OpenKernel)?;
-            if let Some(magic) = data
-                .windows(3)
-                .position(|window| window == [b'B', b'Z', b'h'])
-            {
+            if let Some(magic) = data.windows(3).position(|window| window == b"BZh") {
                 debug!("Found BZIP2 header on Image file at: 0x{magic:x}");
                 let (_, compressed) = data.split_at(magic);
                 let mut kernel_data: Vec<u8> = Vec::new();


### PR DESCRIPTION
CI floats `rustup update stable`; the newer clippy (1.97) fails the `-D warnings` gates on three pre-existing spots unrelated to any feature work:

- `rutabaga_gralloc/formats.rs`: DRM fourcc consts under `byte_char_slices` — same bytes as a dereferenced byte string, values unchanged.
- `virtio/input/worker.rs`: `&buffer` passed to `{:?}` under `redundant_reference` — inlined.
- `vmm/builder.rs`: bz2 magic compared against `[b'B', b'Z', b'h']` under `byte_char_slices` — compared against `b"BZh"`.

Pulling them out so the clippy jobs go green independently of the PRs that keep tripping over them.
