### PR TITLE
display: accumulate damage regions across updates

### DIFF
--- a/examples/krun_gtk_display/src/scanout_paintable/imp.rs
+++ b/examples/krun_gtk_display/src/scanout_paintable/imp.rs
@@ -1,4 +1,5 @@
 use gtk::{
+    cairo::Region,
     gdk::{Paintable, PaintableFlags, RGBA, Snapshot, Texture},
     glib,
     graphene::Rect,
@@ -18,7 +19,7 @@ pub struct ScanoutPaintable {
     pub default_width: Cell<i32>,
     #[property(get, set)]
     pub default_height: Cell<i32>,
-    pub rect: Rect,
+    pub update_region: RefCell<Option<Region>>,
 }
 
 #[glib::object_subclass]
@@ -39,6 +40,7 @@ impl PaintableImpl for ScanoutPaintable {
     fn snapshot(&self, snapshot: &Snapshot, width: f64, height: f64) {
         if let Some(texture) = self.texture.borrow().as_ref() {
             snapshot.append_texture(texture, &Rect::new(0.0, 0.0, width as f32, height as f32));
+            self.update_region.replace(None);
         } else {
             snapshot.append_color(
                 &RGBA::new(0.0, 0.0, 0.0, 1.0),

--- a/examples/krun_gtk_display/src/scanout_paintable/mod.rs
+++ b/examples/krun_gtk_display/src/scanout_paintable/mod.rs
@@ -32,6 +32,27 @@ impl ScanoutPaintable {
     ) {
         assert_eq!(buffer.len(), width as usize * height as usize * 4);
         let imp = self.imp();
+
+        if let Some(rect) = rect {
+            let damage = RectangleInt::new(
+                rect.x as i32,
+                rect.y as i32,
+                rect.width as i32,
+                rect.height as i32,
+            );
+            let mut region_ref = imp.update_region.borrow_mut();
+            match *region_ref {
+                Some(ref region) => {
+                    let _ = region.union_rectangle(&damage);
+                }
+                None => {
+                    *region_ref = Some(Region::create_rectangle(&damage));
+                }
+            }
+        } else {
+            imp.update_region.replace(None);
+        }
+
         let builder = MemoryTextureBuilder::new()
             .set_width(width)
             .set_height(height)
@@ -39,20 +60,18 @@ impl ScanoutPaintable {
             .set_stride(width as usize * ResourceFormat::BYTES_PER_PIXEL)
             .set_bytes(Some(&buffer));
 
-        let builder = if let Some(rect) = rect {
+        let region_ref = imp.update_region.borrow();
+        let builder = if let Some(ref region) = *region_ref {
             builder
-                .set_update_region(Some(&Region::create_rectangle(&RectangleInt::new(
-                    rect.x as i32,
-                    rect.y as i32,
-                    rect.width as i32,
-                    rect.height as i32,
-                ))))
+                .set_update_region(Some(region))
                 .set_update_texture(imp.texture.borrow().as_ref())
         } else {
             builder
         };
 
-        let old_texture = imp.texture.replace(Some(builder.build()));
+        let new_texture = builder.build();
+        drop(region_ref);
+        let old_texture = imp.texture.replace(Some(new_texture));
 
         self.invalidate_contents();
         if let Some(old_texture) = old_texture


### PR DESCRIPTION
Track damage rectangles in a persistent Region that accumulates across multiple update() calls, rather than creating a new region from a single rectangle each time. The accumulated region is cleared after snapshotting.

This ensures MemoryTextureBuilder sees the full damaged area when multiple updates arrive between frames, preventing partial rendering artifacts.

Assisted-by: Claude Code: opus-4.6

cc @mtjhrc 