### PR TITLE
CI: Update Co-Authored-By AI checks

### DIFF
--- a/.github/scripts/check-ai-trailers.py
+++ b/.github/scripts/check-ai-trailers.py
@@ -62,6 +62,7 @@ def assisted_by(msg: str) -> Iterator[tuple[str, str | None, str | None]]:
 BANNED_CO_AUTHOR_EMAILS = [
     _re(r"^noreply@anthropic\.com$"),
     _re(r"^(\d+\+)?copilot@(github\.com|users\.noreply\.github\.com)$"),
+    _re(r"^cursoragent@cursor\.com$"),
 ]
 NON_STANDARD_AI_ATRIBUTION = [
     _re(r"^[^\x00-\x7F]*\s*Generated with \[Claude Code\]"),
@@ -81,6 +82,8 @@ def suggest_assisted_by(name: str, email: str) -> str | None:
         return "Assisted-by: Claude Code:<model>"
     if "github" in email:
         return "Assisted-by: Copilot:<model>"
+    if email.lower() == "cursoragent@cursor.com":
+        return "Assisted-by: Cursor:<model>"
     return None
 
 
@@ -206,6 +209,8 @@ def tests() -> None:
         "Co-authored-by: Copilot <999999+Copilot@users.noreply.github.com>",
         "Co-authored-by: 🤖 Claude <noreply@anthropic.com>",
         "Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>",
+        "Co-authored-by: Cursor <cursoragent@cursor.com>",
+        "Co-Authored-By: Cursor <cursoragent@cursor.com>",
     ]:
         expect("banned co-author", v, errors=1)
 
@@ -214,6 +219,7 @@ def tests() -> None:
         "Co-authored-by: John Doe <john@example.com>",
         "Co-authored-by: Claude Bernard <claude.bernard@anthropic.com>",
         "Co-authored-by: Mike Copilot <mike.copilot@github.com>",
+        "Co-authored-by: Alice Cursor <alice@cursor.com>",
     ]:
         expect("human co-author", v)
 
@@ -238,6 +244,7 @@ def tests() -> None:
         ("\N{ROBOT FACE} Claude", "noreply@anthropic.com", "Assisted-by: Claude Code:<model>"),
         ("Copilot", "copilot@github.com", "Assisted-by: Copilot:<model>"),
         ("Copilot", "223556219+Copilot@users.noreply.github.com", "Assisted-by: Copilot:<model>"),
+        ("Cursor", "cursoragent@cursor.com", "Assisted-by: Cursor:<model>"),
     ]
     for name, email, expected in suggestion_cases:
         got = suggest_assisted_by(name, email)

--- a/.github/scripts/check-ai-trailers.py
+++ b/.github/scripts/check-ai-trailers.py
@@ -30,7 +30,7 @@ def co_authors(msg: str) -> Iterator[tuple[str, str]]:
 
 
 # AGENT:MODEL | AGENT: MODEL | AGENT / MODEL | AGENT (MODEL)
-ASSISTED_BY_RE = re.compile(
+ASSISTED_BY_RE = _re(
     r"^(?P<key>Assisted-by|Generated-by):\s*"
     r"(?P<agent>[A-Za-z][A-Za-z0-9 -]*[A-Za-z0-9])"
     r"(?:"
@@ -39,6 +39,7 @@ ASSISTED_BY_RE = re.compile(
     r"| \((?P<model_paren>.+)\)"      # AGENT (MODEL)
     r")$"
 )
+ASSISTED_BY_PREFIX_RE = _re(r"^(Assisted-by|Generated-by):\s")
 
 
 def assisted_by(msg: str) -> Iterator[tuple[str, str | None, str | None]]:
@@ -48,7 +49,7 @@ def assisted_by(msg: str) -> Iterator[tuple[str, str | None, str | None]]:
     the format check.
     """
     for line in msg.splitlines():
-        if not re.match(r"^(Assisted-by|Generated-by):\s", line):
+        if not ASSISTED_BY_PREFIX_RE.match(line):
             continue
         m = ASSISTED_BY_RE.match(line)
         if m:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,9 +152,9 @@ The `Assisted-by` / `Generated-by` trailer should appear before
 
 `Co-authored-by` implies authorship, but AI tools are generally not
 considered authors in a copyright sense. Many AI coding tools add
-`Co-authored-by` tags by default (e.g. Claude Code, GitHub Copilot)
-— please replace them with `Assisted-by`. An automated CI check
-rejects PRs that contain AI `Co-authored-by` trailers.
+`Co-authored-by` tags by default (e.g. Claude Code, GitHub Copilot,
+Cursor) — please replace them with `Assisted-by`. An automated CI
+check rejects PRs that contain AI `Co-authored-by` trailers.
 
 This policy is inspired by the
 [Linux kernel's AI Coding Assistants policy](https://docs.kernel.org/process/coding-assistants.html).


### PR DESCRIPTION
- Follow-up to #687 review feedback: `Co-authored-by` was already matched case-insensitively, but `Assisted-by` / `Generated-by` were not
- Add Cursor to the list of banned Co-Authors, by default they have also started using the problematic `Co-authored-by` 
  - https://forum.cursor.com/t/co-author-added-without-consent-and-cant-be-turned-off/150096 - there is a setting in the UI you need to turn off. By default it injects this Co-Authored-by into commit shell commands making it hard for the agent/LLM itself to fight the harness.