### PR TITLE
vhost-user: add media device support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,7 +565,7 @@ dependencies = [
  "rustc_version",
  "tokio",
  "tracing",
- "vm-memory",
+ "vm-memory 0.17.1",
  "windows-sys",
 ]
 
@@ -680,7 +680,7 @@ dependencies = [
  "libc",
  "linux-loader",
  "tdx",
- "vm-memory",
+ "vm-memory 0.17.1",
  "vmm-sys-util",
  "windows-sys",
 ]
@@ -740,7 +740,7 @@ dependencies = [
  "vhost",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory",
+ "vm-memory 0.17.1",
  "vmm-sys-util",
  "windows-sys",
  "zerocopy",
@@ -816,7 +816,7 @@ name = "krun-kernel"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
  "krun-utils",
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -848,7 +848,7 @@ dependencies = [
 name = "krun-smbios"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -895,7 +895,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tdx",
- "vm-memory",
+ "vm-memory 0.17.1",
  "vmm-sys-util",
  "windows-sys",
  "zstd",
@@ -963,7 +963,7 @@ dependencies = [
  "log",
  "nitro-enclaves 0.5.0",
  "once_cell",
- "vm-memory",
+ "vm-memory 0.17.1",
  "windows-sys",
 ]
 
@@ -995,7 +995,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -1667,14 +1667,14 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vhost"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76d90ce3c6b37d610a5304c9a445cfff580cf8b4b9fd02fb256aaf68552c28a"
+checksum = "1c63c14485260662b4257bd929d5fd4aaf96bbecbe61d2224bad8807849f5f8f"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "uuid",
- "vm-memory",
+ "vm-memory 0.18.0",
  "vmm-sys-util",
 ]
 
@@ -1701,6 +1701,17 @@ name = "vm-memory"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
+dependencies = [
+ "libc",
+ "thiserror 2.0.18",
+ "winapi",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
 dependencies = [
  "libc",
  "thiserror 2.0.18",

--- a/examples/chroot_vm.c
+++ b/examples/chroot_vm.c
@@ -107,6 +107,7 @@ static const struct option long_options[] = {
     { "vhost-user-vsock", required_argument, NULL, 'K' },
     { "vhost-user-can", required_argument, NULL, 'A' },
     { "vhost-user-console", required_argument, NULL, 'O' },
+    { "vhost-user-media", required_argument, NULL, 'M' },
     { NULL, 0, NULL, 0 }
 };
 
@@ -124,6 +125,7 @@ struct cmdline {
     char const *vhost_user_vsock_socket;
     char const *vhost_user_can_socket;
     char const *vhost_user_console_socket;
+    char const *vhost_user_media_socket;
     char const *new_root;
     char *const *guest_argv;
 };
@@ -158,6 +160,7 @@ bool parse_cmdline(int argc, char *const argv[], struct cmdline *cmdline)
         .vhost_user_vsock_socket = NULL,
         .vhost_user_can_socket = NULL,
         .vhost_user_console_socket = NULL,
+        .vhost_user_media_socket = NULL,
         .new_root = NULL,
         .guest_argv = NULL,
         .log_target = KRUN_LOG_TARGET_DEFAULT,
@@ -216,6 +219,9 @@ bool parse_cmdline(int argc, char *const argv[], struct cmdline *cmdline)
             break;
         case 'O':
             cmdline->vhost_user_console_socket = optarg;
+            break;
+        case 'M':
+            cmdline->vhost_user_media_socket = optarg;
             break;
         case '?':
             return false;
@@ -354,7 +360,7 @@ int main(int argc, char *const argv[])
         uint16_t custom_sizes[] = {512, 0};  // 0 = sentinel terminator
 
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_RNG,
-                                                          cmdline.vhost_user_rng_socket, NULL, 0, custom_sizes),
+                                                          cmdline.vhost_user_rng_socket, NULL, 0, custom_sizes, 0),
                               "Error adding vhost-user RNG device")) {
             return -1;
         }
@@ -366,7 +372,7 @@ int main(int argc, char *const argv[])
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_RTC,
                                                           cmdline.vhost_user_rtc_socket, NULL,
                                                           KRUN_VHOST_USER_RTC_NUM_QUEUES,
-                                                          KRUN_VHOST_USER_RTC_QUEUE_SIZES),
+                                                          KRUN_VHOST_USER_RTC_QUEUE_SIZES, 0),
                               "Error adding vhost-user RTC device")) {
             return -1;
         }
@@ -378,7 +384,7 @@ int main(int argc, char *const argv[])
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_INPUT,
                                                           cmdline.vhost_user_input_socket, NULL,
                                                           KRUN_VHOST_USER_INPUT_NUM_QUEUES,
