### PR TITLE
linux, gentoo, asahi, guest write to a dma-buf blob mapping kills the VM with EFAULT, prefault the mapping in the VMM

### DIFF
--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -20,7 +20,7 @@ use krun_display::{
 use libc::c_void;
 #[cfg(target_os = "macos")]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_APPLE;
-#[cfg(all(feature = "virgl_resource_map2", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_DMABUF;
 #[cfg(all(not(feature = "virgl_resource_map2"), target_os = "linux"))]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_OPAQUE_FD;
@@ -66,6 +66,32 @@ fn sglist_to_rutabaga_iovecs(
         });
     }
     Ok(rutabaga_iovecs)
+}
+
+/// A dma-buf mapping is `VM_PFNMAP`, which KVM cannot fault in on its own: on a
+/// guest write to a page that has no writable PTE yet, `hva_to_pfn_remapped()`
+/// returns `KVM_PFN_ERR_RO_FAULT` and `KVM_RUN` fails with `EFAULT`, taking the
+/// VM down. Establishing the PTEs is therefore up to the VMM. Rewriting each
+/// page with the value it already holds leaves the contents untouched.
+///
+/// `MAP_POPULATE` is no substitute; it skips `VM_PFNMAP` VMAs.
+#[cfg(target_os = "linux")]
+fn prefault_dmabuf(addr: *mut c_void, size: usize, prot: i32) {
+    if prot & (libc::PROT_READ | libc::PROT_WRITE) != libc::PROT_READ | libc::PROT_WRITE {
+        return;
+    }
+
+    // SAFETY: `_SC_PAGESIZE` is always available.
+    let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) } as usize;
+
+    for offset in (0..size).step_by(page_size) {
+        // SAFETY: `offset` is within the readable and writable mapping of
+        // `size` bytes that starts at `addr`.
+        unsafe {
+            let page = (addr as *mut u8).add(offset);
+            page.write_volatile(page.read_volatile());
+        }
+    }
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -800,6 +826,9 @@ impl VirtioGpu {
                 if ret == libc::MAP_FAILED {
                     return Err(ErrUnspec);
                 }
+                if export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_DMABUF {
+                    prefault_dmabuf(ret, resource.size as usize, prot);
+                }
             } else {
                 return Err(ErrUnspec);
             }
@@ -871,6 +900,9 @@ impl VirtioGpu {
                         export.handle_type
                     );
                     return Err(ErrUnspec);
+                }
+                if export.handle_type == RUTABAGA_MEM_HANDLE_TYPE_DMABUF {
+                    prefault_dmabuf(ret, resource.size as usize, prot);
                 }
             } else {
                 self.rutabaga.resource_map(


### PR DESCRIPTION
I don´t know if this actually is a proper fix, this pr is at least a reminder that there is a problem (tested with krun 1.18) on asahi with kernel 7.1.5 which lets muvm crash when using this.

libkrun maps a blob resource exported as a dma-buf into the virtio-gpu shm region with mmap(MAP_FIXED). That VMA is VM_PFNMAP,  no struct page, not ordinary managed memory. 

When the guest writes to a page that has no writable PTE yet, KVM resolves the fault through hva_to_pfn_remapped(), finds no writable PTE, and returns KVM_PFN_ERR_RO_FAULT; user_mem_abort() fails with -EFAULT and KVM_RUN tears the VM down (Failure during vcpu run: Bad address). KVM cannot fault such memory in on its own, populating it is the VMM's job, and libkrun doesn't do it. Under muvm on Apple Silicon that means every GPU accelerated workload dies the moment the guest touches the GPU. memfd backed blobs have ordinary VMA flags and are unaffected.

The patch walks the fresh mapping once and rewrites every page with the value it already holds: contents unchanged, but a writable PTE exists before the guest ever reaches the page. It applies only to RUTABAGA_MEM_HANDLE_TYPE_DMABUF exports (memfd blobs keep lazy faulting) and only to PROT_READ|PROT_WRITE mappings, where the read modify write is safe. MAP_POPULATE is not an option: populate_vma_page_range() goes through __get_user_pages(), which rejects VM_PFNMAP in check_vma_flags(), and mm_populate() swallows the error. Cost: every page of a dma-buf blob is faulted in at map time rather than on demand.