### PR TITLE
devices/rng: fix AsRawFd import for Windows compilation

### DIFF
--- a/src/devices/src/virtio/rng/event_handler.rs
+++ b/src/devices/src/virtio/rng/event_handler.rs
@@ -1,4 +1,7 @@
+#[cfg(unix)]
 use std::os::unix::io::AsRawFd;
+#[cfg(target_os = "windows")]
+use utils::windows::AsRawFd;
 
 use polly::event_manager::{EventManager, Subscriber};
 use utils::epoll::{EpollEvent, EventSet};


### PR DESCRIPTION
The device itself already works cross-platform since it uses rand::OsRng for entropy, which delegates to BCryptGenRandom on Windows. This commit just imports AsRawFd based on the platform.