-                                                          KRUN_VHOST_USER_INPUT_QUEUE_SIZES),
+                                                          KRUN_VHOST_USER_INPUT_QUEUE_SIZES, 0),
                               "Error adding vhost-user input device")) {
             return -1;
         }
@@ -390,7 +396,8 @@ int main(int argc, char *const argv[])
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_GPU,
                                                           cmdline.vhost_user_gpu_socket, NULL,
                                                           KRUN_VHOST_USER_GPU_NUM_QUEUES,
-                                                          KRUN_VHOST_USER_GPU_QUEUE_SIZES),
+                                                          KRUN_VHOST_USER_GPU_QUEUE_SIZES,
+                                                          KRUN_VHOST_USER_GPU_SHM_SIZE),
                               "Error adding vhost-user GPU device")) {
             return -1;
         }
@@ -402,7 +409,7 @@ int main(int argc, char *const argv[])
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_SND,
                                                           cmdline.vhost_user_snd_socket, NULL,
                                                           KRUN_VHOST_USER_SND_NUM_QUEUES,
-                                                          KRUN_VHOST_USER_SND_QUEUE_SIZES),
+                                                          KRUN_VHOST_USER_SND_QUEUE_SIZES, 0),
                               "Error adding vhost-user sound device")) {
             return -1;
         }
@@ -414,7 +421,7 @@ int main(int argc, char *const argv[])
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_VSOCK,
                                                           cmdline.vhost_user_vsock_socket, NULL,
                                                           KRUN_VHOST_USER_VSOCK_NUM_QUEUES,
-                                                          KRUN_VHOST_USER_VSOCK_QUEUE_SIZES),
+                                                          KRUN_VHOST_USER_VSOCK_QUEUE_SIZES, 0),
                               "Error adding vhost-user vsock device")) {
             return -1;
         }
@@ -426,7 +433,7 @@ int main(int argc, char *const argv[])
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_CAN,
                                                           cmdline.vhost_user_can_socket, NULL,
                                                           KRUN_VHOST_USER_CAN_NUM_QUEUES,
-                                                          KRUN_VHOST_USER_CAN_QUEUE_SIZES),
+                                                          KRUN_VHOST_USER_CAN_QUEUE_SIZES, 0),
                               "Error adding vhost-user CAN device")) {
             return -1;
         }
@@ -438,12 +445,25 @@ int main(int argc, char *const argv[])
         if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_CONSOLE,
                                                           cmdline.vhost_user_console_socket, NULL,
                                                           KRUN_VHOST_USER_CONSOLE_NUM_QUEUES,
-                                                          KRUN_VHOST_USER_CONSOLE_QUEUE_SIZES),
+                                                          KRUN_VHOST_USER_CONSOLE_QUEUE_SIZES, 0),
                               "Error adding vhost-user console device")) {
             return -1;
         }
         printf("Using vhost-user console backend at %s (available as /dev/hvc1 in guest)\n", cmdline.vhost_user_console_socket);
         printf("Test with: echo 'hello' > /dev/hvc1\n");
+    }
+
+    // Configure vhost-user media if requested
+    if (cmdline.vhost_user_media_socket != NULL) {
+        if (!check_krun_error(krun_add_vhost_user_device(ctx_id, KRUN_VIRTIO_DEVICE_MEDIA,
+                                                          cmdline.vhost_user_media_socket, NULL,
+                                                          KRUN_VHOST_USER_MEDIA_NUM_QUEUES,
+                                                          KRUN_VHOST_USER_MEDIA_QUEUE_SIZES,
+                                                          KRUN_VHOST_USER_MEDIA_SHM_SIZE),
+                              "Error adding vhost-user media device")) {
+            return -1;
+        }
+        printf("Using vhost-user media backend at %s\n", cmdline.vhost_user_media_socket);
     }
 
     // Raise RLIMIT_NOFILE to the maximum allowed to create some room for virtio-fs

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -609,6 +609,7 @@ int krun_add_input_device_fd(uint32_t ctx_id, int input_fd);
 #define KRUN_VIRTIO_DEVICE_VSOCK 19
 #define KRUN_VIRTIO_DEVICE_SND 25
 #define KRUN_VIRTIO_DEVICE_CAN 36
+#define KRUN_VIRTIO_DEVICE_MEDIA 48
 
 /**
  * Vhost-user console device default queue configuration.
@@ -666,6 +667,15 @@ int krun_add_input_device_fd(uint32_t ctx_id, int input_fd);
  */
 #define KRUN_VHOST_USER_GPU_NUM_QUEUES 2
 #define KRUN_VHOST_USER_GPU_QUEUE_SIZES ((uint16_t[]){1024, 1024})
