### PR TITLE
tests: Improve test runner ergonomics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,7 +248,24 @@ test-prefix/$(LIBDIR_$(OS))/libkrun.pc: $(LIBRARY_RELEASE_$(OS))
 	mkdir -p test-prefix
 	PREFIX="$$(realpath test-prefix)" make install
 
+# Build and install libkrunfw from a source tree into test-prefix.
+# Usage: make test LIBKRUNFW_SRC=/path/to/libkrunfw
+ifdef LIBKRUNFW_SRC
+.PHONY: test-prefix-libkrunfw
+test-prefix-libkrunfw:
+	$(MAKE) -C $(LIBKRUNFW_SRC)
+	mkdir -p test-prefix
+	PREFIX="$$(realpath test-prefix)" $(MAKE) -C $(LIBKRUNFW_SRC) install
+
+test-prefix: test-prefix/$(LIBDIR_$(OS))/libkrun.pc test-prefix-libkrunfw
+else
 test-prefix: test-prefix/$(LIBDIR_$(OS))/libkrun.pc
+	@if ls test-prefix/$(LIBDIR_$(OS))/libkrunfw* >/dev/null 2>&1; then \
+		echo "WARNING: test-prefix contains a custom libkrunfw from a previous LIBKRUNFW_SRC= run." >&2; \
+		echo "         Tests will use it instead of the system libkrunfw." >&2; \
+		echo "         To reset, run: rm -rf test-prefix" >&2; \
+	fi
+endif
 
 TEST ?= all
 TEST_FLAGS ?=

--- a/Makefile
+++ b/Makefile
@@ -267,7 +267,7 @@ test-prefix: test-prefix/$(LIBDIR_$(OS))/libkrun.pc
 	fi
 endif
 
-TEST ?= all
+TEST ?= *
 TEST_FLAGS ?=
 
 # Extra library paths needed for tests (libkrunfw, llvm)

--- a/tests/Cargo.lock
+++ b/tests/Cargo.lock
@@ -404,6 +404,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "glob",
  "macros",
  "nix",
  "tempdir",

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -149,12 +149,9 @@ else
 	echo "(Run 'make' with BUILD_BSD_INIT=1 in the libkrun root to build FreeBSD assets.)"
 fi
 
-# Build runner args: pass through all arguments
-RUNNER_ARGS="$*"
-
 # Add --base-dir if KRUN_TEST_BASE_DIR is set
 if [ -n "${KRUN_TEST_BASE_DIR}" ]; then
-	RUNNER_ARGS="${RUNNER_ARGS} --base-dir ${KRUN_TEST_BASE_DIR}"
+	set -- "$@" --base-dir "${KRUN_TEST_BASE_DIR}"
 fi
 
 # Resolve gvproxy path: prefer explicit env var, then cached binary in
@@ -215,4 +212,4 @@ if [ -z "${KRUN_TEST_GVPROXY_PATH}" ]; then
 	fi
 fi
 
-target/debug/runner ${RUNNER_ARGS}
+exec target/debug/runner "$@"

--- a/tests/runner/Cargo.toml
+++ b/tests/runner/Cargo.toml
@@ -9,3 +9,4 @@ nix = { version = "0.29.0", features = ["resource", "fs", "signal", "process"] }
 macros = { path = "../macros" }
 clap = { version = "4.5.27", features = ["derive"] }
 tempdir = "0.3.7"
