### PR TITLE
display/input: add ABS_MT_TRACKING_ID for multitouch

### DIFF
--- a/examples/krun_gtk_display/src/input_backend.rs
+++ b/examples/krun_gtk_display/src/input_backend.rs
@@ -187,7 +187,12 @@ impl InputQueryConfig for GtkTouchscreenConfig {
                 let bitmap_len2 = if self.options.emit_mt {
                     write_bitmap(
                         bitmap_buf,
-                        &[ABS_MT_SLOT, ABS_MT_POSITION_X, ABS_MT_POSITION_Y],
+                        &[
+                            ABS_MT_SLOT,
+                            ABS_MT_TRACKING_ID,
+                            ABS_MT_POSITION_X,
+                            ABS_MT_POSITION_Y,
+                        ],
                     )
                 } else {
                     0


### PR DESCRIPTION
Include ABS_MT_TRACKING_ID in the multitouch capability bitmap so the guest can properly track individual touch contacts across touch events.

Assisted-by: Claude Code: opus-4.6