+#define KRUN_VHOST_USER_GPU_SHM_SIZE (UINT64_C(1) << 33)
+
+/**
+ * Vhost-user media device default queue configuration.
+ * Media device uses 2 queues: commandq (idx 0), eventq (idx 1).
+ */
+#define KRUN_VHOST_USER_MEDIA_NUM_QUEUES 2
+#define KRUN_VHOST_USER_MEDIA_QUEUE_SIZES ((uint16_t[]){1024, 1024})
+#define KRUN_VHOST_USER_MEDIA_SHM_SIZE (UINT64_C(1) << 32)
 
 /**
  * Add a vhost-user device to the VM.
@@ -691,23 +701,27 @@ int krun_add_input_device_fd(uint32_t ctx_id, int input_fd);
  *                   When num_queues=0 (auto-detect): array must be 0-terminated (sentinel).
  *                   When num_queues>0 (explicit): array must have exactly num_queues elements.
  *                   Use device-specific constants like KRUN_VHOST_USER_RNG_QUEUE_SIZES for defaults.
+ *  "shm_size"     - size of the SHMEM region in bytes.
+ *                   0 = no SHMEM region.
+ *                   Use device-specific constants like KRUN_VHOST_USER_MEDIA_SHM_SIZE for defaults.
  *
  * Examples:
- *  // Auto-detect queue count, use default size (256)
- *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_RNG, "/tmp/rng.sock", NULL, 0, NULL);
+ *  // Auto-detect queue count, use default size (256), no SHMEM
+ *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_RNG, "/tmp/rng.sock", NULL, 0, NULL, 0);
  *
  *  // Auto-detect queue count, use custom size (512) for all queues
  *  uint16_t custom_size[] = {512, 0};  // 0 = sentinel terminator
- *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_RNG, "/tmp/rng.sock", NULL, 0, custom_size);
+ *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_RNG, "/tmp/rng.sock", NULL, 0, custom_size, 0);
  *
- *  // Explicit defaults using #define constants
- *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_RNG, "/tmp/rng.sock", "vhost-rng",
- *                             KRUN_VHOST_USER_RNG_NUM_QUEUES,
- *                             KRUN_VHOST_USER_RNG_QUEUE_SIZES);
+ *  // Media device with SHMEM region
+ *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_MEDIA, "/tmp/media.sock", NULL,
+ *                             KRUN_VHOST_USER_MEDIA_NUM_QUEUES,
+ *                             KRUN_VHOST_USER_MEDIA_QUEUE_SIZES,
+ *                             KRUN_VHOST_USER_MEDIA_SHM_SIZE);
  *
  *  // Explicit queue count with custom sizes
  *  uint16_t sizes[] = {256, 512};
- *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_SND, "/tmp/snd.sock", "vhost-snd", 2, sizes);
+ *  krun_add_vhost_user_device(ctx, KRUN_VHOST_USER_DEVICE_SND, "/tmp/snd.sock", "vhost-snd", 2, sizes, 0);
  *
  * Returns:
  *  Zero on success or a negative error number on failure.
@@ -720,7 +734,8 @@ int32_t krun_add_vhost_user_device(uint32_t ctx_id,
                                    const char *socket_path,
                                    const char *name,
                                    uint16_t num_queues,
-                                   const uint16_t *queue_sizes);
+                                   const uint16_t *queue_sizes,
+                                   uint64_t shm_size);
 
 /**
  * Configures a map of rlimits to be set in the guest before starting the

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -30,7 +30,7 @@ libloading = "0.8"
 log = "0.4.0"
 rand = "0.10.2"
 thiserror = { version = "2.0", optional = true }
-vhost = { version = "0.15", optional = true, features = ["vhost-user-frontend"] }
+vhost = { version = "0.17", optional = true, features = ["vhost-user-frontend"] }
 vmm-sys-util = { version = "0.15", optional = true }
 virtio-bindings = "0.2.0"
 vm-memory = { version = "0.17", default-features = false, features = ["backend-mmap", "rawfd"] }

--- a/src/devices/src/virtio/vhost_user/device.rs
+++ b/src/devices/src/virtio/vhost_user/device.rs
@@ -264,24 +264,20 @@ impl VhostUserDevice {
             debug!("{}: GPU socket configured", self.device_name);
         }
 
-        // Only share memory regions that have file backing (memfd)
+        // Can't use from_guest_region(): vhost 0.17 expects vm-memory 0.18 types.
         let regions: Vec<VhostUserMemoryRegionInfo> = mem
             .iter()
             .filter_map(|region| {
-                if region.file_offset().is_some() {
-                    Some(VhostUserMemoryRegionInfo::from_guest_region(region))
-                } else {
-                    None
-                }
+                let file_offset = region.file_offset()?;
+                Some(VhostUserMemoryRegionInfo {
+                    guest_phys_addr: region.start_addr().raw_value(),
+                    memory_size: region.len(),
+                    userspace_addr: region.as_ptr() as u64,
+                    mmap_offset: file_offset.start(),
+                    mmap_handle: file_offset.file().as_raw_fd(),
+                })
             })
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| {
-                error!(
-                    "{}: failed to convert memory regions: {:?}",
-                    self.device_name, e
-                );
-                io::Error::other(e)
-            })?;
+            .collect();
 
         debug!(
             "{}: sharing {} file-backed regions with backend",

--- a/src/devices/src/virtio/vhost_user/device.rs
+++ b/src/devices/src/virtio/vhost_user/device.rs
@@ -7,7 +7,7 @@
 //! adapting it to work with libkrun's VirtioDevice trait.
 
 use std::io::{self, ErrorKind, IoSlice, Read, Result as IoResult, Write};
-use std::os::fd::{AsRawFd, FromRawFd};
+use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
 
@@ -20,8 +20,13 @@ use vhost::vhost_user::gpu_message::{
     GpuBackendReq, VhostUserGpuHeaderFlag, VirtioGpuDisplayOne, VirtioGpuRect,
     VirtioGpuRespDisplayInfo, VirtioGpuRespGetEdid,
 };
-use vhost::vhost_user::message::{FrontendReq, VhostUserConfigFlags};
-use vhost::vhost_user::{Frontend, VhostUserFrontend, VhostUserProtocolFeatures};
+use vhost::vhost_user::message::{
+    FrontendReq, VhostUserConfigFlags, VhostUserMMap, VhostUserMMapFlags,
+};
+use vhost::vhost_user::{
+    Frontend, FrontendReqHandler, VhostUserFrontend, VhostUserFrontendReqHandlerMut,
+    VhostUserProtocolFeatures,
+};
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
 use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
 use vmm_sys_util::eventfd::EventFd as VhostEventFd;
@@ -29,15 +34,22 @@ use vmm_sys_util::eventfd::EventFd as VhostEventFd;
 use crate::display::DisplayInfo;
 use crate::virtio::{
     ActivateError, ActivateResult, DeviceQueue, DeviceState, InterruptTransport, QueueConfig,
-    VirtioDevice,
+    VirtioDevice, VirtioShmRegion,
 };
 
 /// VHOST_USER_F_PROTOCOL_FEATURES (bit 30) is a backend-only feature
 /// that enables vhost-user protocol extensions. It's not a virtio feature.
 const VHOST_USER_F_PROTOCOL_FEATURES: u64 = 1 << 30;
 
-/// Virtio device type ID for GPU
-const VIRTIO_ID_GPU: u32 = 16;
+pub const VIRTIO_ID_GPU: u32 = 16;
+pub const VIRTIO_ID_MEDIA: u32 = 48;
+
+struct BorrowedFd(RawFd);
+impl AsRawFd for BorrowedFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
 
 /// Helper function to send GPU_SET_SOCKET message to vhost-user backend.
 /// Following QEMU's vhost_user_gpu_set_socket() pattern - sends message without waiting for ACK.
@@ -71,6 +83,124 @@ fn send_gpu_set_socket(
     Ok(())
 }
 
+/// Handles backend-to-frontend requests on the BACKEND_REQ channel,
+/// in particular shmem_map/shmem_unmap for devices that use shared memory regions.
+struct BackendReqInner {
+    shm_region: Option<VirtioShmRegion>,
+    device_name: String,
+}
+
+impl VhostUserFrontendReqHandlerMut for BackendReqInner {
+    fn handle_config_change(&mut self) -> io::Result<u64> {
+        debug!("{}: backend config change notification", self.device_name);
+        Ok(0)
+    }
+
+    fn shmem_map(&mut self, req: &VhostUserMMap, fd: &dyn AsRawFd) -> io::Result<u64> {
+        let shm = self
+            .shm_region
+            .as_ref()
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOTSUP))?;
+
+        let shm_offset = req.shm_offset;
+        let len = req.len;
+        let fd_offset = req.fd_offset;
+        let flags = req.flags;
+
+        let end = shm_offset
+            .checked_add(len)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+        if end > shm.size as u64 {
+            error!(
+                "{}: shmem_map out of bounds: offset={:#x} len={:#x} region_size={:#x}",
+                self.device_name, shm_offset, len, shm.size
+            );
+            return Err(io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let addr = shm.host_addr + shm_offset;
+        let prot = if VhostUserMMapFlags::from_bits(flags)
+            .unwrap_or_default()
+            .contains(VhostUserMMapFlags::WRITABLE)
+        {
+            libc::PROT_READ | libc::PROT_WRITE
+        } else {
+            libc::PROT_READ
+        };
+
+        // SAFETY: addr is within the pre-allocated shm_region (bounds checked above).
+        let result = unsafe {
+            libc::mmap(
+                addr as *mut libc::c_void,
+                len as usize,
+                prot,
+                libc::MAP_SHARED | libc::MAP_FIXED,
+                fd.as_raw_fd(),
+                fd_offset as libc::off_t,
+            )
+        };
+
+        if result == libc::MAP_FAILED {
+            let err = io::Error::last_os_error();
+            error!("{}: shmem_map mmap failed: {}", self.device_name, err);
+            return Err(err);
+        }
+
+        debug!(
+            "{}: shmem_map: offset={:#x} len={:#x} fd_offset={:#x}",
+            self.device_name, shm_offset, len, fd_offset
+        );
+        Ok(0)
+    }
+
+    fn shmem_unmap(&mut self, req: &VhostUserMMap) -> io::Result<u64> {
+        let shm = self
+            .shm_region
+            .as_ref()
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::ENOTSUP))?;
+
+        let shm_offset = req.shm_offset;
+        let len = req.len;
+
+        let end = shm_offset
+            .checked_add(len)
+            .ok_or_else(|| io::Error::from_raw_os_error(libc::EINVAL))?;
+        if end > shm.size as u64 {
+            error!(
+                "{}: shmem_unmap out of bounds: offset={:#x} len={:#x} region_size={:#x}",
+                self.device_name, shm_offset, len, shm.size
+            );
+            return Err(io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let addr = shm.host_addr + shm_offset;
+
+        // SAFETY: addr is within the pre-allocated shm_region (bounds checked above).
+        let result = unsafe {
+            libc::mmap(
+                addr as *mut libc::c_void,
+                len as usize,
+                libc::PROT_NONE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_FIXED,
+                -1,
+                0,
+            )
+        };
+
+        if result == libc::MAP_FAILED {
+            let err = io::Error::last_os_error();
+            error!("{}: shmem_unmap mmap failed: {}", self.device_name, err);
+            return Err(err);
+        }
+
+        debug!(
+            "{}: shmem_unmap: offset={:#x} len={:#x}",
+            self.device_name, shm_offset, len
+        );
+        Ok(0)
+    }
+}
+
 /// Generic vhost-user device wrapper.
 ///
 /// This wraps a vhost-user backend connection and implements the VirtioDevice
@@ -94,6 +224,9 @@ pub struct VhostUserDevice {
     /// Whether the backend supports protocol features
     has_protocol_features: bool,
 
+    /// Protocol features successfully negotiated with the backend
+    negotiated_protocol_features: VhostUserProtocolFeatures,
+
     /// Acknowledged features
     acked_features: u64,
 
@@ -111,6 +244,12 @@ pub struct VhostUserDevice {
 
     /// User-configured display resolution for GPU devices (display size, not guest scanout).
     gpu_display_info: Option<DisplayInfo>,
+
+    /// Shared memory region for devices that need it (e.g., media, GPU)
+    shm_region: Option<VirtioShmRegion>,
+
+    /// Handler for backend-to-frontend requests (BACKEND_REQ protocol feature)
+    backend_req_handler: Option<FrontendReqHandler<Mutex<BackendReqInner>>>,
 }
 
 impl VhostUserDevice {
@@ -156,19 +295,26 @@ impl VhostUserDevice {
         let has_protocol_features = avail_features & VHOST_USER_F_PROTOCOL_FEATURES != 0;
         let avail_features = avail_features & !VHOST_USER_F_PROTOCOL_FEATURES;
 
+        let mut negotiated_protocol_features = VhostUserProtocolFeatures::empty();
+
         if has_protocol_features {
             let protocol_features = frontend.get_protocol_features().map_err(io::Error::other)?;
 
-            let mut our_protocol_features = VhostUserProtocolFeatures::empty();
             if protocol_features.contains(VhostUserProtocolFeatures::CONFIG) {
-                our_protocol_features |= VhostUserProtocolFeatures::CONFIG;
+                negotiated_protocol_features |= VhostUserProtocolFeatures::CONFIG;
             }
             if protocol_features.contains(VhostUserProtocolFeatures::MQ) {
-                our_protocol_features |= VhostUserProtocolFeatures::MQ;
+                negotiated_protocol_features |= VhostUserProtocolFeatures::MQ;
+            }
+            if protocol_features.contains(VhostUserProtocolFeatures::BACKEND_REQ) {
+                negotiated_protocol_features |= VhostUserProtocolFeatures::BACKEND_REQ;
+            }
+            if protocol_features.contains(VhostUserProtocolFeatures::SHMEM) {
+                negotiated_protocol_features |= VhostUserProtocolFeatures::SHMEM;
             }
 
             frontend
-                .set_protocol_features(our_protocol_features)
+                .set_protocol_features(negotiated_protocol_features)
                 .map_err(io::Error::other)?;
         }
 
@@ -214,13 +360,20 @@ impl VhostUserDevice {
             queue_configs,
             avail_features,
             has_protocol_features,
+            negotiated_protocol_features,
             acked_features: 0,
             device_state: DeviceState::Inactive,
             activate_evt: EventFd::new(EFD_NONBLOCK)?,
             vring_call_event: None,
             gpu_socket: None,
             gpu_display_info,
+            shm_region: None,
+            backend_req_handler: None,
         })
+    }
+
+    pub fn set_shm_region(&mut self, region: VirtioShmRegion) {
+        self.shm_region = Some(region);
     }
 
     /// Activate the vhost-user device by setting up memory and vrings.
@@ -262,6 +415,27 @@ impl VhostUserDevice {
             self.gpu_socket = Some(our_end);
 
             debug!("{}: GPU socket configured", self.device_name);
+        }
+
+        // Set up backend request channel for shmem_map/shmem_unmap
+        if self
+            .negotiated_protocol_features
+            .contains(VhostUserProtocolFeatures::BACKEND_REQ)
+        {
+            let inner = BackendReqInner {
+                shm_region: self.shm_region.clone(),
+                device_name: self.device_name.clone(),
+            };
+            let handler = FrontendReqHandler::new(Arc::new(Mutex::new(inner)))
+                .map_err(|e| io::Error::other(format!("FrontendReqHandler::new: {e}")))?;
+
+            let tx_fd = BorrowedFd(handler.get_tx_raw_fd());
+            frontend
+                .set_backend_request_fd(&tx_fd)
+                .map_err(|e| io::Error::other(format!("set_backend_request_fd: {e}")))?;
+
+            debug!("{}: backend request channel established", self.device_name);
+            self.backend_req_handler = Some(handler);
         }
 
         // Can't use from_guest_region(): vhost 0.17 expects vm-memory 0.18 types.
@@ -526,6 +700,10 @@ impl VirtioDevice for VhostUserDevice {
         matches!(self.device_state, DeviceState::Activated(_, _))
     }
 
+    fn shm_region(&self) -> Option<&VirtioShmRegion> {
+        self.shm_region.as_ref()
+    }
+
     fn reset(&mut self) -> bool {
         debug!("{}: resetting vhost-user device", self.device_name);
 
@@ -543,6 +721,7 @@ impl VirtioDevice for VhostUserDevice {
 
         self.vring_call_event = None;
         self.gpu_socket = None;
+        self.backend_req_handler = None;
         self.device_state = DeviceState::Inactive;
         true
     }
@@ -735,6 +914,29 @@ impl VhostUserDevice {
         }
     }
 
+    fn handle_backend_req_event(&mut self, event: &EpollEvent) {
+        let event_set = event.event_set();
+
+        if event_set.contains(EventSet::HANG_UP) || event_set.contains(EventSet::ERROR) {
+            warn!("{}: backend request channel disconnected", self.device_name);
+            self.backend_req_handler = None;
+            return;
+        }
+
+        if !event_set.contains(EventSet::IN) {
+            return;
+        }
+
+        if let Some(ref mut handler) = self.backend_req_handler
+            && let Err(e) = handler.handle_request()
+        {
+            error!(
+                "{}: failed to handle backend request: {}",
+                self.device_name, e
+            );
+        }
+    }
+
     fn handle_activate_event(&mut self, event_manager: &mut EventManager) {
         debug!("{}: activate event", self.device_name);
 
@@ -782,6 +984,26 @@ impl VhostUserDevice {
                     self.device_name
                 );
             }
+
+            // Register backend request channel for shmem_map/shmem_unmap
+            if let Some(ref handler) = self.backend_req_handler {
+                event_manager
+                    .register(
+                        handler.as_raw_fd(),
+                        EpollEvent::new(EventSet::IN, handler.as_raw_fd() as u64),
+                        self_subscriber.clone(),
+                    )
+                    .unwrap_or_else(|e| {
+                        error!(
+                            "{}: failed to register backend_req_handler with event manager: {e:?}",
+                            self.device_name
+                        );
+                    });
+                debug!(
+                    "{}: backend request channel registered with event manager",
+                    self.device_name
+                );
+            }
         } else {
             error!(
                 "{}: vring_call_event is None during activation",
@@ -815,11 +1037,17 @@ impl Subscriber for VhostUserDevice {
             .as_ref()
             .map(|s| s.as_raw_fd())
             .unwrap_or(-1);
+        let backend_req_fd = self
+            .backend_req_handler
+            .as_ref()
+            .map(|h| h.as_raw_fd())
+            .unwrap_or(-1);
 
         if self.is_activated() {
             match source {
                 _ if source == vring_call_fd => self.handle_vring_call_event(event),
                 _ if source == gpu_socket_fd => self.handle_gpu_socket_event(event),
+                _ if source == backend_req_fd => self.handle_backend_req_event(event),
                 _ if source == activate_evt_fd => self.handle_activate_event(event_manager),
                 _ => warn!(
                     "{}: unexpected event received: {source:?}",

--- a/src/devices/src/virtio/vhost_user/mod.rs
+++ b/src/devices/src/virtio/vhost_user/mod.rs
@@ -8,4 +8,4 @@
 
 mod device;
 
-pub use device::VhostUserDevice;
+pub use device::{VIRTIO_ID_GPU, VIRTIO_ID_MEDIA, VhostUserDevice};

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -86,7 +86,6 @@ const MAX_ARGS: usize = 4096;
 /// Maximum number of virtqueues allowed by virtio spec (16-bit queue index: 0-65535)
 #[cfg(feature = "vhost-user")]
 const VIRTIO_MAX_QUEUES: usize = 65536;
-
 // krunfw library name for each context
 #[cfg(all(target_os = "linux", not(feature = "tee")))]
 const KRUNFW_NAME: &str = "libkrunfw.so.5";
@@ -1738,6 +1737,7 @@ pub unsafe extern "C" fn krun_add_vhost_user_device(
     name: *const c_char,
     num_queues: u16,
     queue_sizes: *const u16,
+    shm_size: u64,
 ) -> i32 {
     use vmm::resources::VhostUserDeviceConfig;
 
@@ -1786,12 +1786,19 @@ pub unsafe extern "C" fn krun_add_vhost_user_device(
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => {
             let cfg = ctx_cfg.get_mut();
+            let shm_size = if shm_size > 0 {
+                Some(shm_size as usize)
+            } else {
+                None
+            };
+
             cfg.vmr.vhost_user_devices.push(VhostUserDeviceConfig {
                 device_type,
                 socket_path: socket_path_str.to_string(),
                 name: name_opt,
                 num_queues,
                 queue_sizes: queue_sizes_vec,
+                shm_size,
             });
             KRUN_SUCCESS
         }
@@ -1809,6 +1816,7 @@ pub unsafe extern "C" fn krun_add_vhost_user_device(
     _name: *const c_char,
     _num_queues: u16,
     _queue_sizes: *const u16,
+    _shm_size: u64,
 ) -> i32 {
     -libc::ENOTSUP
 }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1212,12 +1212,14 @@ pub fn build_microvm(
         #[cfg(all(feature = "vhost-user", target_os = "linux"))]
         {
             const VIRTIO_ID_RNG: u32 = 4;
-            for device_config in &vm_resources.vhost_user_devices {
+            for (index, device_config) in vm_resources.vhost_user_devices.iter().enumerate() {
                 attach_vhost_user_device(
                     &mut vmm,
+                    &_shm_manager,
                     event_manager,
                     intc.clone(),
                     device_config,
+                    index,
                     vm_resources.displays.first().cloned(),
                 )?;
             }
@@ -1881,6 +1883,15 @@ pub fn create_guest_memory(
         shm_manager
             .create_gpu_region(size)
             .map_err(StartMicrovmError::ShmCreate)?;
+    }
+
+    #[cfg(all(feature = "vhost-user", target_os = "linux"))]
+    for (index, device_config) in vm_resources.vhost_user_devices.iter().enumerate() {
+        if let Some(shm_size) = device_config.shm_size {
+            shm_manager
+                .create_vhost_user_region(index, shm_size)
+                .map_err(StartMicrovmError::ShmCreate)?;
+        }
     }
 
     // For vhost-user devices, we need file-backed memory so the backend can mmap it
@@ -2887,9 +2898,11 @@ fn attach_rng_device(
 #[cfg(all(feature = "vhost-user", target_os = "linux"))]
 fn attach_vhost_user_device(
     vmm: &mut Vmm,
+    shm_manager: &ShmManager,
     event_manager: &mut EventManager,
     intc: IrqChip,
     device_config: &VhostUserDeviceConfig,
+    device_index: usize,
     gpu_display: Option<DisplayInfo>,
 ) -> std::result::Result<(), StartMicrovmError> {
     use self::StartMicrovmError::*;
@@ -2910,6 +2923,17 @@ fn attach_vhost_user_device(
         )
         .map_err(|e| RegisterVhostUserDevice(device_manager::mmio::Error::VhostUserDevice(e)))?,
     ));
+
+    if let Some(shm_region) = shm_manager.vhost_user_region(device_index) {
+        device.lock().unwrap().set_shm_region(VirtioShmRegion {
+            host_addr: vmm
+                .guest_memory
+                .get_host_address(shm_region.guest_addr)
+                .map_err(StartMicrovmError::ShmHostAddr)? as u64,
+            guest_addr: shm_region.guest_addr.raw_value(),
+            size: shm_region.size,
+        });
+    }
 
     event_manager
         .add_subscriber(device.clone())

--- a/src/vmm/src/device_manager/shm.rs
+++ b/src/vmm/src/device_manager/shm.rs
@@ -21,6 +21,8 @@ pub struct ShmManager {
     page_size: usize,
     fs_regions: BTreeMap<usize, ShmRegion>,
     gpu_region: Option<ShmRegion>,
+    #[cfg(feature = "vhost-user")]
+    vhost_user_regions: BTreeMap<usize, ShmRegion>,
 }
 
 impl ShmManager {
@@ -30,6 +32,8 @@ impl ShmManager {
             page_size: info.page_size,
             fs_regions: BTreeMap::new(),
             gpu_region: None,
+            #[cfg(feature = "vhost-user")]
+            vhost_user_regions: BTreeMap::new(),
         }
     }
 
@@ -41,6 +45,11 @@ impl ShmManager {
         }
 
         if let Some(region) = &self.gpu_region {
+            regions.push((region.guest_addr, region.size));
+        }
+
+        #[cfg(feature = "vhost-user")]
+        for region in self.vhost_user_regions.values() {
             regions.push((region.guest_addr, region.size));
         }
 
@@ -87,5 +96,17 @@ impl ShmManager {
         let region = self.create_region(size)?;
         self.fs_regions.insert(index, region);
         Ok(())
+    }
+
+    #[cfg(feature = "vhost-user")]
+    pub fn create_vhost_user_region(&mut self, index: usize, size: usize) -> Result<(), Error> {
+        let region = self.create_region(size)?;
+        self.vhost_user_regions.insert(index, region);
+        Ok(())
+    }
+
+    #[cfg(feature = "vhost-user")]
+    pub fn vhost_user_region(&self, index: usize) -> Option<&ShmRegion> {
+        self.vhost_user_regions.get(&index)
     }
 }

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -60,6 +60,8 @@ pub struct VhostUserDeviceConfig {
     pub num_queues: u16,
     /// Size of each queue (empty = use device defaults)
     pub queue_sizes: Vec<u16>,
+    /// Size of the shared memory region (None = no SHMEM region)
+    pub shm_size: Option<usize>,
 }
 
 /// Errors encountered when configuring microVM resources.


### PR DESCRIPTION
### Summary

- Upgrade vhost crate from 0.15 to 0.17 for SHMEM and BACKEND_REQ protocol support
- Add shared memory region allocation for vhost-user devices and implement the BACKEND_REQ channel for handling shmem_map/shmem_unmap requests from backends
- Expose vhost-user media device type (VIRTIO_ID_MEDIA = 48) with 4 GiB SHMEM region

### How to test

For the backend run:
RUST_LOG=debug ./target/debug/vhost-device-media \
--socket-path /tmp/vhost-user-media.sock \
--v4l2-device /dev/video0 --backend v4l2-proxy

In the guest:
LD_LIBRARY_PATH=./target/release ./examples/chroot_vm \
--vhost-user-media=/tmp/vhost-user-media.sock / /bin/bash

To Capture:
v4l2-ctl -d /dev/video0 --set-fmt-video=pixelformat=MJPG \
--stream-mmap --stream-count=60 --stream-to=/tmp/video.mjpg

Test Playback (on host):
ffplay -f mjpeg /tmp/video.mjpg