### PR TITLE
CI: `cargo clippy --features aws-nitro,net` + fix the error

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -25,6 +25,9 @@ jobs:
       
       - name: Clippy (net+blk+gpu+input)
         run: cargo clippy --locked --features net,blk,gpu,input -- -D warnings
+      
+      - name: Clippy (aws-nitro+net)
+        run: cargo clippy --locked --features aws-nitro,net -- -D warnings
 
   code-quality-linux-aarch64:
     name: libkrun (Linux aarch64)

--- a/src/aws_nitro/src/enclave/proxy/mod.rs
+++ b/src/aws_nitro/src/enclave/proxy/mod.rs
@@ -105,7 +105,7 @@ impl DeviceProxyList {
                                             continue;
                                         } else {
                                             // Error in fetching message from receiver thread.
-                                            return Err(Error::ShutdownSignalReceive(e))?;
+                                            return Err(Error::ShutdownSignalReceive(e));
                                         }
                                     }
                                 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -368,9 +368,7 @@ impl TryFrom<ContextConfig> for NitroEnclave {
             return Err(-libc::EINVAL);
         };
 
-        let rootfs = if let Some(path) = &ctx.vmr.fs.first() {
-            path.shared_dir.clone()
-        } else {
+        let Some(rootfs) = ctx.vmr.fs.first().and_then(|p| p.shared_dir.clone()) else {
             error!("rootfs path required");
             return Err(-libc::EINVAL);
         };

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -57,7 +57,7 @@ use vmm::vmm_config::block::{BlockDeviceConfig, BlockRootConfig};
 use vmm::vmm_config::external_kernel::{ExternalKernel, KernelFormat};
 #[cfg(not(feature = "tee"))]
 use vmm::vmm_config::firmware::FirmwareConfig;
-#[cfg(not(feature = "tee"))]
+#[cfg(not(any(feature = "tee", feature = "aws-nitro")))]
 use vmm::vmm_config::fs::FsDeviceConfig;
 use vmm::vmm_config::kernel_bundle::KernelBundle;
 #[cfg(feature = "tee")]


### PR DESCRIPTION
Not sure if it is broken in other ways, but this should make it at least compile + we check for it in the CI.
@jakecorrenti 