### PR TITLE
virtio/gpu: Allow setting display name / manufacturer name

### DIFF
--- a/examples/gui_vm/src/main.rs
+++ b/examples/gui_vm/src/main.rs
@@ -264,6 +264,7 @@ fn main() -> anyhow::Result<()> {
                 emit_mt: true,
                 emit_non_mt: false,
                 triggered_by_mouse: true,
+                device_name: None,
             }));
         }
     }

--- a/examples/krun_gtk_display/src/input_backend.rs
+++ b/examples/krun_gtk_display/src/input_backend.rs
@@ -145,8 +145,13 @@ impl ObjectNew<TouchScreenOptions> for GtkTouchscreenConfig {
 
 impl InputQueryConfig for GtkTouchscreenConfig {
     fn query_device_name(&self, name_buf: &mut [u8]) -> Result<u8, InputBackendError> {
-        let copy_len = std::cmp::min(TOUCHSCREEN_DEVICE_NAME.len(), name_buf.len());
-        name_buf[..copy_len].copy_from_slice(&TOUCHSCREEN_DEVICE_NAME[..copy_len]);
+        let name = self
+            .options
+            .device_name
+            .as_deref()
+            .unwrap_or(std::str::from_utf8(TOUCHSCREEN_DEVICE_NAME).unwrap());
+        let copy_len = std::cmp::min(name.len(), name_buf.len());
+        name_buf[..copy_len].copy_from_slice(&name.as_bytes()[..copy_len]);
         Ok(copy_len as u8)
     }
 

--- a/examples/krun_gtk_display/src/lib.rs
+++ b/examples/krun_gtk_display/src/lib.rs
@@ -112,6 +112,8 @@ pub struct TouchScreenOptions {
     pub emit_non_mt: bool,
     /// Translate mouse click & drag into touch events
     pub triggered_by_mouse: bool,
+    /// Custom device name reported to the guest (defaults to "libkrun Touchscreen")
+    pub device_name: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -510,6 +510,23 @@ int32_t krun_add_display(uint32_t ctx_id, uint32_t width, uint32_t height);
 int32_t krun_display_set_edid(uint32_t ctx_id, uint32_t display_id, const uint8_t* edid_blob, size_t blob_size);
 
 /**
+ * Set the EDID manufacturer and display name for a display.
+ *
+ * These values are used to generate the EDID reported to the guest.
+ * Either parameter may be NULL to leave that field unchanged.
+ *
+ * Arguments:
+ *  "ctx_id"        - the configuration context ID.
+ *  "display_id"    - the ID of the display (range: 0 to KRUN_MAX_DISPLAYS - 1)
+ *  "manufacturer"  - 3-character PNP manufacturer ID (e.g. "GGL"), or NULL
+ *  "display_name"  - display product name (max 13 characters), or NULL
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ */
+int32_t krun_display_set_edid_name(uint32_t ctx_id, uint32_t display_id, const char* manufacturer, const char* display_name);
+
+/**
  * Configure DPI of the display reported to the guest
  *
  * This overrides the DPI set by krun_set_display_dpi()

--- a/src/devices/src/display/edid.rs
+++ b/src/devices/src/display/edid.rs
@@ -27,7 +27,7 @@ const DEFAULT_HORIZONTAL_SYNC_PULSE: u16 = 192;
 const DEFAULT_VERTICAL_SYNC_PULSE: u16 = 3;
 const MILLIMETERS_PER_INCH: f32 = 25.4;
 
-#[derive(Copy, Clone)]
+#[derive(Clone)]
 pub struct EdidInfo {
     width: u32,
     height: u32,
@@ -40,6 +40,8 @@ pub struct EdidInfo {
     vertical_sync: u16,
     width_millimeters: u16,
     height_millimeters: u16,
+    manufacturer: [u8; 3],
+    display_name: String,
 }
 
 impl EdidInfo {
@@ -67,6 +69,8 @@ impl EdidInfo {
             vertical_sync: DEFAULT_VERTICAL_SYNC_PULSE,
             width_millimeters,
             height_millimeters,
+            manufacturer: params.manufacturer,
+            display_name: params.display_name.clone(),
         }
     }
 
@@ -82,7 +86,7 @@ impl EdidInfo {
         let mut edid_box: Box<[u8]> = vec![0; EDID_DATA_LENGTH].into_boxed_slice();
         let edid = &mut edid_box[..];
 
-        populate_header(edid);
+        populate_header(edid, &self.manufacturer);
         populate_edid_version(edid);
         populate_size(edid, &self);
         populate_standard_timings(edid, &self);
@@ -92,7 +96,7 @@ impl EdidInfo {
         populate_detailed_timing(block0, &self);
 
         let block1 = &mut edid[72..90];
-        populate_display_name(block1);
+        populate_display_name(block1, &self.display_name);
 
         calculate_checksum(edid);
 
@@ -100,12 +104,16 @@ impl EdidInfo {
     }
 }
 
-fn populate_display_name(edid_block: &mut [u8]) {
-    // Display Product Name String Descriptor Tag
+fn populate_display_name(edid_block: &mut [u8], name: &str) {
     edid_block[0..5].clone_from_slice(&[0x00, 0x00, 0x00, 0xFC, 0x00]);
-    // This should to be padded to 13 bytes, see Section 3.10.3.4
-    let product_name: &[u8; 13] = b"krun-display\n";
-    edid_block[5..].clone_from_slice(product_name);
+    // Section 3.10.3.4: 13-byte field, newline-terminated if shorter than 13 chars
+    let mut product_name = [b' '; 13];
+    let len = name.len().min(13);
+    product_name[..len].copy_from_slice(&name.as_bytes()[..len]);
+    if len < 13 {
+        product_name[len] = b'\n';
+    }
+    edid_block[5..].clone_from_slice(&product_name);
 }
 
 fn populate_detailed_timing(edid_block: &mut [u8], info: &EdidInfo) {
@@ -210,7 +218,7 @@ fn populate_detailed_timing(edid_block: &mut [u8], info: &EdidInfo) {
 }
 
 // The EDID header. This is defined by the EDID spec.
-fn populate_header(edid: &mut [u8]) {
+fn populate_header(edid: &mut [u8], manufacturer_name: &[u8; 3]) {
     edid[0] = 0x00;
     edid[1] = 0xFF;
     edid[2] = 0xFF;
@@ -220,8 +228,6 @@ fn populate_header(edid: &mut [u8]) {
     edid[6] = 0xFF;
     edid[7] = 0x00;
 
-    // Red Hat 'RHT' is also used in QEMU, though it is not technically officially assigned
-    let manufacturer_name = b"RHT";
     // 00001 -> A, 00010 -> B, etc
     let manufacturer_id: u16 = manufacturer_name
         .iter()
@@ -318,5 +324,86 @@ const fn gcd(x: u32, y: u32) -> u32 {
     match y {
         0 => x,
         _ => gcd(y, x % y),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_edid(manufacturer: [u8; 3], display_name: &str) -> Box<[u8]> {
+        let params = EdidParams {
+            manufacturer,
+            display_name: display_name.to_string(),
+            ..EdidParams::default()
+        };
+        EdidInfo::new(1920, 1080, &params).bytes()
+    }
+
+    fn decode_manufacturer(edid: &[u8]) -> [u8; 3] {
+        let id = u16::from_be_bytes([edid[8], edid[9]]);
+        [
+            b'A' + ((id >> 10) & 0x1F) as u8 - 1,
+            b'A' + ((id >> 5) & 0x1F) as u8 - 1,
+            b'A' + (id & 0x1F) as u8 - 1,
+        ]
+    }
+
+    #[test]
+    fn manufacturer_encoding() {
+        assert_eq!(decode_manufacturer(&make_edid(*b"RHT", "x")), *b"RHT");
+        assert_eq!(decode_manufacturer(&make_edid(*b"GGL", "x")), *b"GGL");
+    }
+
+    #[test]
+    fn display_name_short_is_newline_terminated() {
+        let name = &make_edid(*b"RHT", "Hello")[77..90];
+        assert_eq!(&name[..5], b"Hello");
+        assert_eq!(name[5], b'\n');
+    }
+
+    #[test]
+    fn display_name_max_13_chars() {
+        let name = &make_edid(*b"RHT", "1234567890123")[77..90];
+        assert_eq!(name, b"1234567890123");
+    }
+
+    #[test]
+    fn valid_checksum() {
+        let edid = make_edid(*b"RHT", "test");
+        let sum: u8 = edid.iter().fold(0u8, |a, &b| a.wrapping_add(b));
+        assert_eq!(sum, 0);
+    }
+
+    #[test]
+    fn header_and_version() {
+        let edid = make_edid(*b"RHT", "test");
+        assert_eq!(
+            &edid[0..8],
+            &[0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00]
+        );
+        assert_eq!((edid[18], edid[19]), (1, 4));
+        assert_eq!(&edid[72..77], &[0x00, 0x00, 0x00, 0xFC, 0x00]);
+    }
+
+    // Android's PhysicalDisplayId is derived from the EDID manufacturer ID
+    // (bytes 8-9) and a CityHash of the display name (descriptor 0xFC).
+    // The Cuttlefish APEX IDC files hardcode hashes for manufacturer "GGL"
+    // and display name "CrosvmDisplay". This test verifies our EDID produces
+    // the exact bytes Android expects, so touch routing works without
+    // modifying any Android code.
+    #[test]
+    fn crosvm_display_android_id_compatibility() {
+        let edid = make_edid(*b"GGL", "CrosvmDisplay");
+
+        // Android reads manufacturer ID as big-endian u16 from bytes 8-9.
+        // GGL: G=7, G=7, L=12 → (7 << 10) | (7 << 5) | 12 = 0x1CEC
+        let manufacturer_id = u16::from_be_bytes([edid[8], edid[9]]);
+        assert_eq!(manufacturer_id, 0x1CEC);
+
+        // Android extracts the display name from the 0xFC descriptor (bytes 77-90),
+        // strips the newline terminator, and hashes via CityHash64. Verify the name
+        // is stored verbatim so the hash will match.
+        assert_eq!(&edid[77..90], b"CrosvmDisplay");
     }
 }

--- a/src/devices/src/display/types.rs
+++ b/src/devices/src/display/types.rs
@@ -9,10 +9,12 @@ pub const MAX_DISPLAYS: usize = VIRTIO_GPU_MAX_SCANOUTS as usize;
 
 use super::edid::EdidInfo;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct EdidParams {
     pub refresh_rate: u32,
     pub physical_size: PhysicalSize,
+    pub manufacturer: [u8; 3],
+    pub display_name: String,
 }
 
 impl Default for EdidParams {
@@ -20,6 +22,8 @@ impl Default for EdidParams {
         EdidParams {
             refresh_rate: 60,
             physical_size: PhysicalSize::Dpi(300),
+            manufacturer: *b"RHT",
+            display_name: "krun-display".to_string(),
         }
     }
 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1667,6 +1667,60 @@ pub unsafe extern "C" fn krun_display_set_edid(
 
 #[cfg(any(feature = "gpu", feature = "vhost-user"))]
 #[unsafe(no_mangle)]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn krun_display_set_edid_name(
+    ctx_id: u32,
+    display_id: u32,
+    manufacturer: *const c_char,
+    display_name: *const c_char,
+) -> i32 {
+    with_cfg(ctx_id, |cfg| {
+        let Some(display_info) = cfg.vmr.displays.get_mut(display_id as usize) else {
+            return -libc::EINVAL;
+        };
+
+        let DisplayInfoEdid::Generated(ref mut edid_params) = display_info.edid else {
+            return -libc::EALREADY;
+        };
+
+        if !manufacturer.is_null() {
+            let mfr = unsafe { CStr::from_ptr(manufacturer) }.to_bytes();
+            if mfr.len() != 3 || !mfr.iter().all(|&c| c.is_ascii_uppercase()) {
+                return -libc::EINVAL;
+            }
+            edid_params.manufacturer = [mfr[0], mfr[1], mfr[2]];
+        }
+
+        if !display_name.is_null() {
+            let name = unsafe { CStr::from_ptr(display_name) };
+            let name_str = match name.to_str() {
+                Ok(s) => s,
+                Err(_) => return -libc::EINVAL,
+            };
+            if name_str.is_empty() || name_str.len() > 13 {
+                return -libc::EINVAL;
+            }
+            edid_params.display_name = name_str.to_string();
+        }
+
+        KRUN_SUCCESS
+    })
+}
+
+#[cfg(not(any(feature = "gpu", feature = "vhost-user")))]
+#[unsafe(no_mangle)]
+#[allow(clippy::missing_safety_doc)]
+pub unsafe extern "C" fn krun_display_set_edid_name(
+    _ctx_id: u32,
+    _display_id: u32,
+    _manufacturer: *const c_char,
+    _display_name: *const c_char,
+) -> i32 {
+    -libc::ENOTSUP
+}
+
+#[cfg(any(feature = "gpu", feature = "vhost-user"))]
+#[unsafe(no_mangle)]
 pub extern "C" fn krun_display_set_physical_size(
     ctx_id: u32,
     display_id: u32,


### PR DESCRIPTION
The Cuttlefish APEX `com.google.cf.input.config` ships IDC files that map touchscreen input to specific displays. The mapping uses a hash derived from the display's EDID manufacturer ID and name. The IDC files hardcode the hash for `GGL + CrosvmDisplay`, values crosvm normally produces.

Without this patch, libkrun's virtio-gpu generated a generic EDID. Android's GuestFrameComposer reads that EDID and computes a display ID hash that doesn't match the APEX IDC files, so touch input fails to route to the correct display.

The patch exposes `krun_display_set_edid_name()` so callers can set the manufacturer and display name in the generated EDID. Setting them to GGL/CrosvmDisplay produces the exact hash the APEX IDC files expect, making touch routing work correctly on both displays without modifying any Android code.