+glob = "0.3"

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -360,14 +360,37 @@ fn run_tests(
     let tests_to_run: Vec<_> = if test_case == "all" {
         all_tests
     } else {
+        let mut include: Vec<glob::Pattern> = Vec::new();
+        let mut exclude: Vec<glob::Pattern> = Vec::new();
+        for p in test_case.split(',').map(|p| p.trim()) {
+            if let Some(neg) = p.strip_prefix('!') {
+                exclude.push(
+                    glob::Pattern::new(neg)
+                        .with_context(|| format!("invalid glob pattern: {p}"))?,
+                );
+            } else {
+                include.push(
+                    glob::Pattern::new(p).with_context(|| format!("invalid glob pattern: {p}"))?,
+                );
+            }
+        }
+        if include.is_empty() {
+            anyhow::bail!(
+                "No include patterns given (only exclusions). Use e.g. \"*,{test_case}\" to exclude."
+            );
+        }
+
         all_tests
             .into_iter()
-            .filter(|t| t.name == test_case)
+            .filter(|t| {
+                include.iter().any(|p| p.matches(t.name))
+                    && !exclude.iter().any(|p| p.matches(t.name))
+            })
             .collect()
     };
 
     if tests_to_run.is_empty() {
-        anyhow::bail!("No such test: {test_case}");
+        anyhow::bail!("No tests matched: {test_case}");
     }
 
     let max_name_len = tests_to_run.iter().map(|t| t.name.len()).max().unwrap_or(0);
@@ -429,7 +452,7 @@ fn run_tests(
 #[derive(clap::Subcommand, Clone, Debug)]
 enum CliCommand {
     Test {
-        /// Specify which test to run or "all"
+        /// Test(s) to run: "all", a name, or comma-separated glob patterns (e.g. "net-*,!net-tap")
         #[arg(long, default_value = "all")]
         test_case: String,
         /// Base directory for test artifacts

--- a/tests/runner/src/main.rs
+++ b/tests/runner/src/main.rs
@@ -357,37 +357,30 @@ fn run_tests(
     let mut results: Vec<TestResult> = Vec::new();
     let all_tests = test_cases();
 
-    let tests_to_run: Vec<_> = if test_case == "all" {
-        all_tests
-    } else {
-        let mut include: Vec<glob::Pattern> = Vec::new();
-        let mut exclude: Vec<glob::Pattern> = Vec::new();
-        for p in test_case.split(',').map(|p| p.trim()) {
-            if let Some(neg) = p.strip_prefix('!') {
-                exclude.push(
-                    glob::Pattern::new(neg)
-                        .with_context(|| format!("invalid glob pattern: {p}"))?,
-                );
-            } else {
-                include.push(
-                    glob::Pattern::new(p).with_context(|| format!("invalid glob pattern: {p}"))?,
-                );
-            }
-        }
-        if include.is_empty() {
-            anyhow::bail!(
-                "No include patterns given (only exclusions). Use e.g. \"*,{test_case}\" to exclude."
+    let mut include: Vec<glob::Pattern> = Vec::new();
+    let mut exclude: Vec<glob::Pattern> = Vec::new();
+    for p in test_case.split(',').map(|p| p.trim()) {
+        if let Some(neg) = p.strip_prefix('!') {
+            exclude.push(
+                glob::Pattern::new(neg).with_context(|| format!("invalid glob pattern: {p}"))?,
             );
+        } else {
+            include
+                .push(glob::Pattern::new(p).with_context(|| format!("invalid glob pattern: {p}"))?);
         }
+    }
+    if include.is_empty() {
+        anyhow::bail!(
+            "No include patterns given (only exclusions). Use e.g. \"*,{test_case}\" to exclude."
+        );
+    }
 
-        all_tests
-            .into_iter()
-            .filter(|t| {
-                include.iter().any(|p| p.matches(t.name))
-                    && !exclude.iter().any(|p| p.matches(t.name))
-            })
-            .collect()
-    };
+    let tests_to_run: Vec<_> = all_tests
+        .into_iter()
+        .filter(|t| {
+            include.iter().any(|p| p.matches(t.name)) && !exclude.iter().any(|p| p.matches(t.name))
+        })
+        .collect();
 
     if tests_to_run.is_empty() {
         anyhow::bail!("No tests matched: {test_case}");
@@ -452,8 +445,8 @@ fn run_tests(
 #[derive(clap::Subcommand, Clone, Debug)]
 enum CliCommand {
     Test {
-        /// Test(s) to run: "all", a name, or comma-separated glob patterns (e.g. "net-*,!net-tap")
-        #[arg(long, default_value = "all")]
+        /// Test(s) to run: a name or comma-separated glob patterns (e.g. "net-*,!net-tap")
+        #[arg(long, default_value = "*")]
         test_case: String,
         /// Base directory for test artifacts
         #[arg(long)]
@@ -476,7 +469,7 @@ enum CliCommand {
 impl Default for CliCommand {
     fn default() -> Self {
         Self::Test {
-            test_case: "all".to_string(),
+            test_case: "*".to_string(),
             base_dir: None,
             keep_all: false,
             github_summary: false,

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -334,6 +334,13 @@ mod tests {
             if name == "all" {
                 panic!("test_cases() contains test named {name}, but the name is reseved")
             }
+            for c in ['*', '?', '[', ']', ',', '!'] {
+                if name.contains(c) {
+                    panic!(
+                        "test name `{name}` contains `{c}`, which is reserved for the test selection syntax"
+                    )
+                }
+            }
         }
     }
 }

--- a/tests/test_cases/src/lib.rs
+++ b/tests/test_cases/src/lib.rs
@@ -331,9 +331,6 @@ mod tests {
                 panic!("test_cases() contains multiple items named `{name}`")
             }
 
-            if name == "all" {
-                panic!("test_cases() contains test named {name}, but the name is reseved")
-            }
             for c in ['*', '?', '[', ']', ',', '!'] {
                 if name.contains(c) {
                     panic!(


### PR DESCRIPTION
Test runner improvements:

- Fix argument quoting in run.sh (`$*` → `"$@"`) so arguments with spaces aren't split
- Support comma-separated glob patterns in `--test-case` with `!` negation (e.g. `TEST="net-*,!net-tap"`) to run all network tests except tap.
- Add `LIBKRUNFW_SRC=` to build and install libkrunfw from a source tree automatically into test-prefix, for iterating on kernel + libkrun changes together
- Remove the `"all"` special case value for testcase name. It is superseded by `"*"` pattern instead