### PR TITLE
Add TDX quote relay, SNP host data, and confidential VFIO

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,6 @@ dependencies = [
  "rustc_version",
  "tokio",
  "tracing",
- "vm-memory 0.17.1",
  "windows-sys",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bzip2"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,7 +571,7 @@ dependencies = [
  "rustc_version",
  "tokio",
  "tracing",
- "vm-memory",
+ "vm-memory 0.17.1",
  "windows-sys",
 ]
 
@@ -586,6 +592,23 @@ name = "iocuddle"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
+
+[[package]]
+name = "iommufd-bindings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd7de3a04f6fd55f171a6682852f7aa360bb848a85e0c610513349e006b3c139"
+
+[[package]]
+name = "iommufd-ioctls"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8050f03ef0c6979597140b6d20da076931fb7a06389b8b0eb971b8f65b271748"
+dependencies = [
+ "iommufd-bindings",
+ "thiserror 2.0.18",
+ "vmm-sys-util",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -676,12 +699,12 @@ dependencies = [
  "krun-utils",
  "krun-whp",
  "kvm-bindings",
- "kvm-ioctls",
+ "kvm-ioctls 0.24.0",
  "libc",
  "linux-loader",
  "tdx",
- "vm-memory",
- "vmm-sys-util 0.15.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util",
  "windows-sys",
 ]
 
@@ -708,8 +731,8 @@ name = "krun-cpuid"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
  "kvm-bindings",
- "kvm-ioctls",
- "vmm-sys-util 0.15.0",
+ "kvm-ioctls 0.24.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -729,7 +752,7 @@ dependencies = [
  "krun-utils",
  "krun-whp",
  "kvm-bindings",
- "kvm-ioctls",
+ "kvm-ioctls 0.24.0",
  "libc",
  "libloading",
  "log",
@@ -740,8 +763,8 @@ dependencies = [
  "vhost",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory",
- "vmm-sys-util 0.15.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util",
  "windows-sys",
  "zerocopy",
 ]
@@ -816,7 +839,7 @@ name = "krun-kernel"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
  "krun-utils",
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -839,7 +862,7 @@ dependencies = [
  "pkg-config",
  "remain",
  "thiserror 1.0.69",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "winapi",
  "zerocopy",
 ]
@@ -848,7 +871,7 @@ dependencies = [
 name = "krun-smbios"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -861,7 +884,7 @@ dependencies = [
  "libc",
  "log",
  "nix 0.30.1",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
  "windows-sys",
 ]
 
@@ -875,6 +898,7 @@ dependencies = [
  "crossbeam-channel",
  "flate2",
  "iocuddle",
+ "iommufd-ioctls",
  "kbs-types",
  "krun-arch",
  "krun-arch-gen",
@@ -887,7 +911,8 @@ dependencies = [
  "krun-polly",
  "krun-utils",
  "kvm-bindings",
- "kvm-ioctls",
+ "kvm-ioctls 0.24.0",
+ "kvm-ioctls 0.25.0",
  "libc",
  "linux-loader",
  "log",
@@ -895,8 +920,10 @@ dependencies = [
  "serde",
  "serde_json",
  "tdx",
- "vm-memory",
- "vmm-sys-util 0.14.0",
+ "vfio-bindings",
+ "vfio-ioctls",
+ "vm-memory 0.17.1",
+ "vmm-sys-util",
  "windows-sys",
  "zstd",
 ]
@@ -911,11 +938,11 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
 dependencies = [
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -927,7 +954,19 @@ dependencies = [
  "bitflags 2.11.0",
  "kvm-bindings",
  "libc",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "kvm-ioctls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ac372c120eb893b086d1a12027669cf2b478d1f71204021ffa7adf57948d63"
+dependencies = [
+ "bitflags 2.11.0",
+ "kvm-bindings",
+ "libc",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -957,13 +996,13 @@ dependencies = [
  "krun-utils",
  "krun-vmm",
  "kvm-bindings",
- "kvm-ioctls",
+ "kvm-ioctls 0.24.0",
  "libc",
  "libloading",
  "log",
  "nitro-enclaves 0.5.0",
  "once_cell",
- "vm-memory",
+ "vm-memory 0.17.1",
  "windows-sys",
 ]
 
@@ -995,7 +1034,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
 dependencies = [
- "vm-memory",
+ "vm-memory 0.17.1",
 ]
 
 [[package]]
@@ -1531,10 +1570,10 @@ dependencies = [
  "bitflags 2.11.0",
  "iocuddle",
  "kvm-bindings",
- "kvm-ioctls",
+ "kvm-ioctls 0.24.0",
  "libc",
  "uuid",
- "vmm-sys-util 0.15.0",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1666,6 +1705,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "vfio-bindings"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "188dac3057a0cbc94470085204c84b82ff7ec5dac629a514323cd133d1f9abe0"
+
+[[package]]
+name = "vfio-ioctls"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22f93a7f6cc51b8671b9282ed6487b0c905890be20ffa4a26835d2652a7c638"
+dependencies = [
+ "byteorder",
+ "iommufd-bindings",
+ "iommufd-ioctls",
+ "kvm-bindings",
+ "kvm-ioctls 0.25.0",
+ "libc",
+ "log",
+ "thiserror 2.0.18",
+ "vfio-bindings",
+ "vm-memory 0.18.0",
+ "vmm-sys-util",
+]
+
+[[package]]
 name = "vhost"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,8 +1738,8 @@ dependencies = [
  "bitflags 2.11.0",
  "libc",
  "uuid",
- "vm-memory",
- "vmm-sys-util 0.15.0",
+ "vm-memory 0.17.1",
+ "vmm-sys-util",
 ]
 
 [[package]]
@@ -1708,13 +1772,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "vmm-sys-util"
-version = "0.14.0"
+name = "vm-memory"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d21f366bf22bfba3e868349978766a965cbe628c323d58e026be80b8357ab789"
+checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
 dependencies = [
- "bitflags 1.3.2",
  "libc",
+ "thiserror 2.0.18",
+ "winapi",
 ]
 
 [[package]]

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ endif
 ifeq ($(VHOST_USER),1)
     FEATURE_FLAGS += --features vhost-user
 endif
+ifeq ($(VFIO),1)
+    FEATURE_FLAGS += --features vfio
+endif
 ifeq ($(TIMESYNC),1)
     FEATURE_FLAGS += --features timesync
 endif

--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ When TSI is enabled, the VMM acts as a proxy for AF_INET, AF_INET6 and AF_UNIX s
 * **VIRGL_RESOURCE_MAP2=1**: Uses virgl_resource_map2 function. Requires a virglrenderer-devel patched with [1374](https://gitlab.freedesktop.org/virgl/virglrenderer/-/merge_requests/1374)
 * **BLK=1**: Enables virtio-block.
 * **NET=1**: Enables virtio-net.
+* **VFIO=1**: Enables Linux x86_64 PCI device assignment through VFIO cdev and
+  IOMMUFD. See [the VFIO guide](docs/vfio.md) for its host and security
+  requirements.
 
 
 #### Compiling

--- a/docs/vfio.md
+++ b/docs/vfio.md
@@ -1,0 +1,66 @@
+# VFIO PCI device assignment
+
+libkrun can cold-plug Linux PCI functions into an x86_64 guest with the VFIO
+cdev and IOMMUFD kernel APIs. Build the selected library variant with `VFIO=1`
+and pass one already-open `/dev/vfio/devices/vfioN` descriptor per function to
+`krun_add_vfio_device` before starting the VM.
+
+```c
+int fd = open("/dev/vfio/devices/vfio42", O_RDWR | O_CLOEXEC);
+if (fd < 0)
+    /* handle errno */;
+
+/* Expose the function as 0000:00:01.0 in the guest. */
+int ret = krun_add_vfio_device(ctx_id, fd, 1, 0);
+close(fd); /* libkrun retained its own duplicate */
+if (ret < 0)
+    /* handle -ret as errno */;
+```
+
+The host must provide `/dev/iommu`, VFIO cdev support, and a VFIO PCI variant
+driver. The caller is responsible for binding every function it assigns and
+for ensuring that every device in the effective IOMMU isolation group is
+assigned together or detached from host drivers. Use each function's
+`vfio-dev` sysfs entry to resolve the exact cdev; cdev numbers are not stable
+identifiers.
+
+The current boundary deliberately supports:
+
+- PCI mechanism #1 on guest bus 0, with explicit device/function placement.
+- Fixed 32-bit and 64-bit memory BAR assignment, including very large 64-bit
+  BARs.
+- MSI-X delivery through KVM and device reset at attach and teardown.
+- One IOMMUFD IOAS for the VM with identity IOVA-to-GPA mappings.
+- Confidential-guest DMA only to pages that the guest converted to shared
+  state. Ordinary guests map all RAM at startup.
+
+It does not currently implement hot plug, migration, I/O BARs, MSI, or INTx.
+Guest drivers for assigned devices therefore need usable MSI-X capabilities.
+
+## Confidential-computing boundary
+
+VFIO assignment and IOMMU isolation are necessary plumbing, not proof that a
+device belongs to the confidential VM. This API does not by itself establish
+PCIe IDE encryption, TDISP assignment, device firmware identity, GPU protected
+mode, or encrypted GPU-to-GPU links. A relying party must verify those claims
+from CPU, device, and topology evidence tied to the same launch policy.
+
+For accelerator configurations such as NVIDIA B200, the guest and vendor
+driver stack must establish the protected-device session and collect signed
+GPU evidence. An eight-GPU system must additionally attest every GPU and the
+NVSwitch/NVLink topology; a successful VM quote alone is insufficient. libkrun
+fails closed on confidential DMA by leaving all pages unmapped until the guest
+explicitly shares them, but hardware-backed validation still requires the
+target platform.
+
+## Build combinations
+
+```sh
+make VFIO=1
+make SEV=1 VFIO=1
+make TDX=1 VFIO=1
+```
+
+`krun_has_feature(KRUN_FEATURE_VFIO)` reports whether the running library has
+the supported Linux x86_64 VFIO boundary. Other targets retain the API symbol
+and return `ENOTSUP` from `krun_add_vfio_device`.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -900,6 +900,26 @@ int32_t krun_set_tdx_quote_generation_socket(uint32_t ctx_id,
                                               const char *filepath);
 
 /**
+ * Adds a pre-opened VFIO cdev as a cold-plugged PCI function.
+ *
+ * The descriptor must refer to /dev/vfio/devices/vfioN and is duplicated by
+ * libkrun, so the caller may close its copy after this call. The device must
+ * already be bound to a VFIO PCI variant driver. All devices in its effective
+ * IOMMU isolation group must be assigned together or otherwise detached from
+ * host drivers.
+ *
+ * On confidential VMs, DMA is mapped only for guest pages converted to shared
+ * state. Device assignment does not by itself establish TDISP, PCIe IDE, or a
+ * vendor confidential-computing trust relationship.
+ *
+ * Returns zero on success or a negative errno on failure.
+ */
+int32_t krun_add_vfio_device(uint32_t ctx_id,
+                             int vfio_cdev_fd,
+                             uint8_t guest_device,
+                             uint8_t guest_function);
+
+/**
  * Adds a port-path pairing for guest IPC with a process in the host.
  *
  * Arguments:
@@ -1035,6 +1055,7 @@ int32_t krun_check_nested_virt(void);
 #define KRUN_FEATURE_INTEL_TDX 8
 #define KRUN_FEATURE_AWS_NITRO 9
 #define KRUN_FEATURE_VIRGL_RESOURCE_MAP2 10
+#define KRUN_FEATURE_VFIO 12
 
 /**
  * Checks if a specific feature was enabled at build time.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -884,6 +884,18 @@ int32_t krun_set_tee_config_file(uint32_t ctx_id, const char *filepath);
 int32_t krun_set_tee_type(uint32_t ctx_id, uint32_t tee_type);
 
 /**
+ * Sets the exact 32-byte guest-owner commitment returned in the HOST_DATA
+ * field of every SEV-SNP attestation report for this VM. The value is copied.
+ * Only available in AMD SEV-SNP variants.
+ *
+ * Returns zero on success, -EINVAL for a null or non-32-byte input, -ENOENT
+ * when ctx_id does not exist, or -ENOTSUP in non-SNP builds.
+ */
+int32_t krun_set_snp_host_data(uint32_t ctx_id,
+                               const uint8_t *host_data,
+                               size_t host_data_len);
+
+/**
  * Sets the host Quote Generation Service Unix socket used to service the TDX
  * TDG.VP.VMCALL<GetQuote> interface. Only available in the TDX variant.
  *

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -852,7 +852,8 @@ int32_t krun_set_kernel(uint32_t ctx_id,
                         const char *cmdline);
 
 /**
- * Sets the file path to the TEE configuration file. Only available in libkrun-sev.
+ * Sets the file path to the legacy JSON TEE configuration file. Only available
+ * in TEE variants.
  *
  * Arguments:
  *  "ctx_id"    - the configuration context ID.
@@ -862,6 +863,25 @@ int32_t krun_set_kernel(uint32_t ctx_id,
  *  Zero on success or a negative error number on failure.
  */
 int32_t krun_set_tee_config_file(uint32_t ctx_id, const char *filepath);
+
+#define KRUN_TEE_SNP 0
+#define KRUN_TEE_TDX 1
+/**
+ * Selects the confidential-computing technology for this context. Only
+ * available in TEE variants. CPU and memory configuration remains owned by
+ * krun_set_vm_config().
+ *
+ * Arguments:
+ *  "ctx_id"    - the configuration context ID.
+ *  "tee_type"  - KRUN_TEE_SNP or KRUN_TEE_TDX.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ *  -EINVAL  - tee_type is unknown.
+ *  -ENOTSUP - tee_type is not supported by this libkrun variant.
+ *  -ENOENT  - ctx_id does not exist.
+ */
+int32_t krun_set_tee_type(uint32_t ctx_id, uint32_t tee_type);
 
 /**
  * Adds a port-path pairing for guest IPC with a process in the host.

--- a/include/libkrun.h
+++ b/include/libkrun.h
@@ -884,6 +884,22 @@ int32_t krun_set_tee_config_file(uint32_t ctx_id, const char *filepath);
 int32_t krun_set_tee_type(uint32_t ctx_id, uint32_t tee_type);
 
 /**
+ * Sets the host Quote Generation Service Unix socket used to service the TDX
+ * TDG.VP.VMCALL<GetQuote> interface. Only available in the TDX variant.
+ *
+ * Arguments:
+ *  "ctx_id"    - the configuration context ID.
+ *  "filepath"  - a null-terminated host Unix socket path.
+ *
+ * Returns:
+ *  Zero on success or a negative error number on failure.
+ *  -EINVAL - filepath is not valid UTF-8.
+ *  -ENOENT - ctx_id does not exist.
+ */
+int32_t krun_set_tdx_quote_generation_socket(uint32_t ctx_id,
+                                              const char *filepath);
+
+/**
  * Adds a port-path pairing for guest IPC with a process in the host.
  *
  * Arguments:

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -42,7 +42,10 @@ arch = { package = "krun-arch", version = "=0.1.0-2.0.0-dev", path = "../arch" }
 utils = { package = "krun-utils", version = "=0.1.0-2.0.0-dev", path = "../utils" }
 polly = { package = "krun-polly", version = "=0.1.0-2.0.0-dev", path = "../polly" }
 rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-2.0.0-dev", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
-imago = { version = "0.2.3", features = ["sync-wrappers", "vm-memory"] }
+# Keep vm-memory owned by this crate. imago's broad >=0.16,<0.19 range can
+# otherwise resolve to VFIO's 0.18 release and make its VolatileSlice helpers
+# ABI-incompatible with libkrun's 0.17 guest-memory types.
+imago = { version = "0.2.3", features = ["sync-wrappers"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30.1", features = ["ioctl", "net", "poll", "socket", "fs"] }

--- a/src/devices/src/virtio/file_traits.rs
+++ b/src/devices/src/virtio/file_traits.rs
@@ -4,11 +4,15 @@
 
 use std::fs::File;
 use std::io::{Error, ErrorKind, Result};
+#[cfg(feature = "blk")]
+use std::io::{IoSlice, IoSliceMut};
 use std::os::unix::io::AsRawFd;
 
 #[cfg(feature = "blk")]
 use imago::io_buffers::{IoVector, IoVectorMut};
 use vm_memory::VolatileSlice;
+#[cfg(feature = "blk")]
+use vm_memory::bitmap::Bitmap;
 
 use libc::{c_int, c_void, read, readv, size_t, write, writev};
 
@@ -427,12 +431,29 @@ impl FileReadWriteAtVolatile for DiskProperties {
             return Ok(0);
         }
 
-        let (iovec, _guard) = IoVectorMut::from_volatile_slice(bufs);
+        let guards = bufs
+            .iter()
+            .map(VolatileSlice::ptr_guard_mut)
+            .collect::<Vec<_>>();
+        let buffers = guards
+            .iter()
+            .map(|guard| {
+                // SAFETY: each pointer guard keeps its guest mapping valid for
+                // the lifetime of the I/O vector, and exposes exactly `len`
+                // writable bytes.
+                let slice = unsafe { std::slice::from_raw_parts_mut(guard.as_ptr(), guard.len()) };
+                IoSliceMut::new(slice)
+            })
+            .collect::<Vec<_>>();
+        let iovec = IoVectorMut::from(buffers);
         let full_length = iovec
             .len()
             .try_into()
             .map_err(|e| Error::new(ErrorKind::InvalidData, e))?;
         self.file.lock().unwrap().readv(iovec, offset)?;
+        for buf in bufs {
+            buf.bitmap().mark_dirty(0, buf.len());
+        }
         Ok(full_length)
     }
 
@@ -445,7 +466,21 @@ impl FileReadWriteAtVolatile for DiskProperties {
             return Ok(0);
         }
 
-        let (iovec, _guard) = IoVector::from_volatile_slice(bufs);
+        let guards = bufs
+            .iter()
+            .map(VolatileSlice::ptr_guard)
+            .collect::<Vec<_>>();
+        let buffers = guards
+            .iter()
+            .map(|guard| {
+                // SAFETY: each pointer guard keeps its guest mapping valid for
+                // the lifetime of the I/O vector, and exposes exactly `len`
+                // readable bytes.
+                let slice = unsafe { std::slice::from_raw_parts(guard.as_ptr(), guard.len()) };
+                IoSlice::new(slice)
+            })
+            .collect::<Vec<_>>();
+        let iovec = IoVector::from(buffers);
         let full_length = iovec
             .len()
             .try_into()

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -19,6 +19,7 @@ input = ["krun_input", "vmm/input", "devices/input"]
 virgl_resource_map2 = ["devices/virgl_resource_map2"]
 aws-nitro = ["vmm/aws-nitro", "devices/aws-nitro", "dep:aws-nitro", "dep:nitro-enclaves"]
 vhost-user = ["vmm/vhost-user", "devices/vhost-user"]
+vfio = ["vmm/vfio"]
 timesync = ["devices/timesync"]
 
 [dependencies]

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -50,6 +50,8 @@ use utils::windows::SendHandle;
 use vmm::VmCtl;
 #[cfg(feature = "tee")]
 use vmm::resources::TeeType;
+#[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+use vmm::resources::VfioDeviceConfig;
 use vmm::resources::{
     DefaultVirtioConsoleConfig, PortConfig, SerialConsoleConfig, TsiFlags, VirtioConsoleConfigMode,
     VmResources, VsockConfig,
@@ -1361,6 +1363,69 @@ pub extern "C" fn krun_set_tee_type(ctx_id: u32, tee_type: u32) -> i32 {
     KRUN_SUCCESS
 }
 
+/// Adds a pre-opened VFIO cdev as a cold-plugged PCI function.
+///
+/// The file descriptor is duplicated with `F_DUPFD_CLOEXEC`; the caller may
+/// close its copy after this function returns. The descriptor must refer to a
+/// `/dev/vfio/devices/vfioN` cdev. Device 0 is reserved for the virtual host
+/// bridge, and duplicate guest BDFs are rejected.
+#[unsafe(no_mangle)]
+#[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+pub extern "C" fn krun_add_vfio_device(
+    ctx_id: u32,
+    vfio_cdev_fd: c_int,
+    guest_device: u8,
+    guest_function: u8,
+) -> i32 {
+    if vfio_cdev_fd < 0 || guest_device == 0 || guest_device > 31 || guest_function > 7 {
+        return -libc::EINVAL;
+    }
+
+    // SAFETY: fcntl does not take ownership of the source descriptor. A
+    // non-negative return value is a new descriptor owned by this context.
+    let duplicated = unsafe { libc::fcntl(vfio_cdev_fd, libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicated < 0 {
+        return -std::io::Error::last_os_error()
+            .raw_os_error()
+            .unwrap_or(libc::EIO);
+    }
+    // SAFETY: `duplicated` is a fresh descriptor returned by fcntl and its
+    // ownership is transferred into File exactly once.
+    let device = unsafe { File::from_raw_fd(duplicated) };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => {
+            if ctx_cfg
+                .get_mut()
+                .vmr
+                .add_vfio_device(VfioDeviceConfig {
+                    device,
+                    guest_device,
+                    guest_function,
+                })
+                .is_err()
+            {
+                return -libc::EEXIST;
+            }
+        }
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+/// Reports that VFIO PCI assignment is unavailable in this build or target.
+#[unsafe(no_mangle)]
+#[cfg(not(all(feature = "vfio", target_os = "linux", target_arch = "x86_64")))]
+pub extern "C" fn krun_add_vfio_device(
+    _ctx_id: u32,
+    _vfio_cdev_fd: c_int,
+    _guest_device: u8,
+    _guest_function: u8,
+) -> i32 {
+    -libc::ENOTSUP
+}
+
 #[allow(clippy::missing_safety_doc)]
 #[unsafe(no_mangle)]
 #[cfg(feature = "tdx")]
@@ -1926,6 +1991,7 @@ const KRUN_FEATURE_AMD_SEV: u64 = 7;
 const KRUN_FEATURE_INTEL_TDX: u64 = 8;
 const KRUN_FEATURE_AWS_NITRO: u64 = 9;
 const KRUN_FEATURE_VIRGL_RESOURCE_MAP2: u64 = 10;
+const KRUN_FEATURE_VFIO: u64 = 12;
 
 #[unsafe(no_mangle)]
 pub extern "C" fn krun_has_feature(feature: u64) -> c_int {
@@ -1939,6 +2005,11 @@ pub extern "C" fn krun_has_feature(feature: u64) -> c_int {
         KRUN_FEATURE_INTEL_TDX => cfg!(feature = "tdx"),
         KRUN_FEATURE_AWS_NITRO => cfg!(feature = "aws-nitro"),
         KRUN_FEATURE_VIRGL_RESOURCE_MAP2 => cfg!(feature = "virgl_resource_map2"),
+        KRUN_FEATURE_VFIO => cfg!(all(
+            feature = "vfio",
+            target_os = "linux",
+            target_arch = "x86_64"
+        )),
         _ => return -libc::EINVAL,
     };
 
@@ -3195,6 +3266,39 @@ mod tee_tests {
                 .get_tdx_quote_generation_socket(),
             Some(PathBuf::from("/run/tdx-qgs/qgs.socket"))
         );
+        assert_eq!(krun_free_ctx(ctx_id), KRUN_SUCCESS);
+    }
+}
+
+#[cfg(all(test, feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+mod vfio_tests {
+    use super::*;
+
+    #[test]
+    fn vfio_api_retains_a_duplicate_and_rejects_duplicate_bdfs() {
+        let source = File::open("/dev/null").unwrap();
+        let ctx_id = krun_create_ctx();
+        assert!(ctx_id >= 0);
+        let ctx_id = ctx_id as u32;
+
+        assert_eq!(
+            krun_add_vfio_device(ctx_id, source.as_raw_fd(), 0, 0),
+            -libc::EINVAL
+        );
+        assert_eq!(
+            krun_add_vfio_device(ctx_id, source.as_raw_fd(), 1, 0),
+            KRUN_SUCCESS
+        );
+        assert_eq!(
+            krun_add_vfio_device(ctx_id, source.as_raw_fd(), 1, 0),
+            -libc::EEXIST
+        );
+
+        let context = CTX_MAP.lock().unwrap();
+        let retained = &context.get(&ctx_id).unwrap().vmr.vfio_devices[0].device;
+        assert_ne!(retained.as_raw_fd(), source.as_raw_fd());
+        drop(context);
+
         assert_eq!(krun_free_ctx(ctx_id), KRUN_SUCCESS);
     }
 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -48,6 +48,8 @@ use utils::windows::AsRawFd;
 use utils::windows::SendHandle;
 #[cfg(target_os = "macos")]
 use vmm::VmCtl;
+#[cfg(feature = "tee")]
+use vmm::resources::TeeType;
 use vmm::resources::{
     DefaultVirtioConsoleConfig, PortConfig, SerialConsoleConfig, TsiFlags, VirtioConsoleConfigMode,
     VmResources, VsockConfig,
@@ -79,6 +81,10 @@ use krun_input::{InputConfigBackend, InputEventProviderBackend};
 
 // Value returned on success. We use libc's errors otherwise.
 const KRUN_SUCCESS: i32 = 0;
+#[cfg(feature = "tee")]
+const KRUN_TEE_SNP: u32 = 0;
+#[cfg(feature = "tee")]
+const KRUN_TEE_TDX: u32 = 1;
 // Maximum number of arguments/environment variables we allow
 const MAX_ARGS: usize = 4096;
 /// Maximum number of virtqueues allowed by virtio spec (16-bit queue index: 0-65535)
@@ -152,6 +158,13 @@ impl KrunfwBindingsResult {
     }
 }
 
+#[cfg(feature = "tee")]
+#[derive(Clone)]
+enum TeeConfigSource {
+    File(PathBuf),
+    Type(TeeType),
+}
+
 /// AWS Nitro enclave-specific configuration.
 ///
 /// These fields are only used by the aws-nitro path, which delivers
@@ -181,7 +194,7 @@ struct ContextConfig {
     #[cfg(feature = "blk")]
     block_root: Option<BlockRootConfig>,
     #[cfg(feature = "tee")]
-    tee_config_file: Option<PathBuf>,
+    tee_config: Option<TeeConfigSource>,
     unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     shutdown_efd: Option<EventFd>,
     gpu_virgl_flags: Option<u32>,
@@ -266,12 +279,17 @@ impl ContextConfig {
 
     #[cfg(feature = "tee")]
     fn set_tee_config_file(&mut self, filepath: PathBuf) {
-        self.tee_config_file = Some(filepath);
+        self.tee_config = Some(TeeConfigSource::File(filepath));
     }
 
     #[cfg(feature = "tee")]
-    fn get_tee_config_file(&self) -> Option<PathBuf> {
-        self.tee_config_file.clone()
+    fn set_tee_type(&mut self, tee: TeeType) {
+        self.tee_config = Some(TeeConfigSource::Type(tee));
+    }
+
+    #[cfg(feature = "tee")]
+    fn get_tee_config(&self) -> Option<TeeConfigSource> {
+        self.tee_config.clone()
     }
 
     fn add_vsock_port(&mut self, port: u32, filepath: PathBuf, listen: bool) {
@@ -1311,6 +1329,24 @@ pub unsafe extern "C" fn krun_set_tee_config_file(ctx_id: u32, c_filepath: *cons
 
         KRUN_SUCCESS
     }
+}
+
+#[unsafe(no_mangle)]
+#[cfg(feature = "tee")]
+pub extern "C" fn krun_set_tee_type(ctx_id: u32, tee_type: u32) -> i32 {
+    let tee = match tee_type {
+        KRUN_TEE_SNP if cfg!(feature = "amd-sev") => TeeType::Snp,
+        KRUN_TEE_TDX if cfg!(feature = "tdx") => TeeType::Tdx,
+        KRUN_TEE_SNP | KRUN_TEE_TDX => return -libc::ENOTSUP,
+        _ => return -libc::EINVAL,
+    };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => ctx_cfg.get_mut().set_tee_type(tee),
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
 }
 
 #[allow(clippy::missing_safety_doc)]
@@ -2896,21 +2932,19 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         }
     }
 
-    /*
-     * Before krun_start_enter() is called in an encrypted context, the TEE
-     * config must have been set via krun_set_tee_config_file(). If the TEE
-     * config is not set by this point, print the relevant error message and
-     * fail.
-     */
     #[cfg(feature = "tee")]
-    if let Some(tee_config) = ctx_cfg.get_tee_config_file() {
-        if let Err(e) = ctx_cfg.vmr.set_tee_config(tee_config) {
-            error!("Error setting up TEE config: {e:?}");
+    match ctx_cfg.get_tee_config() {
+        Some(TeeConfigSource::File(tee_config)) => {
+            if let Err(e) = ctx_cfg.vmr.set_tee_config(tee_config) {
+                error!("Error setting up TEE config: {e:?}");
+                return -libc::EINVAL;
+            }
+        }
+        Some(TeeConfigSource::Type(tee)) => ctx_cfg.vmr.set_tee_type(tee),
+        None => {
+            error!("Missing TEE type");
             return -libc::EINVAL;
         }
-    } else {
-        error!("Missing TEE config file");
-        return -libc::EINVAL;
     }
 
     let mut prolog = DEFAULT_KERNEL_CMDLINE.to_string();
@@ -3074,5 +3108,31 @@ fn krun_start_enter_nitro(ctx_id: u32) -> i32 {
 
             -libc::EINVAL
         }
+    }
+}
+
+#[cfg(all(test, feature = "tee"))]
+mod tee_tests {
+    use super::*;
+
+    #[test]
+    fn typed_tee_selection_rejects_unknown_and_incompatible_types() {
+        let ctx_id = krun_create_ctx();
+        assert!(ctx_id >= 0);
+        let ctx_id = ctx_id as u32;
+
+        assert_eq!(krun_set_tee_type(ctx_id, u32::MAX), -libc::EINVAL);
+        #[cfg(feature = "amd-sev")]
+        {
+            assert_eq!(krun_set_tee_type(ctx_id, KRUN_TEE_TDX), -libc::ENOTSUP);
+            assert_eq!(krun_set_tee_type(ctx_id, KRUN_TEE_SNP), KRUN_SUCCESS);
+        }
+        #[cfg(feature = "tdx")]
+        {
+            assert_eq!(krun_set_tee_type(ctx_id, KRUN_TEE_SNP), -libc::ENOTSUP);
+            assert_eq!(krun_set_tee_type(ctx_id, KRUN_TEE_TDX), KRUN_SUCCESS);
+        }
+
+        assert_eq!(krun_free_ctx(ctx_id), KRUN_SUCCESS);
     }
 }

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -1363,6 +1363,43 @@ pub extern "C" fn krun_set_tee_type(ctx_id: u32, tee_type: u32) -> i32 {
     KRUN_SUCCESS
 }
 
+/// Sets the 32-byte guest-owner commitment included in SEV-SNP `HOST_DATA`.
+///
+/// The firmware returns these exact bytes in every attestation report for the
+/// lifetime of the VM. The input is copied before this function returns.
+#[unsafe(no_mangle)]
+#[cfg(feature = "amd-sev")]
+pub unsafe extern "C" fn krun_set_snp_host_data(
+    ctx_id: u32,
+    host_data: *const u8,
+    host_data_len: usize,
+) -> i32 {
+    if host_data.is_null() || host_data_len != 32 {
+        return -libc::EINVAL;
+    }
+    let mut value = [0_u8; 32];
+    // SAFETY: the caller promises `host_data_len` readable bytes; the exact
+    // length was checked above and the destination has the same size.
+    unsafe { std::ptr::copy_nonoverlapping(host_data, value.as_mut_ptr(), value.len()) };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => ctx_cfg.get_mut().vmr.set_snp_host_data(value),
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+    KRUN_SUCCESS
+}
+
+/// Reports that SEV-SNP launch host data is unavailable in this build.
+#[unsafe(no_mangle)]
+#[cfg(not(feature = "amd-sev"))]
+pub unsafe extern "C" fn krun_set_snp_host_data(
+    _ctx_id: u32,
+    _host_data: *const u8,
+    _host_data_len: usize,
+) -> i32 {
+    -libc::ENOTSUP
+}
+
 /// Adds a pre-opened VFIO cdev as a cold-plugged PCI function.
 ///
 /// The file descriptor is duplicated with `F_DUPFD_CLOEXEC`; the caller may
@@ -3241,6 +3278,35 @@ mod tee_tests {
             assert_eq!(krun_set_tee_type(ctx_id, KRUN_TEE_TDX), KRUN_SUCCESS);
         }
 
+        assert_eq!(krun_free_ctx(ctx_id), KRUN_SUCCESS);
+    }
+
+    #[cfg(feature = "amd-sev")]
+    #[test]
+    fn snp_host_data_is_copied_into_vm_resources() {
+        let ctx_id = krun_create_ctx();
+        assert!(ctx_id >= 0);
+        let ctx_id = ctx_id as u32;
+        let host_data = [0x5a_u8; 32];
+
+        assert_eq!(
+            unsafe { krun_set_snp_host_data(ctx_id, host_data.as_ptr(), host_data.len()) },
+            KRUN_SUCCESS
+        );
+        assert_eq!(
+            CTX_MAP
+                .lock()
+                .unwrap()
+                .get(&ctx_id)
+                .unwrap()
+                .vmr
+                .snp_host_data,
+            host_data
+        );
+        assert_eq!(
+            unsafe { krun_set_snp_host_data(ctx_id, host_data.as_ptr(), 31) },
+            -libc::EINVAL
+        );
         assert_eq!(krun_free_ctx(ctx_id), KRUN_SUCCESS);
     }
 

--- a/src/libkrun/src/lib.rs
+++ b/src/libkrun/src/lib.rs
@@ -195,6 +195,8 @@ struct ContextConfig {
     block_root: Option<BlockRootConfig>,
     #[cfg(feature = "tee")]
     tee_config: Option<TeeConfigSource>,
+    #[cfg(feature = "tdx")]
+    tdx_quote_generation_socket: Option<PathBuf>,
     unix_ipc_port_map: Option<HashMap<u32, (PathBuf, bool)>>,
     shutdown_efd: Option<EventFd>,
     gpu_virgl_flags: Option<u32>,
@@ -290,6 +292,16 @@ impl ContextConfig {
     #[cfg(feature = "tee")]
     fn get_tee_config(&self) -> Option<TeeConfigSource> {
         self.tee_config.clone()
+    }
+
+    #[cfg(feature = "tdx")]
+    fn set_tdx_quote_generation_socket(&mut self, socket: PathBuf) {
+        self.tdx_quote_generation_socket = Some(socket);
+    }
+
+    #[cfg(feature = "tdx")]
+    fn get_tdx_quote_generation_socket(&self) -> Option<PathBuf> {
+        self.tdx_quote_generation_socket.clone()
     }
 
     fn add_vsock_port(&mut self, port: u32, filepath: PathBuf, listen: bool) {
@@ -1343,6 +1355,26 @@ pub extern "C" fn krun_set_tee_type(ctx_id: u32, tee_type: u32) -> i32 {
 
     match CTX_MAP.lock().unwrap().entry(ctx_id) {
         Entry::Occupied(mut ctx_cfg) => ctx_cfg.get_mut().set_tee_type(tee),
+        Entry::Vacant(_) => return -libc::ENOENT,
+    }
+
+    KRUN_SUCCESS
+}
+
+#[allow(clippy::missing_safety_doc)]
+#[unsafe(no_mangle)]
+#[cfg(feature = "tdx")]
+pub unsafe extern "C" fn krun_set_tdx_quote_generation_socket(
+    ctx_id: u32,
+    c_filepath: *const c_char,
+) -> i32 {
+    let filepath = match unsafe { CStr::from_ptr(c_filepath) }.to_str() {
+        Ok(filepath) => PathBuf::from(filepath),
+        Err(_) => return -libc::EINVAL,
+    };
+
+    match CTX_MAP.lock().unwrap().entry(ctx_id) {
+        Entry::Occupied(mut ctx_cfg) => ctx_cfg.get_mut().set_tdx_quote_generation_socket(filepath),
         Entry::Vacant(_) => return -libc::ENOENT,
     }
 
@@ -2947,6 +2979,11 @@ pub extern "C" fn krun_start_enter(ctx_id: u32) -> i32 {
         }
     }
 
+    #[cfg(feature = "tdx")]
+    if let Some(socket) = ctx_cfg.get_tdx_quote_generation_socket() {
+        ctx_cfg.vmr.set_tdx_quote_generation_socket(socket);
+    }
+
     let mut prolog = DEFAULT_KERNEL_CMDLINE.to_string();
     for arg in &ctx_cfg.extra_kernel_cmdline {
         prolog.push(' ');
@@ -3133,6 +3170,31 @@ mod tee_tests {
             assert_eq!(krun_set_tee_type(ctx_id, KRUN_TEE_TDX), KRUN_SUCCESS);
         }
 
+        assert_eq!(krun_free_ctx(ctx_id), KRUN_SUCCESS);
+    }
+
+    #[cfg(feature = "tdx")]
+    #[test]
+    fn tdx_quote_generation_socket_is_retained() {
+        let ctx_id = krun_create_ctx();
+        assert!(ctx_id >= 0);
+        let ctx_id = ctx_id as u32;
+
+        assert_eq!(
+            unsafe {
+                krun_set_tdx_quote_generation_socket(ctx_id, c"/run/tdx-qgs/qgs.socket".as_ptr())
+            },
+            KRUN_SUCCESS
+        );
+        assert_eq!(
+            CTX_MAP
+                .lock()
+                .unwrap()
+                .get(&ctx_id)
+                .unwrap()
+                .get_tdx_quote_generation_socket(),
+            Some(PathBuf::from("/run/tdx-qgs/qgs.socket"))
+        );
         assert_eq!(krun_free_ctx(ctx_id), KRUN_SUCCESS);
     }
 }

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -18,6 +18,7 @@ gpu = ["devices/gpu", "krun_display"]
 input = ["devices/input", "krun_input"]
 aws-nitro = []
 vhost-user = ["devices/vhost-user"]
+vfio = ["dep:iommufd-ioctls", "dep:kvm-ioctls-vfio", "dep:vfio-bindings", "dep:vfio-ioctls"]
 
 [dependencies]
 crossbeam-channel = ">=0.5.15"
@@ -26,7 +27,7 @@ libc = ">=0.2.39"
 linux-loader = { version = "0.13.2", features = ["bzimage", "elf", "pe"] }
 log = "0.4.0"
 vm-memory = { version = "0.17.0", default-features = false, features = ["backend-mmap"] }
-vmm-sys-util = "0.14"
+vmm-sys-util = "0.15"
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", optional = true, features = ["bindgen_clang_runtime"] }
 
@@ -57,6 +58,10 @@ nix = { version = "0.30.1", features = ["fs", "term"] }
 tdx = { version = "0.1.1", optional = true }
 kvm-bindings = { version = "0.14", features = ["fam-wrappers"] }
 kvm-ioctls = "0.24"
+iommufd-ioctls = { version = "0.2.0", optional = true }
+kvm-ioctls-vfio = { package = "kvm-ioctls", version = "0.25.0", optional = true }
+vfio-bindings = { version = "0.6.2", optional = true }
+vfio-ioctls = { version = "0.8.0", default-features = false, features = ["vfio_cdev"], optional = true }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { package = "krun-hvf", version = "=0.1.0-2.0.0-dev", path = "../hvf" }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -681,7 +681,7 @@ pub fn build_microvm(
 
     #[cfg(all(feature = "tee", not(feature = "tdx")))]
     let measured_regions = {
-        println!("Injecting and measuring memory regions. This may take a while.");
+        eprintln!("Injecting and measuring memory regions. This may take a while.");
 
         let qboot_size = if let Some(qboot_bundle) = &vm_resources.qboot_bundle {
             qboot_bundle.size
@@ -733,17 +733,21 @@ pub fn build_microvm(
 
     #[cfg(feature = "tdx")]
     let measured_regions = {
-        println!("Injecting and measuring memory regions. This may take a while.");
+        eprintln!("Injecting and measuring memory regions. This may take a while.");
+        let low_memory_size = arch_memory_info
+            .ram_below_gap
+            .try_into()
+            .map_err(|_| StartMicrovmError::MissingKernelConfig)?;
         let qboot_size = if let Some(qboot_bundle) = &vm_resources.qboot_bundle {
             qboot_bundle.size
         } else {
             return Err(StartMicrovmError::MissingKernelConfig);
         };
-        let m = vec![
+        let mut regions = vec![
             MeasuredRegion {
                 guest_addr: 0,
                 host_addr: guest_memory.get_host_address(GuestAddress(0)).unwrap() as u64,
-                size: 0x8000_0000,
+                size: low_memory_size,
             },
             MeasuredRegion {
                 guest_addr: arch::FIRMWARE_START,
@@ -754,7 +758,21 @@ pub fn build_microvm(
             },
         ];
 
-        m
+        if arch_memory_info.ram_above_gap != 0 {
+            let guest_addr = arch::x86_64::layout::FIRST_ADDR_PAST_32BITS;
+            regions.push(MeasuredRegion {
+                guest_addr,
+                host_addr: guest_memory
+                    .get_host_address(GuestAddress(guest_addr))
+                    .unwrap() as u64,
+                size: arch_memory_info
+                    .ram_above_gap
+                    .try_into()
+                    .map_err(|_| StartMicrovmError::MissingKernelConfig)?,
+            });
+        }
+
+        regions
     };
 
     let mut serial_devices = Vec::new();
@@ -1199,7 +1217,7 @@ pub fn build_microvm(
             Tee::Tdx => {
                 vmm.kvm_vm()
                     .tdx_secure_virt_prepare_memory(&mut tdx_launcher, &measured_regions)
-                    .unwrap();
+                    .map_err(StartMicrovmError::SecureVirtPrepare)?;
                 vmm.kvm_vm()
                     .tdx_secure_virt_finalize_vm(tdx_launcher)
                     .map_err(StartMicrovmError::SecureVirtPrepare)?;
@@ -1207,7 +1225,7 @@ pub fn build_microvm(
             _ => return Err(StartMicrovmError::InvalidTee),
         }
 
-        println!("Starting TEE/microVM.");
+        eprintln!("Starting TEE/microVM.");
     }
 
     vmm.start_vcpus(vcpus)

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -243,6 +243,9 @@ pub enum StartMicrovmError {
     ShmHostAddr(vm_memory::GuestMemoryError),
     /// The TEE specified is not supported.
     InvalidTee,
+    /// Cannot create or attach the VFIO PCI subsystem.
+    #[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+    Vfio(device_manager::vfio::Error),
 }
 
 /// It's convenient to automatically convert `kernel::cmdline::Error`s
@@ -532,6 +535,8 @@ impl Display for StartMicrovmError {
             InvalidTee => {
                 write!(f, "TEE selected is not currently supported")
             }
+            #[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+            Vfio(ref err) => write!(f, "Cannot initialize VFIO PCI devices: {err}"),
         }
     }
 }
@@ -846,6 +851,8 @@ pub fn build_microvm(
 
     let vcpus;
     let intc: IrqChip;
+    #[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+    let vfio_dma_manager;
     // For x86_64 we need to create the interrupt controller before calling `KVM_CREATE_VCPUS`
     // while on aarch64 we need to do it the other way around.
     #[cfg(target_arch = "x86_64")]
@@ -867,6 +874,19 @@ pub fn build_microvm(
             &mut mmio_device_manager,
             Some(intc.clone()),
         )?;
+
+        #[cfg(all(feature = "vfio", target_os = "linux"))]
+        {
+            vfio_dma_manager = device_manager::vfio::attach_devices(
+                vm.fd(),
+                &guest_memory,
+                &vm_resources.vfio_devices,
+                &mut pio_device_manager,
+                &mut mmio_device_manager,
+                cfg!(feature = "tee"),
+            )
+            .map_err(StartMicrovmError::Vfio)?;
+        }
 
         let kernel_boot = vm_resources.firmware_config.is_none() && !cfg!(feature = "tee");
 
@@ -1013,6 +1033,8 @@ pub fn build_microvm(
         mmio_device_manager,
         #[cfg(target_arch = "x86_64")]
         pio_device_manager,
+        #[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+        vfio_dma_manager,
         #[cfg(target_os = "macos")]
         vm_ctl_tx,
         #[cfg(target_os = "macos")]

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1210,6 +1210,7 @@ pub fn build_microvm(
                         vmm.guest_memory(),
                         measured_regions,
                         snp_launcher.unwrap(),
+                        vm_resources.snp_host_data,
                     )
                     .map_err(StartMicrovmError::SecureVirtAttest)?;
             }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -599,6 +599,12 @@ pub fn build_microvm(
 
     let vcpu_config = vm_resources.vcpu_config();
 
+    #[cfg(feature = "tdx")]
+    let quote_generator = vm_resources
+        .tdx_quote_generation_socket()
+        .cloned()
+        .map(crate::linux::tee::inteltdx::quote::QuoteGenerator::new);
+
     // Clone the command-line so that a failed boot doesn't pollute the original.
     #[allow(unused_mut)]
     let mut kernel_cmdline = Cmdline::new(arch::CMDLINE_MAX_SIZE);
@@ -875,6 +881,8 @@ pub fn build_microvm(
             payload_config.pvh,
             #[cfg(feature = "tee")]
             _sender,
+            #[cfg(feature = "tdx")]
+            quote_generator,
         )
         .map_err(StartMicrovmError::Internal)?;
     }
@@ -1988,6 +1996,9 @@ fn create_vcpus_x86_64(
     kernel_boot: bool,
     pvh: bool,
     #[cfg(feature = "tee")] pm_sender: Sender<WorkerMessage>,
+    #[cfg(feature = "tdx")] quote_generator: Option<
+        crate::linux::tee::inteltdx::quote::QuoteGenerator,
+    >,
 ) -> super::Result<Vec<Vcpu>> {
     let mut vcpus = Vec::with_capacity(vcpu_config.vcpu_count as usize);
     for cpu_index in 0..vcpu_config.vcpu_count {
@@ -1998,8 +2009,14 @@ fn create_vcpus_x86_64(
             vm.supported_msrs().clone(),
             io_bus.clone(),
             exit_evt.try_clone().map_err(Error::EventFd)?,
-            #[cfg(feature = "tee")]
+            #[cfg(all(feature = "tee", not(feature = "tdx")))]
             pm_sender.clone(),
+            #[cfg(feature = "tdx")]
+            crate::vstate::TdxVcpuConfig {
+                pm_sender: pm_sender.clone(),
+                guest_memory: guest_mem.clone(),
+                quote_generator: quote_generator.clone(),
+            },
         )
         .map_err(Error::Vcpu)?;
 
@@ -2783,7 +2800,7 @@ fn attach_input_devices(
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tee")))]
 pub mod tests {
     use super::*;
     use crate::vmm_config::kernel_bundle::KernelBundle;

--- a/src/vmm/src/device_manager/kvm/mmio.rs
+++ b/src/vmm/src/device_manager/kvm/mmio.rs
@@ -317,7 +317,7 @@ impl DeviceInfoForFDT for MMIODeviceInfo {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tee")))]
 mod tests {
     use super::super::super::super::builder;
     use super::*;

--- a/src/vmm/src/device_manager/mod.rs
+++ b/src/vmm/src/device_manager/mod.rs
@@ -11,6 +11,10 @@ pub mod legacy;
 /// Device Shared Memory Region Manager.
 pub mod shm;
 
+/// Linux x86 PCI/VFIO cold-plug support.
+#[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+pub mod vfio;
+
 /// Memory Mapped I/O Manager.
 #[cfg(target_os = "linux")]
 pub mod kvm;

--- a/src/vmm/src/device_manager/vfio.rs
+++ b/src/vmm/src/device_manager/vfio.rs
@@ -1,0 +1,1077 @@
+// Copyright 2026 The libkrun Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Minimal PCI host bridge and VFIO cdev/IOMMUFD backend.
+//!
+//! This is deliberately a cold-plug-only boundary. It provides PCI mechanism
+//! #1 config space, fixed BAR assignment, MSI-X delivery, reset, and identity
+//! DMA mappings. Confidential guests get no initial DMA mappings: ranges are
+//! added only when the guest converts those pages to shared state.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fs::File;
+use std::io;
+use std::os::fd::{AsRawFd, FromRawFd};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+use devices::{BusDevice, BusError};
+use iommufd_ioctls::IommuFd;
+use kvm_bindings::{KVMIO, kvm_create_device, kvm_device_type_KVM_DEV_TYPE_VFIO, kvm_msi};
+use kvm_ioctls::VmFd;
+use vfio_bindings::bindings::vfio::{
+    VFIO_PCI_CONFIG_REGION_INDEX, VFIO_REGION_INFO_FLAG_READ, VFIO_REGION_INFO_FLAG_WRITE,
+};
+use vfio_ioctls::{VfioDevice, VfioDeviceFd, VfioIommufd, VfioOps};
+use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vmm_sys_util::eventfd::{EFD_NONBLOCK, EventFd};
+use vmm_sys_util::ioctl::ioctl_with_ref;
+
+use crate::device_manager::legacy::PortIODeviceManager;
+use crate::device_manager::mmio::MMIODeviceManager;
+use crate::resources::VfioDeviceConfig;
+
+const PCI_CONFIG_ADDRESS: u64 = 0xcf8;
+const PCI_CONFIG_PORT_SIZE: u64 = 8;
+const PCI_CONFIG_ENABLE: u32 = 1 << 31;
+const PCI_BAR0: usize = 0x10;
+const PCI_HEADER_TYPE: usize = 0x0e;
+const PCI_CAP_PTR: usize = 0x34;
+const PCI_STATUS_CAP_LIST: u16 = 1 << 4;
+const PCI_CAP_ID_MSIX: u8 = 0x11;
+const PCI_MSIX_ENABLE: u16 = 1 << 15;
+const PCI_MSIX_FUNCTION_MASK: u16 = 1 << 14;
+const PCI_MSIX_TABLE_ENTRY_SIZE: u64 = 16;
+const PCI_MMIO32_START: u64 = 0xe000_0000;
+const PCI_MMIO32_END: u64 = 0xfebf_ffff;
+const PCI_MMIO64_MIN: u64 = 1 << 40;
+const PAGE_SIZE: u64 = 4096;
+
+ioctl_iow_nr!(kvm_signal_msi, KVMIO, 0xa5, kvm_msi);
+
+#[derive(Debug)]
+pub enum Error {
+    KvmDevice(kvm_ioctls::Error),
+    Iommufd(iommufd_ioctls::IommufdError),
+    Vfio(vfio_ioctls::VfioError),
+    DuplicateBdf(u8, u8),
+    InvalidConfigSpace,
+    IoBarUnsupported(u8),
+    InvalidBarSize(u8, u64),
+    Mmio32Exhausted(u64),
+    AddressOverflow,
+    Bus(BusError),
+    File(io::Error),
+    EventFd(io::Error),
+    Thread(io::Error),
+    DmaRange,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::KvmDevice(e) => write!(f, "failed to create KVM VFIO device: {e}"),
+            Self::Iommufd(e) => write!(f, "failed to create IOMMUFD address space: {e}"),
+            Self::Vfio(e) => write!(f, "VFIO operation failed: {e}"),
+            Self::DuplicateBdf(d, fun) => write!(f, "duplicate guest PCI BDF 00:{d:02x}.{fun}"),
+            Self::InvalidConfigSpace => write!(f, "VFIO device has invalid PCI config space"),
+            Self::IoBarUnsupported(bar) => write!(f, "VFIO PCI I/O BAR {bar} is unsupported"),
+            Self::InvalidBarSize(bar, size) => {
+                write!(f, "VFIO PCI BAR {bar} has invalid size {size:#x}")
+            }
+            Self::Mmio32Exhausted(size) => {
+                write!(
+                    f,
+                    "32-bit PCI MMIO aperture cannot fit BAR of size {size:#x}"
+                )
+            }
+            Self::AddressOverflow => write!(f, "PCI MMIO address allocation overflowed"),
+            Self::Bus(e) => write!(f, "failed to register PCI bus range: {e}"),
+            Self::File(e) => write!(f, "failed to duplicate VFIO/KVM descriptor: {e}"),
+            Self::EventFd(e) => write!(f, "failed to create VFIO interrupt eventfd: {e}"),
+            Self::Thread(e) => write!(f, "failed to start VFIO interrupt worker: {e}"),
+            Self::DmaRange => write!(f, "invalid or overlapping VFIO DMA range"),
+        }
+    }
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+/// Shared IOMMU address-space owner. Its mappings have IOVA equal to GPA.
+pub struct VfioDmaManager {
+    ops: Arc<VfioIommufd>,
+    mappings: Mutex<BTreeMap<u64, u64>>,
+}
+
+impl VfioDmaManager {
+    fn new(ops: Arc<VfioIommufd>) -> Self {
+        Self {
+            ops,
+            mappings: Mutex::new(BTreeMap::new()),
+        }
+    }
+
+    pub fn map_range(&self, iova: u64, size: u64, host_addr: *mut u8) -> Result<()> {
+        validate_dma_range(iova, size)?;
+        let end = iova.checked_add(size).ok_or(Error::DmaRange)?;
+        let mut mappings = self.mappings.lock().unwrap();
+        if mappings
+            .range(..end)
+            .next_back()
+            .is_some_and(|(&start, &len)| {
+                start.checked_add(len).is_none_or(|old_end| old_end > iova)
+            })
+        {
+            return Err(Error::DmaRange);
+        }
+
+        // SAFETY: the guest-memory mapping outlives this manager and remains
+        // pinned by IOMMUFD until the identical IOVA range is unmapped.
+        unsafe {
+            self.ops
+                .vfio_dma_map(iova, size as usize, host_addr)
+                .map_err(Error::Vfio)?;
+        }
+        mappings.insert(iova, size);
+        Ok(())
+    }
+
+    #[cfg(feature = "tee")]
+    pub fn unmap_range(&self, iova: u64, size: u64) -> Result<()> {
+        validate_dma_range(iova, size)?;
+        let mut mappings = self.mappings.lock().unwrap();
+        if mappings.get(&iova).copied() != Some(size) {
+            return Err(Error::DmaRange);
+        }
+        self.ops
+            .vfio_dma_unmap(iova, size as usize)
+            .map_err(Error::Vfio)?;
+        mappings.remove(&iova);
+        Ok(())
+    }
+
+    fn map_guest_memory(&self, memory: &GuestMemoryMmap) -> Result<()> {
+        for region in memory.iter() {
+            let start = region.start_addr().raw_value();
+            let host = region.as_ptr();
+            self.map_range(start, region.len(), host)?;
+        }
+        Ok(())
+    }
+}
+
+fn validate_dma_range(iova: u64, size: u64) -> Result<()> {
+    if size == 0 || !iova.is_multiple_of(PAGE_SIZE) || !size.is_multiple_of(PAGE_SIZE) {
+        return Err(Error::DmaRange);
+    }
+    Ok(())
+}
+
+trait PciFunction: Send {
+    fn read_config(&mut self, offset: usize, data: &mut [u8]);
+    fn write_config(&mut self, offset: usize, data: &[u8]);
+    fn set_multifunction(&mut self, multifunction: bool);
+}
+
+struct HostBridge {
+    config: [u8; 256],
+}
+
+impl HostBridge {
+    fn new() -> Self {
+        let mut config = [0_u8; 256];
+        config[0..2].copy_from_slice(&0x8086_u16.to_le_bytes());
+        config[2..4].copy_from_slice(&0x1237_u16.to_le_bytes());
+        config[0x0a] = 0x00;
+        config[0x0b] = 0x06;
+        Self { config }
+    }
+}
+
+impl PciFunction for HostBridge {
+    fn read_config(&mut self, offset: usize, data: &mut [u8]) {
+        copy_config_read(&self.config, offset, data);
+    }
+
+    fn write_config(&mut self, _offset: usize, _data: &[u8]) {}
+
+    fn set_multifunction(&mut self, _multifunction: bool) {}
+}
+
+struct PciConfigIo {
+    address: u32,
+    functions: BTreeMap<(u8, u8), Arc<Mutex<dyn PciFunction>>>,
+}
+
+impl PciConfigIo {
+    fn new(functions: BTreeMap<(u8, u8), Arc<Mutex<dyn PciFunction>>>) -> Self {
+        Self {
+            address: 0,
+            functions,
+        }
+    }
+
+    fn selected(&self, data_port_offset: u64) -> Option<(&(u8, u8), usize)> {
+        if self.address & PCI_CONFIG_ENABLE == 0 {
+            return None;
+        }
+        let bus = ((self.address >> 16) & 0xff) as u8;
+        if bus != 0 {
+            return None;
+        }
+        let device = ((self.address >> 11) & 0x1f) as u8;
+        let function = ((self.address >> 8) & 0x07) as u8;
+        let register = (self.address & 0xfc) as usize + data_port_offset as usize;
+        self.functions
+            .get_key_value(&(device, function))
+            .map(|(key, _)| (key, register))
+    }
+}
+
+impl BusDevice for PciConfigIo {
+    fn read(&mut self, _vcpuid: u64, offset: u64, data: &mut [u8]) {
+        data.fill(0xff);
+        if offset < 4 {
+            let bytes = self.address.to_le_bytes();
+            copy_config_read(&bytes, offset as usize, data);
+            return;
+        }
+        let Some((key, register)) = self.selected(offset - 4) else {
+            return;
+        };
+        if let Some(function) = self.functions.get(key) {
+            function.lock().unwrap().read_config(register, data);
+        }
+    }
+
+    fn write(&mut self, _vcpuid: u64, offset: u64, data: &[u8]) {
+        if offset < 4 {
+            if offset as usize + data.len() <= 4 {
+                let mut bytes = self.address.to_le_bytes();
+                bytes[offset as usize..offset as usize + data.len()].copy_from_slice(data);
+                self.address = u32::from_le_bytes(bytes);
+            }
+            return;
+        }
+        let Some((key, register)) = self.selected(offset - 4) else {
+            return;
+        };
+        if let Some(function) = self.functions.get(key) {
+            function.lock().unwrap().write_config(register, data);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PciBar {
+    index: u8,
+    address: u64,
+    size: u64,
+    flags: u32,
+    is_64bit: bool,
+    prefetchable: bool,
+}
+
+struct BarAllocator {
+    mmio32: u64,
+    mmio64: u64,
+}
+
+impl BarAllocator {
+    fn new(memory: &GuestMemoryMmap) -> Result<Self> {
+        let memory_end = memory
+            .iter()
+            .map(|region| region.last_addr().raw_value().saturating_add(1))
+            .max()
+            .unwrap_or(0);
+        let mmio64 = align_up(memory_end.max(PCI_MMIO64_MIN), 1 << 30)?;
+        Ok(Self {
+            mmio32: PCI_MMIO32_START,
+            mmio64,
+        })
+    }
+
+    fn allocate(&mut self, size: u64, is_64bit: bool) -> Result<u64> {
+        if size == 0 || !size.is_power_of_two() {
+            return Err(Error::InvalidBarSize(0, size));
+        }
+        if is_64bit {
+            let address = align_up(self.mmio64, size)?;
+            self.mmio64 = address.checked_add(size).ok_or(Error::AddressOverflow)?;
+            Ok(address)
+        } else {
+            let address = align_up(self.mmio32, size)?;
+            let end = address.checked_add(size).ok_or(Error::AddressOverflow)?;
+            if end.saturating_sub(1) > PCI_MMIO32_END {
+                return Err(Error::Mmio32Exhausted(size));
+            }
+            self.mmio32 = end;
+            Ok(address)
+        }
+    }
+}
+
+fn align_up(value: u64, alignment: u64) -> Result<u64> {
+    let mask = alignment.checked_sub(1).ok_or(Error::AddressOverflow)?;
+    value
+        .checked_add(mask)
+        .map(|aligned| aligned & !mask)
+        .ok_or(Error::AddressOverflow)
+}
+
+#[derive(Clone, Default)]
+struct MsixEntry {
+    bytes: [u8; 16],
+}
+
+impl MsixEntry {
+    fn message(&self) -> kvm_msi {
+        kvm_msi {
+            address_lo: u32::from_le_bytes(self.bytes[0..4].try_into().unwrap()),
+            address_hi: u32::from_le_bytes(self.bytes[4..8].try_into().unwrap()),
+            data: u32::from_le_bytes(self.bytes[8..12].try_into().unwrap()),
+            ..Default::default()
+        }
+    }
+
+    fn masked(&self) -> bool {
+        u32::from_le_bytes(self.bytes[12..16].try_into().unwrap()) & 1 != 0
+    }
+}
+
+struct MsixRuntime {
+    entries: Vec<MsixEntry>,
+    pending: Vec<bool>,
+    enabled: bool,
+    function_masked: bool,
+}
+
+struct InterruptWorker {
+    stop: EventFd,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl InterruptWorker {
+    fn start(vm: &VmFd, events: &[EventFd], runtime: Arc<Mutex<MsixRuntime>>) -> Result<Self> {
+        let stop = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd)?;
+        let stop_thread = stop.try_clone().map_err(Error::EventFd)?;
+        let event_clones = events
+            .iter()
+            .map(EventFd::try_clone)
+            .collect::<io::Result<Vec<_>>>()
+            .map_err(Error::EventFd)?;
+        let raw_vm = unsafe { libc::fcntl(vm.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+        if raw_vm < 0 {
+            return Err(Error::File(io::Error::last_os_error()));
+        }
+        // SAFETY: raw_vm is a fresh descriptor owned by the worker thread.
+        let vm_file = unsafe { File::from_raw_fd(raw_vm) };
+        let thread = thread::Builder::new()
+            .name("krun-vfio-msix".to_string())
+            .spawn(move || interrupt_loop(vm_file, stop_thread, event_clones, runtime))
+            .map_err(Error::Thread)?;
+        Ok(Self {
+            stop,
+            thread: Some(thread),
+        })
+    }
+}
+
+impl Drop for InterruptWorker {
+    fn drop(&mut self) {
+        let _ = self.stop.write(1);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn interrupt_loop(vm: File, stop: EventFd, events: Vec<EventFd>, runtime: Arc<Mutex<MsixRuntime>>) {
+    let mut pollfds = Vec::with_capacity(events.len() + 1);
+    pollfds.push(libc::pollfd {
+        fd: stop.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    });
+    pollfds.extend(events.iter().map(|event| libc::pollfd {
+        fd: event.as_raw_fd(),
+        events: libc::POLLIN,
+        revents: 0,
+    }));
+
+    loop {
+        // SAFETY: pollfds points to initialized pollfd values for this call.
+        let ready = unsafe { libc::poll(pollfds.as_mut_ptr(), pollfds.len() as _, -1) };
+        if ready <= 0 {
+            if ready < 0 && io::Error::last_os_error().kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return;
+        }
+        if pollfds[0].revents & libc::POLLIN != 0 {
+            let _ = stop.read();
+            return;
+        }
+        for (index, event) in events.iter().enumerate() {
+            if pollfds[index + 1].revents & libc::POLLIN == 0 {
+                continue;
+            }
+            let _ = event.read();
+            let message = {
+                let mut state = runtime.lock().unwrap();
+                if !state.enabled || state.function_masked || state.entries[index].masked() {
+                    state.pending[index] = true;
+                    None
+                } else {
+                    state.pending[index] = false;
+                    Some(state.entries[index].message())
+                }
+            };
+            if let Some(message) = message {
+                // SAFETY: this is KVM_SIGNAL_MSI on a duplicated live VM fd.
+                let result = unsafe { ioctl_with_ref(&vm, kvm_signal_msi(), &message) };
+                if result < 0 {
+                    error!(
+                        "failed to inject VFIO MSI-X vector {index}: {}",
+                        io::Error::last_os_error()
+                    );
+                }
+            }
+        }
+    }
+}
+
+struct MsixState {
+    cap_offset: usize,
+    table_bar: u8,
+    table_offset: u64,
+    pba_bar: u8,
+    pba_offset: u64,
+    runtime: Arc<Mutex<MsixRuntime>>,
+    events: Vec<EventFd>,
+    _worker: InterruptWorker,
+}
+
+struct VfioPciDevice {
+    vfio: Arc<VfioDevice>,
+    config: Vec<u8>,
+    bars: [Option<PciBar>; 6],
+    bar_owner: [Option<(u8, bool)>; 6],
+    probing: [bool; 6],
+    msix: Option<MsixState>,
+}
+
+impl VfioPciDevice {
+    fn new(vfio: VfioDevice, vm: &VmFd, allocator: &mut BarAllocator) -> Result<Self> {
+        vfio.reset();
+        let vfio = Arc::new(vfio);
+        let config_size = vfio.get_region_size(VFIO_PCI_CONFIG_REGION_INDEX).min(4096) as usize;
+        if config_size < 256 {
+            return Err(Error::InvalidConfigSpace);
+        }
+        let mut config = vec![0_u8; config_size];
+        vfio.region_read(VFIO_PCI_CONFIG_REGION_INDEX, &mut config, 0);
+        let vendor = u16::from_le_bytes(config[0..2].try_into().unwrap());
+        if vendor == 0 || vendor == u16::MAX {
+            return Err(Error::InvalidConfigSpace);
+        }
+
+        let mut bars = [None; 6];
+        let mut bar_owner = [None; 6];
+        let mut bar = 0_u8;
+        while bar < 6 {
+            let offset = PCI_BAR0 + usize::from(bar) * 4;
+            let raw = u32::from_le_bytes(config[offset..offset + 4].try_into().unwrap());
+            let size = vfio.get_region_size(u32::from(bar));
+            if size == 0 {
+                bar += 1;
+                continue;
+            }
+            if raw & 1 != 0 {
+                return Err(Error::IoBarUnsupported(bar));
+            }
+            if !size.is_power_of_two() {
+                return Err(Error::InvalidBarSize(bar, size));
+            }
+            let kind = (raw >> 1) & 0x3;
+            let is_64bit = kind == 0x2;
+            if kind != 0 && !is_64bit {
+                return Err(Error::InvalidBarSize(bar, size));
+            }
+            if is_64bit && bar == 5 {
+                return Err(Error::InvalidBarSize(bar, size));
+            }
+            let address = allocator.allocate(size, is_64bit)?;
+            let pci_bar = PciBar {
+                index: bar,
+                address,
+                size,
+                flags: vfio.get_region_flags(u32::from(bar)),
+                is_64bit,
+                prefetchable: raw & 0x8 != 0,
+            };
+            bars[usize::from(bar)] = Some(pci_bar);
+            bar_owner[usize::from(bar)] = Some((bar, false));
+            write_bar_address(&vfio, &mut config, pci_bar);
+            if is_64bit {
+                bar_owner[usize::from(bar + 1)] = Some((bar, true));
+                bar += 2;
+            } else {
+                bar += 1;
+            }
+        }
+
+        let msix = parse_msix(&config)
+            .map(|parsed| {
+                let events = (0..parsed.vectors)
+                    .map(|_| EventFd::new(EFD_NONBLOCK).map_err(Error::EventFd))
+                    .collect::<Result<Vec<_>>>()?;
+                let runtime = Arc::new(Mutex::new(MsixRuntime {
+                    entries: vec![MsixEntry::default(); parsed.vectors],
+                    pending: vec![false; parsed.vectors],
+                    enabled: false,
+                    function_masked: true,
+                }));
+                let worker = InterruptWorker::start(vm, &events, Arc::clone(&runtime))?;
+                Ok(MsixState {
+                    cap_offset: parsed.cap_offset,
+                    table_bar: parsed.table_bar,
+                    table_offset: parsed.table_offset,
+                    pba_bar: parsed.pba_bar,
+                    pba_offset: parsed.pba_offset,
+                    runtime,
+                    events,
+                    _worker: worker,
+                })
+            })
+            .transpose()?;
+
+        Ok(Self {
+            vfio,
+            config,
+            bars,
+            bar_owner,
+            probing: [false; 6],
+            msix,
+        })
+    }
+
+    fn read_bar(&mut self, bar: u8, offset: u64, data: &mut [u8]) {
+        if self.msix_read(bar, offset, data) {
+            return;
+        }
+        let flags = self.bars[usize::from(bar)].map_or(0, |region| region.flags);
+        if flags & VFIO_REGION_INFO_FLAG_READ != 0 {
+            self.vfio.region_read(u32::from(bar), data, offset);
+        } else {
+            data.fill(0xff);
+        }
+    }
+
+    fn write_bar(&mut self, bar: u8, offset: u64, data: &[u8]) {
+        if self.msix_write(bar, offset, data) {
+            return;
+        }
+        let flags = self.bars[usize::from(bar)].map_or(0, |region| region.flags);
+        if flags & VFIO_REGION_INFO_FLAG_WRITE != 0 {
+            self.vfio.region_write(u32::from(bar), data, offset);
+        }
+    }
+
+    fn msix_read(&self, bar: u8, offset: u64, data: &mut [u8]) -> bool {
+        let Some(msix) = &self.msix else { return false };
+        let table_size =
+            msix.runtime.lock().unwrap().entries.len() as u64 * PCI_MSIX_TABLE_ENTRY_SIZE;
+        if bar == msix.table_bar
+            && range_contains(msix.table_offset, table_size, offset, data.len())
+        {
+            let state = msix.runtime.lock().unwrap();
+            let relative = (offset - msix.table_offset) as usize;
+            for (position, byte) in data.iter_mut().enumerate() {
+                let absolute = relative + position;
+                *byte = state.entries[absolute / 16].bytes[absolute % 16];
+            }
+            return true;
+        }
+        let pba_size = (msix.runtime.lock().unwrap().entries.len().div_ceil(64) * 8) as u64;
+        if bar == msix.pba_bar && range_contains(msix.pba_offset, pba_size, offset, data.len()) {
+            data.fill(0);
+            let state = msix.runtime.lock().unwrap();
+            let relative = (offset - msix.pba_offset) as usize;
+            for (vector, pending) in state.pending.iter().copied().enumerate() {
+                if pending {
+                    let byte = vector / 8;
+                    if byte >= relative && byte < relative + data.len() {
+                        data[byte - relative] |= 1 << (vector % 8);
+                    }
+                }
+            }
+            return true;
+        }
+        false
+    }
+
+    fn msix_write(&mut self, bar: u8, offset: u64, data: &[u8]) -> bool {
+        let Some(msix) = &self.msix else { return false };
+        let table_size =
+            msix.runtime.lock().unwrap().entries.len() as u64 * PCI_MSIX_TABLE_ENTRY_SIZE;
+        if bar != msix.table_bar
+            || !range_contains(msix.table_offset, table_size, offset, data.len())
+        {
+            return bar == msix.pba_bar
+                && range_contains(
+                    msix.pba_offset,
+                    (msix.runtime.lock().unwrap().entries.len().div_ceil(64) * 8) as u64,
+                    offset,
+                    data.len(),
+                );
+        }
+        let relative = (offset - msix.table_offset) as usize;
+        let mut kick = BTreeSet::new();
+        {
+            let mut state = msix.runtime.lock().unwrap();
+            for (position, byte) in data.iter().copied().enumerate() {
+                let absolute = relative + position;
+                let vector = absolute / 16;
+                let was_masked = state.entries[vector].masked();
+                state.entries[vector].bytes[absolute % 16] = byte;
+                if was_masked
+                    && !state.entries[vector].masked()
+                    && state.pending[vector]
+                    && state.enabled
+                    && !state.function_masked
+                {
+                    kick.insert(vector);
+                }
+            }
+        }
+        for vector in kick {
+            let _ = msix.events[vector].write(1);
+        }
+        true
+    }
+
+    fn update_msix_control(&mut self, old: u16, new: u16) {
+        let Some(msix) = &self.msix else { return };
+        let was_enabled = old & PCI_MSIX_ENABLE != 0;
+        let enabled = new & PCI_MSIX_ENABLE != 0;
+        if enabled && !was_enabled {
+            let event_refs = msix.events.iter().collect();
+            if let Err(error) = self.vfio.enable_msix(event_refs) {
+                error!("failed to enable VFIO MSI-X: {error}");
+                let control = u16::from_le_bytes(
+                    self.config[msix.cap_offset + 2..msix.cap_offset + 4]
+                        .try_into()
+                        .unwrap(),
+                ) & !PCI_MSIX_ENABLE;
+                self.config[msix.cap_offset + 2..msix.cap_offset + 4]
+                    .copy_from_slice(&control.to_le_bytes());
+                return;
+            }
+        } else if !enabled
+            && was_enabled
+            && let Err(error) = self.vfio.disable_msix()
+        {
+            warn!("failed to disable VFIO MSI-X: {error}");
+        }
+        let mut state = msix.runtime.lock().unwrap();
+        state.enabled = enabled;
+        state.function_masked = new & PCI_MSIX_FUNCTION_MASK != 0;
+    }
+}
+
+impl PciFunction for VfioPciDevice {
+    fn read_config(&mut self, offset: usize, data: &mut [u8]) {
+        let mut config = self.config.clone();
+        for register in 0..6 {
+            let Some((owner, high)) = self.bar_owner[register] else {
+                continue;
+            };
+            if !self.probing[usize::from(owner)] {
+                continue;
+            }
+            let Some(bar) = self.bars[usize::from(owner)] else {
+                continue;
+            };
+            let mask64 = !(bar.size - 1);
+            let value = if high {
+                (mask64 >> 32) as u32
+            } else {
+                (mask64 as u32 & 0xffff_fff0)
+                    | if bar.is_64bit { 0x4 } else { 0 }
+                    | if bar.prefetchable { 0x8 } else { 0 }
+            };
+            let bar_offset = PCI_BAR0 + register * 4;
+            config[bar_offset..bar_offset + 4].copy_from_slice(&value.to_le_bytes());
+        }
+        copy_config_read(&config, offset, data);
+    }
+
+    fn write_config(&mut self, offset: usize, data: &[u8]) {
+        if offset
+            .checked_add(data.len())
+            .is_none_or(|end| end > self.config.len())
+        {
+            return;
+        }
+        let old_msix = self.msix.as_ref().map(|msix| {
+            u16::from_le_bytes(
+                self.config[msix.cap_offset + 2..msix.cap_offset + 4]
+                    .try_into()
+                    .unwrap(),
+            )
+        });
+        self.config[offset..offset + data.len()].copy_from_slice(data);
+
+        let write_end = offset + data.len();
+        for register in 0..6 {
+            let bar_offset = PCI_BAR0 + register * 4;
+            if offset <= bar_offset && write_end >= bar_offset + 4 {
+                if let Some((owner, _)) = self.bar_owner[register] {
+                    self.probing[usize::from(owner)] = data.len() == 4
+                        && offset == bar_offset
+                        && u32::from_le_bytes(data.try_into().unwrap()) == u32::MAX;
+                    if !self.probing[usize::from(owner)]
+                        && let Some(bar) = self.bars[usize::from(owner)]
+                    {
+                        write_bar_address(&self.vfio, &mut self.config, bar);
+                    }
+                }
+                return;
+            }
+        }
+
+        let msix_transition = if let (Some(msix), Some(old)) = (&self.msix, old_msix) {
+            let control_offset = msix.cap_offset + 2;
+            if offset < control_offset + 2 && write_end > control_offset {
+                let new = u16::from_le_bytes(
+                    self.config[control_offset..control_offset + 2]
+                        .try_into()
+                        .unwrap(),
+                );
+                Some((old, new))
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        if let Some((old, new)) = msix_transition
+            && old & PCI_MSIX_ENABLE == 0
+            && new & PCI_MSIX_ENABLE != 0
+        {
+            // Install VFIO eventfds before the physical function can emit MSI-X.
+            self.update_msix_control(old, new);
+        }
+
+        self.vfio.region_write(
+            VFIO_PCI_CONFIG_REGION_INDEX,
+            &self.config[offset..write_end],
+            offset as u64,
+        );
+
+        if let Some((old, new)) = msix_transition
+            && !(old & PCI_MSIX_ENABLE == 0 && new & PCI_MSIX_ENABLE != 0)
+        {
+            // On disable, quiesce the physical function before tearing down eventfds.
+            self.update_msix_control(old, new);
+        }
+    }
+
+    fn set_multifunction(&mut self, multifunction: bool) {
+        if multifunction {
+            self.config[PCI_HEADER_TYPE] |= 0x80;
+        } else {
+            self.config[PCI_HEADER_TYPE] &= 0x7f;
+        }
+    }
+}
+
+impl Drop for VfioPciDevice {
+    fn drop(&mut self) {
+        if self.msix.is_some() {
+            let _ = self.vfio.disable_msix();
+        }
+        self.vfio.reset();
+    }
+}
+
+struct VfioBarDevice {
+    function: Arc<Mutex<VfioPciDevice>>,
+    bar: u8,
+}
+
+impl BusDevice for VfioBarDevice {
+    fn read(&mut self, _vcpuid: u64, offset: u64, data: &mut [u8]) {
+        self.function
+            .lock()
+            .unwrap()
+            .read_bar(self.bar, offset, data);
+    }
+
+    fn write(&mut self, _vcpuid: u64, offset: u64, data: &[u8]) {
+        self.function
+            .lock()
+            .unwrap()
+            .write_bar(self.bar, offset, data);
+    }
+}
+
+struct ParsedMsix {
+    cap_offset: usize,
+    vectors: usize,
+    table_bar: u8,
+    table_offset: u64,
+    pba_bar: u8,
+    pba_offset: u64,
+}
+
+fn parse_msix(config: &[u8]) -> Option<ParsedMsix> {
+    let status = u16::from_le_bytes(config.get(6..8)?.try_into().ok()?);
+    if status & PCI_STATUS_CAP_LIST == 0 {
+        return None;
+    }
+    let mut offset = usize::from(*config.get(PCI_CAP_PTR)? & !0x3);
+    let mut visited = BTreeSet::new();
+    while offset >= 0x40 && offset + 12 <= config.len() && visited.insert(offset) {
+        if config[offset] == PCI_CAP_ID_MSIX {
+            let control = u16::from_le_bytes(config[offset + 2..offset + 4].try_into().ok()?);
+            let table = u32::from_le_bytes(config[offset + 4..offset + 8].try_into().ok()?);
+            let pba = u32::from_le_bytes(config[offset + 8..offset + 12].try_into().ok()?);
+            return Some(ParsedMsix {
+                cap_offset: offset,
+                vectors: usize::from((control & 0x07ff) + 1),
+                table_bar: (table & 0x7) as u8,
+                table_offset: u64::from(table & !0x7),
+                pba_bar: (pba & 0x7) as u8,
+                pba_offset: u64::from(pba & !0x7),
+            });
+        }
+        offset = usize::from(config[offset + 1] & !0x3);
+    }
+    None
+}
+
+fn write_bar_address(vfio: &VfioDevice, config: &mut [u8], bar: PciBar) {
+    let offset = PCI_BAR0 + usize::from(bar.index) * 4;
+    let low = (bar.address as u32 & 0xffff_fff0)
+        | if bar.is_64bit { 0x4 } else { 0 }
+        | if bar.prefetchable { 0x8 } else { 0 };
+    config[offset..offset + 4].copy_from_slice(&low.to_le_bytes());
+    vfio.region_write(
+        VFIO_PCI_CONFIG_REGION_INDEX,
+        &low.to_le_bytes(),
+        offset as u64,
+    );
+    if bar.is_64bit {
+        let high = (bar.address >> 32) as u32;
+        config[offset + 4..offset + 8].copy_from_slice(&high.to_le_bytes());
+        vfio.region_write(
+            VFIO_PCI_CONFIG_REGION_INDEX,
+            &high.to_le_bytes(),
+            (offset + 4) as u64,
+        );
+    }
+}
+
+fn copy_config_read(config: &[u8], offset: usize, data: &mut [u8]) {
+    data.fill(0xff);
+    if let Some(source) = config.get(offset..offset.saturating_add(data.len())) {
+        data.copy_from_slice(source);
+    }
+}
+
+fn range_contains(base: u64, size: u64, offset: u64, length: usize) -> bool {
+    offset >= base
+        && offset
+            .checked_add(length as u64)
+            .is_some_and(|end| end <= base.saturating_add(size))
+}
+
+/// Creates one IOMMU address space for the VM and attaches all configured PCI
+/// functions. The returned manager must live for the VM lifetime.
+pub fn attach_devices(
+    vm: &VmFd,
+    memory: &GuestMemoryMmap,
+    configs: &[VfioDeviceConfig],
+    pio: &mut PortIODeviceManager,
+    mmio: &mut MMIODeviceManager,
+    confidential: bool,
+) -> Result<Option<Arc<VfioDmaManager>>> {
+    if configs.is_empty() {
+        return Ok(None);
+    }
+
+    let mut kvm_device = kvm_create_device {
+        type_: kvm_device_type_KVM_DEV_TYPE_VFIO,
+        fd: 0,
+        flags: 0,
+    };
+    let kvm_vfio = vm
+        .create_device(&mut kvm_device)
+        .map_err(Error::KvmDevice)?;
+    let duplicated = unsafe { libc::fcntl(kvm_vfio.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+    if duplicated < 0 {
+        return Err(Error::File(io::Error::last_os_error()));
+    }
+    // SAFETY: both kvm-ioctls versions wrap the same kernel device fd ABI;
+    // `duplicated` is a fresh descriptor transferred to the 0.25 wrapper.
+    let kvm_vfio = unsafe { kvm_ioctls_vfio::DeviceFd::from_raw_fd(duplicated) };
+    let kvm_vfio = Arc::new(VfioDeviceFd::new_from_kvm(kvm_vfio));
+    let iommufd = Arc::new(IommuFd::new().map_err(Error::Iommufd)?);
+    let ops = Arc::new(VfioIommufd::new(iommufd, None, Some(kvm_vfio)).map_err(Error::Vfio)?);
+    let dma = Arc::new(VfioDmaManager::new(Arc::clone(&ops)));
+    if !confidential {
+        dma.map_guest_memory(memory)?;
+    }
+
+    let mut allocator = BarAllocator::new(memory)?;
+    let mut functions: BTreeMap<(u8, u8), Arc<Mutex<dyn PciFunction>>> = BTreeMap::new();
+    functions.insert((0, 0), Arc::new(Mutex::new(HostBridge::new())));
+    let mut concrete = Vec::with_capacity(configs.len());
+    for config in configs {
+        let key = (config.guest_device, config.guest_function);
+        if functions.contains_key(&key) {
+            return Err(Error::DuplicateBdf(key.0, key.1));
+        }
+        let file = config.device.try_clone().map_err(Error::File)?;
+        let vfio = VfioDevice::new_from_fd(file, Arc::clone(&ops) as Arc<dyn VfioOps>)
+            .map_err(Error::Vfio)?;
+        let function = Arc::new(Mutex::new(VfioPciDevice::new(vfio, vm, &mut allocator)?));
+        functions.insert(key, Arc::clone(&function) as Arc<Mutex<dyn PciFunction>>);
+        concrete.push(function);
+    }
+
+    let multifunction_slots: BTreeSet<u8> = configs
+        .iter()
+        .filter(|candidate| {
+            configs.iter().any(|other| {
+                other.guest_device == candidate.guest_device
+                    && other.guest_function != candidate.guest_function
+            })
+        })
+        .map(|config| config.guest_device)
+        .collect();
+    for ((device, function), pci_function) in &functions {
+        pci_function
+            .lock()
+            .unwrap()
+            .set_multifunction(*function == 0 && multifunction_slots.contains(device));
+    }
+
+    for function in &concrete {
+        let bars = function.lock().unwrap().bars;
+        for bar in bars.into_iter().flatten() {
+            mmio.bus
+                .insert(
+                    Arc::new(Mutex::new(VfioBarDevice {
+                        function: Arc::clone(function),
+                        bar: bar.index,
+                    })),
+                    bar.address,
+                    bar.size,
+                )
+                .map_err(Error::Bus)?;
+        }
+    }
+    pio.io_bus
+        .insert(
+            Arc::new(Mutex::new(PciConfigIo::new(functions))),
+            PCI_CONFIG_ADDRESS,
+            PCI_CONFIG_PORT_SIZE,
+        )
+        .map_err(Error::Bus)?;
+
+    Ok(Some(dma))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct TestFunction {
+        config: [u8; 256],
+    }
+
+    impl PciFunction for TestFunction {
+        fn read_config(&mut self, offset: usize, data: &mut [u8]) {
+            copy_config_read(&self.config, offset, data);
+        }
+
+        fn write_config(&mut self, offset: usize, data: &[u8]) {
+            self.config[offset..offset + data.len()].copy_from_slice(data);
+        }
+
+        fn set_multifunction(&mut self, multifunction: bool) {
+            self.config[PCI_HEADER_TYPE] = u8::from(multifunction) << 7;
+        }
+    }
+
+    #[test]
+    fn config_mechanism_routes_multifunction_accesses() {
+        let function = Arc::new(Mutex::new(TestFunction { config: [0; 256] }));
+        function.lock().unwrap().config[0..4].copy_from_slice(&0x1234_10de_u32.to_le_bytes());
+        let mut functions: BTreeMap<(u8, u8), Arc<Mutex<dyn PciFunction>>> = BTreeMap::new();
+        functions.insert((3, 2), function);
+        let mut config = PciConfigIo::new(functions);
+        config.write(
+            0,
+            0,
+            &(PCI_CONFIG_ENABLE | (3 << 11) | (2 << 8)).to_le_bytes(),
+        );
+        let mut value = [0_u8; 4];
+        config.read(0, 4, &mut value);
+        assert_eq!(u32::from_le_bytes(value), 0x1234_10de);
+        config.write(0, 4, &0xabcd_10de_u32.to_le_bytes());
+        config.read(0, 4, &mut value);
+        assert_eq!(u32::from_le_bytes(value), 0xabcd_10de);
+    }
+
+    #[test]
+    fn disabled_and_absent_config_reads_all_ones() {
+        let mut config = PciConfigIo::new(BTreeMap::new());
+        let mut value = [0_u8; 4];
+        config.read(0, 4, &mut value);
+        assert_eq!(value, [0xff; 4]);
+        config.write(0, 0, &(PCI_CONFIG_ENABLE | (1 << 11)).to_le_bytes());
+        config.read(0, 4, &mut value);
+        assert_eq!(value, [0xff; 4]);
+    }
+
+    #[test]
+    fn parses_msix_capability_and_stops_on_cycles() {
+        let mut config = vec![0_u8; 256];
+        config[6..8].copy_from_slice(&PCI_STATUS_CAP_LIST.to_le_bytes());
+        config[PCI_CAP_PTR] = 0x50;
+        config[0x50] = PCI_CAP_ID_MSIX;
+        config[0x51] = 0x50;
+        config[0x52..0x54].copy_from_slice(&7_u16.to_le_bytes());
+        config[0x54..0x58].copy_from_slice(&0x2003_u32.to_le_bytes());
+        config[0x58..0x5c].copy_from_slice(&0x3003_u32.to_le_bytes());
+        let parsed = parse_msix(&config).unwrap();
+        assert_eq!(parsed.vectors, 8);
+        assert_eq!(parsed.table_bar, 3);
+        assert_eq!(parsed.table_offset, 0x2000);
+        assert_eq!(parsed.pba_offset, 0x3000);
+    }
+
+    #[test]
+    fn allocates_large_64bit_bars_above_guest_ram() {
+        let memory =
+            GuestMemoryMmap::from_ranges(&[(vm_memory::GuestAddress(0), 1 << 30)]).unwrap();
+        let mut allocator = BarAllocator::new(&memory).unwrap();
+        let first = allocator.allocate(1 << 38, true).unwrap();
+        let second = allocator.allocate(1 << 38, true).unwrap();
+        assert!(first >= PCI_MMIO64_MIN);
+        assert_eq!(first % (1 << 38), 0);
+        assert_eq!(second, first + (1 << 38));
+    }
+
+    #[test]
+    fn rejects_unaligned_dma_ranges() {
+        assert!(validate_dma_range(1, PAGE_SIZE).is_err());
+        assert!(validate_dma_range(0, PAGE_SIZE - 1).is_err());
+        assert!(validate_dma_range(0, PAGE_SIZE).is_ok());
+    }
+}

--- a/src/vmm/src/lib.rs
+++ b/src/vmm/src/lib.rs
@@ -12,6 +12,9 @@
 
 #[macro_use]
 extern crate log;
+#[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+#[macro_use]
+extern crate vmm_sys_util;
 
 /// Handles setup and initialization a `Vmm` object.
 pub mod builder;
@@ -211,6 +214,9 @@ pub struct Vmm {
     mmio_device_manager: MMIODeviceManager,
     #[cfg(target_arch = "x86_64")]
     pio_device_manager: PortIODeviceManager,
+    #[cfg(all(feature = "vfio", target_os = "linux", target_arch = "x86_64"))]
+    #[allow(dead_code)] // Owns the IOAS and ordinary-guest DMA mappings for the VM lifetime.
+    vfio_dma_manager: Option<Arc<crate::device_manager::vfio::VfioDmaManager>>,
 
     // Out-of-band live pause/resume requests: the C API sends `VmCtl` from
     // another thread; the event loop freezes or wakes the vCPUs. A single
@@ -237,6 +243,18 @@ pub enum VmCtl {
 }
 
 impl Vmm {
+    #[cfg(all(
+        feature = "vfio",
+        feature = "tee",
+        target_os = "linux",
+        target_arch = "x86_64"
+    ))]
+    pub(crate) fn vfio_dma_manager(
+        &self,
+    ) -> Option<&Arc<crate::device_manager::vfio::VfioDmaManager>> {
+        self.vfio_dma_manager.as_ref()
+    }
+
     /// Gets the the specified bus device.
     pub fn get_bus_device(
         &self,

--- a/src/vmm/src/linux/tee/amdsnp/mod.rs
+++ b/src/vmm/src/linux/tee/amdsnp/mod.rs
@@ -309,6 +309,7 @@ impl AmdSnp {
         guest_mem: &GuestMemoryMmap,
         measured_regions: Vec<MeasuredRegion>,
         mut launcher: Launcher<Started, RawFd, RawFd>,
+        host_data: [u8; 32],
     ) -> Result<(), Error> {
         for region in measured_regions {
             self.add_region(guest_mem, region, &mut launcher, PageType::Normal)?;
@@ -390,7 +391,7 @@ impl AmdSnp {
             PageType::Zero,
         )?;
 
-        let finish = Finish::new(None, None, [0; 32]);
+        let finish = Finish::new(None, None, host_data);
 
         let (_vmfd, _fwfd) = launcher.finish(finish).map_err(Error::LaunchFinish)?;
 

--- a/src/vmm/src/linux/tee/inteltdx.rs
+++ b/src/vmm/src/linux/tee/inteltdx.rs
@@ -3,6 +3,8 @@ use tdx::launch::{self, Launcher};
 
 use std::os::unix::io::AsRawFd;
 
+pub mod quote;
+
 #[derive(Debug)]
 pub enum Error {
     GetCapabilities(launch::Error),

--- a/src/vmm/src/linux/tee/inteltdx/quote.rs
+++ b/src/vmm/src/linux/tee/inteltdx/quote.rs
@@ -1,0 +1,388 @@
+use std::io::{self, Read, Write};
+use std::os::unix::net::UnixStream;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{Ordering, fence};
+use std::time::Duration;
+
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryMmap};
+
+pub const TDVMCALL_GET_QUOTE: u64 = 0x10002;
+pub const TDVMCALL_STATUS_SUCCESS: u64 = 0;
+pub const TDVMCALL_STATUS_INVALID_OPERAND: u64 = 0x8000_0000_0000_0000;
+pub const TDVMCALL_STATUS_ALIGN_ERROR: u64 = 0x8000_0000_0000_0002;
+
+const GET_QUOTE_STRUCTURE_VERSION: u64 = 1;
+const GET_QUOTE_HEADER_SIZE: usize = 24;
+const GET_QUOTE_MAX_BUFFER_SIZE: usize = 128 * 1024;
+const GET_QUOTE_SUCCESS: u64 = 0;
+const GET_QUOTE_IN_FLIGHT: u64 = u64::MAX;
+const GET_QUOTE_ERROR: u64 = 0x8000_0000_0000_0000;
+const GET_QUOTE_QGS_UNAVAILABLE: u64 = 0x8000_0000_0000_0001;
+
+const QGS_FRAME_HEADER_SIZE: usize = 4;
+const QGS_GET_QUOTE_MESSAGE_SIZE: usize = 24;
+const QGS_MAJOR_VERSION: u16 = 1;
+const QGS_MINOR_VERSION: u16 = 1;
+const QGS_GET_QUOTE_REQUEST: u32 = 0;
+const QGS_GET_QUOTE_RESPONSE: u32 = 1;
+const QGS_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Clone, Debug)]
+pub struct QuoteGenerator {
+    socket: PathBuf,
+}
+
+impl QuoteGenerator {
+    pub fn new(socket: PathBuf) -> Self {
+        Self { socket }
+    }
+
+    fn generate(&self, report: &[u8], quote_capacity: usize) -> Result<Vec<u8>, QuoteError> {
+        let mut stream = UnixStream::connect(&self.socket).map_err(QuoteError::Connect)?;
+        stream
+            .set_read_timeout(Some(QGS_TIMEOUT))
+            .map_err(QuoteError::ConfigureSocket)?;
+        stream
+            .set_write_timeout(Some(QGS_TIMEOUT))
+            .map_err(QuoteError::ConfigureSocket)?;
+
+        let request = encode_request(report)?;
+        stream.write_all(&request).map_err(QuoteError::Write)?;
+        read_response(&mut stream, quote_capacity)
+    }
+
+    pub fn socket(&self) -> &Path {
+        &self.socket
+    }
+}
+
+#[derive(Debug)]
+enum QuoteError {
+    Connect(io::Error),
+    ConfigureSocket(io::Error),
+    Write(io::Error),
+    Read(io::Error),
+    InvalidMessage,
+    MessageTooLarge,
+}
+
+impl QuoteError {
+    fn status(&self) -> u64 {
+        if matches!(self, Self::Connect(_)) {
+            GET_QUOTE_QGS_UNAVAILABLE
+        } else {
+            GET_QUOTE_ERROR
+        }
+    }
+}
+
+impl std::fmt::Display for QuoteError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Connect(error) => write!(formatter, "connect to QGS: {error}"),
+            Self::ConfigureSocket(error) => write!(formatter, "configure QGS socket: {error}"),
+            Self::Write(error) => write!(formatter, "write QGS request: {error}"),
+            Self::Read(error) => write!(formatter, "read QGS response: {error}"),
+            Self::InvalidMessage => write!(formatter, "QGS returned an invalid response"),
+            Self::MessageTooLarge => write!(formatter, "QGS message exceeds the GetQuote buffer"),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct GetQuoteHeader {
+    structure_version: u64,
+    error_code: u64,
+    in_len: u32,
+    out_len: u32,
+}
+
+impl GetQuoteHeader {
+    fn decode(bytes: &[u8; GET_QUOTE_HEADER_SIZE]) -> Self {
+        Self {
+            structure_version: u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+            error_code: u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            in_len: u32::from_le_bytes(bytes[16..20].try_into().unwrap()),
+            out_len: u32::from_le_bytes(bytes[20..24].try_into().unwrap()),
+        }
+    }
+
+    fn encode(self) -> [u8; GET_QUOTE_HEADER_SIZE] {
+        let mut bytes = [0; GET_QUOTE_HEADER_SIZE];
+        bytes[0..8].copy_from_slice(&self.structure_version.to_le_bytes());
+        bytes[8..16].copy_from_slice(&self.error_code.to_le_bytes());
+        bytes[16..20].copy_from_slice(&self.in_len.to_le_bytes());
+        bytes[20..24].copy_from_slice(&self.out_len.to_le_bytes());
+        bytes
+    }
+}
+
+pub fn handle_get_quote(
+    guest_memory: &GuestMemoryMmap,
+    generator: Option<&QuoteGenerator>,
+    gpa: u64,
+    size: u64,
+) -> u64 {
+    let Ok(size) = usize::try_from(size) else {
+        return TDVMCALL_STATUS_INVALID_OPERAND;
+    };
+    if size == 0 || size > GET_QUOTE_MAX_BUFFER_SIZE {
+        return TDVMCALL_STATUS_INVALID_OPERAND;
+    }
+    if gpa & 4095 != 0 || size & 4095 != 0 {
+        return TDVMCALL_STATUS_ALIGN_ERROR;
+    }
+
+    let address = GuestAddress(gpa);
+    let mut header_bytes = [0; GET_QUOTE_HEADER_SIZE];
+    if guest_memory.read_slice(&mut header_bytes, address).is_err() {
+        return TDVMCALL_STATUS_INVALID_OPERAND;
+    }
+    let mut header = GetQuoteHeader::decode(&header_bytes);
+    let input_size = header.in_len as usize;
+    let payload_capacity = size - GET_QUOTE_HEADER_SIZE;
+    if header.structure_version != GET_QUOTE_STRUCTURE_VERSION
+        || header.error_code != 0
+        || header.out_len != 0
+        || input_size == 0
+        || input_size > payload_capacity
+    {
+        return TDVMCALL_STATUS_INVALID_OPERAND;
+    }
+
+    let payload_address = address.unchecked_add(GET_QUOTE_HEADER_SIZE as u64);
+    let mut report = vec![0; input_size];
+    if guest_memory
+        .read_slice(&mut report, payload_address)
+        .is_err()
+    {
+        return TDVMCALL_STATUS_INVALID_OPERAND;
+    }
+
+    let Some(generator) = generator else {
+        header.error_code = GET_QUOTE_QGS_UNAVAILABLE;
+        return publish_header(guest_memory, address, header);
+    };
+
+    header.error_code = GET_QUOTE_IN_FLIGHT;
+    if guest_memory.write_slice(&header.encode(), address).is_err() {
+        return TDVMCALL_STATUS_INVALID_OPERAND;
+    }
+
+    match generator.generate(&report, payload_capacity) {
+        Ok(quote) => {
+            if guest_memory.write_slice(&quote, payload_address).is_err() {
+                return TDVMCALL_STATUS_INVALID_OPERAND;
+            }
+            header.out_len = quote.len() as u32;
+            header.error_code = GET_QUOTE_SUCCESS;
+        }
+        Err(error) => {
+            log::error!(
+                "TDX GetQuote through {} failed: {error}",
+                generator.socket().display()
+            );
+            header.error_code = error.status();
+        }
+    }
+
+    fence(Ordering::Release);
+    publish_header(guest_memory, address, header)
+}
+
+fn publish_header(
+    guest_memory: &GuestMemoryMmap,
+    address: GuestAddress,
+    header: GetQuoteHeader,
+) -> u64 {
+    if guest_memory.write_slice(&header.encode(), address).is_err() {
+        TDVMCALL_STATUS_INVALID_OPERAND
+    } else {
+        TDVMCALL_STATUS_SUCCESS
+    }
+}
+
+fn encode_request(report: &[u8]) -> Result<Vec<u8>, QuoteError> {
+    let report_size = u32::try_from(report.len()).map_err(|_| QuoteError::MessageTooLarge)?;
+    let message_size = QGS_GET_QUOTE_MESSAGE_SIZE
+        .checked_add(report.len())
+        .ok_or(QuoteError::MessageTooLarge)?;
+    let message_size = u32::try_from(message_size).map_err(|_| QuoteError::MessageTooLarge)?;
+
+    let mut request = Vec::with_capacity(QGS_FRAME_HEADER_SIZE + message_size as usize);
+    request.extend_from_slice(&message_size.to_be_bytes());
+    request.extend_from_slice(&QGS_MAJOR_VERSION.to_le_bytes());
+    request.extend_from_slice(&QGS_MINOR_VERSION.to_le_bytes());
+    request.extend_from_slice(&QGS_GET_QUOTE_REQUEST.to_le_bytes());
+    request.extend_from_slice(&message_size.to_le_bytes());
+    request.extend_from_slice(&0u32.to_le_bytes());
+    request.extend_from_slice(&report_size.to_le_bytes());
+    request.extend_from_slice(&0u32.to_le_bytes());
+    request.extend_from_slice(report);
+    Ok(request)
+}
+
+fn read_response(stream: &mut UnixStream, quote_capacity: usize) -> Result<Vec<u8>, QuoteError> {
+    let mut frame_header = [0; QGS_FRAME_HEADER_SIZE];
+    stream
+        .read_exact(&mut frame_header)
+        .map_err(QuoteError::Read)?;
+    let message_size = u32::from_be_bytes(frame_header) as usize;
+    let maximum_message_size = QGS_GET_QUOTE_MESSAGE_SIZE
+        .checked_add(quote_capacity)
+        .ok_or(QuoteError::MessageTooLarge)?;
+    if message_size < QGS_GET_QUOTE_MESSAGE_SIZE || message_size > maximum_message_size {
+        return Err(QuoteError::MessageTooLarge);
+    }
+
+    let mut response = vec![0; message_size];
+    stream.read_exact(&mut response).map_err(QuoteError::Read)?;
+    let major = u16::from_le_bytes(response[0..2].try_into().unwrap());
+    let minor = u16::from_le_bytes(response[2..4].try_into().unwrap());
+    let message_type = u32::from_le_bytes(response[4..8].try_into().unwrap());
+    let declared_size = u32::from_le_bytes(response[8..12].try_into().unwrap()) as usize;
+    let error_code = u32::from_le_bytes(response[12..16].try_into().unwrap());
+    let selected_id_size = u32::from_le_bytes(response[16..20].try_into().unwrap());
+    let quote_size = u32::from_le_bytes(response[20..24].try_into().unwrap()) as usize;
+    if major != QGS_MAJOR_VERSION
+        || minor != QGS_MINOR_VERSION
+        || message_type != QGS_GET_QUOTE_RESPONSE
+        || declared_size != message_size
+        || error_code != 0
+        || selected_id_size != 0
+        || quote_size == 0
+        || quote_size != message_size - QGS_GET_QUOTE_MESSAGE_SIZE
+    {
+        return Err(QuoteError::InvalidMessage);
+    }
+
+    Ok(response[QGS_GET_QUOTE_MESSAGE_SIZE..].to_vec())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::os::unix::net::UnixListener;
+    use std::process;
+    use std::thread;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use vm_memory::{Bytes, GuestAddress, GuestMemoryMmap};
+
+    use super::*;
+
+    fn memory() -> GuestMemoryMmap {
+        GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 256 * 1024)]).unwrap()
+    }
+
+    fn request_header(input_size: u32) -> GetQuoteHeader {
+        GetQuoteHeader {
+            structure_version: GET_QUOTE_STRUCTURE_VERSION,
+            error_code: 0,
+            in_len: input_size,
+            out_len: 0,
+        }
+    }
+
+    #[test]
+    fn rejects_unaligned_and_oversized_buffers() {
+        let memory = memory();
+        assert_eq!(
+            handle_get_quote(&memory, None, 1, 4096),
+            TDVMCALL_STATUS_ALIGN_ERROR
+        );
+        assert_eq!(
+            handle_get_quote(&memory, None, 0, (GET_QUOTE_MAX_BUFFER_SIZE + 4096) as u64),
+            TDVMCALL_STATUS_INVALID_OPERAND
+        );
+    }
+
+    #[test]
+    fn reports_unavailable_qgs_in_the_shared_header() {
+        let memory = memory();
+        let header = request_header(8);
+        memory
+            .write_slice(&header.encode(), GuestAddress(0))
+            .unwrap();
+        memory
+            .write_slice(&[7; 8], GuestAddress(GET_QUOTE_HEADER_SIZE as u64))
+            .unwrap();
+
+        assert_eq!(
+            handle_get_quote(&memory, None, 0, 4096),
+            TDVMCALL_STATUS_SUCCESS
+        );
+        let mut actual = [0; GET_QUOTE_HEADER_SIZE];
+        memory.read_slice(&mut actual, GuestAddress(0)).unwrap();
+        assert_eq!(
+            GetQuoteHeader::decode(&actual).error_code,
+            GET_QUOTE_QGS_UNAVAILABLE
+        );
+    }
+
+    #[test]
+    fn relays_report_and_publishes_quote() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let directory =
+            std::env::temp_dir().join(format!("libkrun-tdx-quote-{}-{nonce}", process::id()));
+        fs::create_dir(&directory).unwrap();
+        let socket = directory.join("qgs.socket");
+        let listener = UnixListener::bind(&socket).unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut frame_header = [0; QGS_FRAME_HEADER_SIZE];
+            stream.read_exact(&mut frame_header).unwrap();
+            let size = u32::from_be_bytes(frame_header) as usize;
+            let mut request = vec![0; size];
+            stream.read_exact(&mut request).unwrap();
+            assert_eq!(&request[QGS_GET_QUOTE_MESSAGE_SIZE..], &[9; 16]);
+
+            let quote = [5; 64];
+            let response_size = QGS_GET_QUOTE_MESSAGE_SIZE + quote.len();
+            let mut response = Vec::new();
+            response.extend_from_slice(&(response_size as u32).to_be_bytes());
+            response.extend_from_slice(&QGS_MAJOR_VERSION.to_le_bytes());
+            response.extend_from_slice(&QGS_MINOR_VERSION.to_le_bytes());
+            response.extend_from_slice(&QGS_GET_QUOTE_RESPONSE.to_le_bytes());
+            response.extend_from_slice(&(response_size as u32).to_le_bytes());
+            response.extend_from_slice(&0u32.to_le_bytes());
+            response.extend_from_slice(&0u32.to_le_bytes());
+            response.extend_from_slice(&(quote.len() as u32).to_le_bytes());
+            response.extend_from_slice(&quote);
+            stream.write_all(&response).unwrap();
+        });
+
+        let memory = memory();
+        memory
+            .write_slice(&request_header(16).encode(), GuestAddress(0))
+            .unwrap();
+        memory
+            .write_slice(&[9; 16], GuestAddress(GET_QUOTE_HEADER_SIZE as u64))
+            .unwrap();
+        let generator = QuoteGenerator::new(socket.clone());
+
+        assert_eq!(
+            handle_get_quote(&memory, Some(&generator), 0, 4096),
+            TDVMCALL_STATUS_SUCCESS
+        );
+        server.join().unwrap();
+
+        let mut actual_header = [0; GET_QUOTE_HEADER_SIZE];
+        memory
+            .read_slice(&mut actual_header, GuestAddress(0))
+            .unwrap();
+        let actual_header = GetQuoteHeader::decode(&actual_header);
+        assert_eq!(actual_header.error_code, GET_QUOTE_SUCCESS);
+        assert_eq!(actual_header.out_len, 64);
+        let mut quote = [0; 64];
+        memory
+            .read_slice(&mut quote, GuestAddress(GET_QUOTE_HEADER_SIZE as u64))
+            .unwrap();
+        assert_eq!(quote, [5; 64]);
+        fs::remove_file(socket).unwrap();
+        fs::remove_dir(directory).unwrap();
+    }
+}

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -849,10 +849,11 @@ impl Vm {
         guest_mem: &GuestMemoryMmap,
         measured_regions: Vec<MeasuredRegion>,
         launcher: snp::Launcher<snp::Started, RawFd, RawFd>,
+        host_data: [u8; 32],
     ) -> Result<()> {
         match &self.tee {
             Some(s) => s
-                .vm_measure(cpuid, guest_mem, measured_regions, launcher)
+                .vm_measure(cpuid, guest_mem, measured_regions, launcher, host_data)
                 .map_err(Error::SnpSecVirtAttest),
             None => Err(Error::InvalidTee),
         }

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -1617,6 +1617,8 @@ impl Vcpu {
                     }
                     Ok(VcpuEmulation::Stopped)
                 }
+                #[cfg(feature = "tdx")]
+                VcpuExit::Unsupported(KVM_EXIT_TDX) => self.handle_tdx_exit(),
                 r => {
                     // TODO: Are we sure we want to finish running a vcpu upon
                     // receiving a vm exit that is not necessarily an error?

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -32,6 +32,8 @@ use super::super::{FC_EXIT_CODE_GENERIC_ERROR, FC_EXIT_CODE_OK};
 use super::tee::amdsnp::{AmdSnp, Error as SnpError};
 
 #[cfg(feature = "tdx")]
+use super::tee::inteltdx::quote::{QuoteGenerator, TDVMCALL_GET_QUOTE, handle_get_quote};
+#[cfg(feature = "tdx")]
 use super::tee::inteltdx::{Error as TdxError, IntelTdx};
 
 #[cfg(feature = "tee")]
@@ -949,6 +951,13 @@ pub struct VcpuConfig {
     pub nested_enabled: bool,
 }
 
+#[cfg(feature = "tdx")]
+pub struct TdxVcpuConfig {
+    pub pm_sender: Sender<WorkerMessage>,
+    pub guest_memory: GuestMemoryMmap,
+    pub quote_generator: Option<QuoteGenerator>,
+}
+
 // Using this for easier explicit type-casting to help IDEs interpret the code.
 type VcpuCell = Cell<Option<*mut Vcpu>>;
 
@@ -984,6 +993,25 @@ pub struct Vcpu {
 
     #[cfg(feature = "tee")]
     pm_sender: Sender<WorkerMessage>,
+    #[cfg(feature = "tdx")]
+    guest_memory: GuestMemoryMmap,
+    #[cfg(feature = "tdx")]
+    quote_generator: Option<QuoteGenerator>,
+}
+
+#[cfg(feature = "tdx")]
+const KVM_EXIT_TDX: u32 = 40;
+
+// kvm-ioctls 0.24 predates KVM_EXIT_TDX, but its generated kvm_run union
+// retains the UAPI-mandated 256-byte padding. Keep this prefix identical to
+// the kernel UAPI until rust-vmm exposes a typed TDX exit.
+#[cfg(feature = "tdx")]
+#[repr(C)]
+struct KvmTdxExit {
+    flags: u64,
+    nr: u64,
+    ret: u64,
+    data: [u64; 5],
 }
 
 impl Vcpu {
@@ -1089,7 +1117,8 @@ impl Vcpu {
         msr_list: MsrList,
         io_bus: devices::Bus,
         exit_evt: EventFd,
-        #[cfg(feature = "tee")] pm_sender: Sender<WorkerMessage>,
+        #[cfg(all(feature = "tee", not(feature = "tdx")))] pm_sender: Sender<WorkerMessage>,
+        #[cfg(feature = "tdx")] tdx: TdxVcpuConfig,
     ) -> Result<Self> {
         let kvm_vcpu = vm_fd.create_vcpu(id as u64).map_err(Error::VcpuFd)?;
         let (event_sender, event_receiver) = unbounded();
@@ -1101,6 +1130,13 @@ impl Vcpu {
         } else {
             false
         };
+
+        #[cfg(feature = "tdx")]
+        let TdxVcpuConfig {
+            pm_sender,
+            guest_memory,
+            quote_generator,
+        } = tdx;
 
         // Initially the cpuid per vCPU is the one supported by this VM.
         Ok(Vcpu {
@@ -1118,6 +1154,10 @@ impl Vcpu {
             response_sender,
             #[cfg(feature = "tee")]
             pm_sender,
+            #[cfg(feature = "tdx")]
+            guest_memory,
+            #[cfg(feature = "tdx")]
+            quote_generator,
         })
     }
 
@@ -1587,6 +1627,10 @@ impl Vcpu {
             // The unwrap on raw_os_error can only fail if we have a logic
             // error in our code in which case it is better to panic.
             Err(ref e) => {
+                #[cfg(feature = "tdx")]
+                if self.fd.get_kvm_run().exit_reason == KVM_EXIT_TDX {
+                    return self.handle_tdx_exit();
+                }
                 match e.errno() {
                     libc::EAGAIN => Ok(VcpuEmulation::Handled),
                     libc::EINTR => {
@@ -1601,6 +1645,32 @@ impl Vcpu {
                 }
             }
         }
+    }
+
+    #[cfg(feature = "tdx")]
+    fn handle_tdx_exit(&mut self) -> Result<VcpuEmulation> {
+        let (flags, nr, gpa, size) = {
+            let run = self.fd.get_kvm_run();
+            // SAFETY: KVM_EXIT_TDX identifies the union payload and KvmTdxExit
+            // is the documented prefix of that payload.
+            let tdx = unsafe { &mut *(&mut run.__bindgen_anon_1 as *mut _ as *mut KvmTdxExit) };
+            (tdx.flags, tdx.nr, tdx.data[0], tdx.data[1])
+        };
+
+        if flags != 0 {
+            error!("KVM_EXIT_TDX returned unsupported flags 0x{flags:x}");
+            return Err(Error::VcpuUnhandledKvmExit);
+        }
+        if nr != TDVMCALL_GET_QUOTE {
+            return Ok(VcpuEmulation::Handled);
+        }
+
+        let ret = handle_get_quote(&self.guest_memory, self.quote_generator.as_ref(), gpa, size);
+        let run = self.fd.get_kvm_run();
+        // SAFETY: This is the same KVM_EXIT_TDX payload validated above.
+        let tdx = unsafe { &mut *(&mut run.__bindgen_anon_1 as *mut _ as *mut KvmTdxExit) };
+        tdx.ret = ret;
+        Ok(VcpuEmulation::Handled)
     }
 
     /// Main loop of the vCPU thread.
@@ -1827,7 +1897,7 @@ enum VcpuEmulation {
     Stopped,
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "tee")))]
 mod tests {
     use crossbeam_channel::unbounded;
     use std::sync::{Arc, Barrier};

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -246,6 +246,9 @@ pub struct VmResources {
     /// TEE configuration
     #[cfg(feature = "tee")]
     pub tee_config: TeeConfig,
+    /// Opaque guest-owner commitment included in every SEV-SNP report.
+    #[cfg(feature = "amd-sev")]
+    pub snp_host_data: [u8; 32],
     /// Intel QGS Unix socket used for TDX GetQuote requests.
     #[cfg(feature = "tdx")]
     pub tdx_quote_generation_socket: Option<PathBuf>,
@@ -470,6 +473,12 @@ impl VmResources {
         self.tee_config.tee = tee.into();
     }
 
+    /// Sets the guest-owner commitment included in SEV-SNP `HOST_DATA`.
+    #[cfg(feature = "amd-sev")]
+    pub fn set_snp_host_data(&mut self, host_data: [u8; 32]) {
+        self.snp_host_data = host_data;
+    }
+
     #[cfg(feature = "tdx")]
     pub fn set_tdx_quote_generation_socket(&mut self, socket: PathBuf) {
         self.tdx_quote_generation_socket = Some(socket);
@@ -544,6 +553,8 @@ mod tests {
             net: Default::default(),
             #[cfg(feature = "tee")]
             tee_config: Default::default(),
+            #[cfg(feature = "amd-sev")]
+            snp_host_data: [0; 32],
             #[cfg(feature = "tdx")]
             tdx_quote_generation_socket: None,
             gpu_virgl_flags: None,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -3,7 +3,7 @@
 
 //#![deny(warnings)]
 
-#[cfg(feature = "tee")]
+#[cfg(any(feature = "tee", feature = "vfio"))]
 use std::fs::File;
 #[cfg(feature = "tee")]
 use std::io::BufReader;
@@ -78,6 +78,27 @@ pub struct VhostUserDeviceConfig {
     pub num_queues: u16,
     /// Size of each queue (empty = use device defaults)
     pub queue_sizes: Vec<u16>,
+}
+
+/// A pre-opened VFIO cdev assigned to a fixed guest PCI function.
+#[cfg(feature = "vfio")]
+pub struct VfioDeviceConfig {
+    /// Open `/dev/vfio/devices/vfioN` file. Ownership is retained by the VM.
+    pub device: File,
+    /// Guest PCI device number on bus 0.
+    pub guest_device: u8,
+    /// Guest PCI function number.
+    pub guest_function: u8,
+}
+
+/// Invalid guest PCI placement for a VFIO function.
+#[cfg(feature = "vfio")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum VfioConfigError {
+    /// Device/function is outside bus 0's supported range or uses slot 0.
+    InvalidBdf,
+    /// Another function already occupies the requested guest BDF.
+    DuplicateBdf,
 }
 
 /// Errors encountered when configuring microVM resources.
@@ -243,6 +264,9 @@ pub struct VmResources {
     #[cfg(feature = "vhost-user")]
     /// Vhost-user device configurations
     pub vhost_user_devices: Vec<VhostUserDeviceConfig>,
+    /// Cold-plugged VFIO PCI functions.
+    #[cfg(feature = "vfio")]
+    pub vfio_devices: Vec<VfioDeviceConfig>,
     /// SMBIOS OEM Strings
     pub smbios_oem_strings: Option<Vec<String>>,
     /// Whether to enable nested virtualization.
@@ -395,6 +419,25 @@ impl VmResources {
         self.block.insert(config)
     }
 
+    /// Adds a pre-opened VFIO cdev at an explicit guest BDF.
+    #[cfg(feature = "vfio")]
+    pub fn add_vfio_device(
+        &mut self,
+        config: VfioDeviceConfig,
+    ) -> std::result::Result<(), VfioConfigError> {
+        if config.guest_device == 0 || config.guest_device > 31 || config.guest_function > 7 {
+            return Err(VfioConfigError::InvalidBdf);
+        }
+        if self.vfio_devices.iter().any(|existing| {
+            existing.guest_device == config.guest_device
+                && existing.guest_function == config.guest_function
+        }) {
+            return Err(VfioConfigError::DuplicateBdf);
+        }
+        self.vfio_devices.push(config);
+        Ok(())
+    }
+
     /// Sets a vsock device to be attached when the VM starts.
     pub fn set_vsock_device(&mut self, config: VsockDeviceConfig) -> Result<VsockConfigError> {
         self.vsock.insert(config)
@@ -513,6 +556,8 @@ mod tests {
             input_backends: Vec::new(),
             #[cfg(feature = "vhost-user")]
             vhost_user_devices: Vec::new(),
+            #[cfg(feature = "vfio")]
+            vfio_devices: Vec::new(),
             smbios_oem_strings: None,
             nested_enabled: false,
             split_irqchip: false,

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -225,6 +225,9 @@ pub struct VmResources {
     /// TEE configuration
     #[cfg(feature = "tee")]
     pub tee_config: TeeConfig,
+    /// Intel QGS Unix socket used for TDX GetQuote requests.
+    #[cfg(feature = "tdx")]
+    pub tdx_quote_generation_socket: Option<PathBuf>,
     /// Flags for the virtio-gpu device.
     pub gpu_virgl_flags: Option<u32>,
     pub gpu_shm_size: Option<usize>,
@@ -424,6 +427,16 @@ impl VmResources {
         self.tee_config.tee = tee.into();
     }
 
+    #[cfg(feature = "tdx")]
+    pub fn set_tdx_quote_generation_socket(&mut self, socket: PathBuf) {
+        self.tdx_quote_generation_socket = Some(socket);
+    }
+
+    #[cfg(feature = "tdx")]
+    pub fn tdx_quote_generation_socket(&self) -> Option<&PathBuf> {
+        self.tdx_quote_generation_socket.as_ref()
+    }
+
     #[cfg(feature = "tee")]
     pub fn set_tee_config(&mut self, filepath: PathBuf) -> Result<Error> {
         let file = File::open(filepath.as_path()).map_err(Error::OpenTeeConfig)?;
@@ -475,12 +488,21 @@ mod tests {
             kernel_cmdline: default_kernel_cmdline(),
             kernel_bundle: Default::default(),
             external_kernel: None,
+            #[cfg(feature = "tee")]
+            qboot_bundle: None,
+            #[cfg(feature = "tee")]
+            initrd_bundle: None,
+            #[cfg(not(feature = "tee"))]
             fs: Default::default(),
             vsock: Default::default(),
             #[cfg(feature = "blk")]
             block: Default::default(),
             #[cfg(feature = "net")]
             net: Default::default(),
+            #[cfg(feature = "tee")]
+            tee_config: Default::default(),
+            #[cfg(feature = "tdx")]
+            tdx_quote_generation_socket: None,
             gpu_virgl_flags: None,
             gpu_shm_size: None,
             #[cfg(feature = "gpu")]

--- a/src/vmm/src/resources.rs
+++ b/src/vmm/src/resources.rs
@@ -41,6 +41,26 @@ use krun_display::DisplayBackend;
 
 type Result<E> = std::result::Result<(), E>;
 
+/// TEE selected by a libkrun caller without a JSON configuration file.
+#[cfg(feature = "tee")]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TeeType {
+    /// AMD Secure Encrypted Virtualization with Secure Nested Paging.
+    Snp,
+    /// Intel Trust Domain Extensions.
+    Tdx,
+}
+
+#[cfg(feature = "tee")]
+impl From<TeeType> for Tee {
+    fn from(tee: TeeType) -> Self {
+        match tee {
+            TeeType::Snp => Self::Snp,
+            TeeType::Tdx => Self::Tdx,
+        }
+    }
+}
+
 // Re-export TsiFlags from devices crate
 pub use devices::virtio::TsiFlags;
 
@@ -400,6 +420,11 @@ impl VmResources {
     }
 
     #[cfg(feature = "tee")]
+    pub fn set_tee_type(&mut self, tee: TeeType) {
+        self.tee_config.tee = tee.into();
+    }
+
+    #[cfg(feature = "tee")]
     pub fn set_tee_config(&mut self, filepath: PathBuf) -> Result<Error> {
         let file = File::open(filepath.as_path()).map_err(Error::OpenTeeConfig)?;
         let reader = BufReader::new(file);
@@ -428,6 +453,11 @@ mod tests {
     use crate::vmm_config::machine_config::{CpuFeaturesTemplate, VmConfig, VmConfigError};
     use crate::vmm_config::vsock::tests::{TempSockFile, default_config};
     use crate::vstate::VcpuConfig;
+    #[cfg(feature = "tee")]
+    use kbs_types::Tee;
+
+    #[cfg(feature = "tee")]
+    use super::TeeType;
     use utils::tempfile::TempFile;
 
     fn default_kernel_cmdline() -> KernelCmdlineConfig {
@@ -527,6 +557,18 @@ mod tests {
             vm_resources.set_vm_config(&aux_vm_config),
             Err(VmConfigError::InvalidMemorySize)
         );
+    }
+
+    #[cfg(feature = "tee")]
+    #[test]
+    fn test_set_tee_type() {
+        let mut vm_resources = default_vm_resources();
+
+        vm_resources.set_tee_type(TeeType::Snp);
+        assert_eq!(vm_resources.tee_config().tee, Tee::Snp);
+
+        vm_resources.set_tee_type(TeeType::Tdx);
+        assert_eq!(vm_resources.tee_config().tee, Tee::Tdx);
     }
 
     #[test]

--- a/src/vmm/src/worker.rs
+++ b/src/vmm/src/worker.rs
@@ -73,7 +73,7 @@ impl super::Vmm {
                     let _ = _sender.send(false);
                 }
             }
-        }
+        };
     }
 
     #[cfg(all(feature = "tee", target_arch = "x86_64"))]
@@ -88,53 +88,67 @@ impl super::Vmm {
             return;
         };
 
-        let attributes: u64 = if properties.private {
-            KVM_MEMORY_ATTRIBUTE_PRIVATE as u64
-        } else {
-            0
-        };
-
-        let attr = kvm_memory_attributes {
-            address: properties.gpa,
-            size: properties.size,
-            attributes,
-            flags: 0,
-        };
-
-        if self.kvm_vm().fd().set_memory_attributes(attr).is_err() {
-            error!(
-                "unable to set memory attributes for memory region corresponding to guest address 0x{:x}",
-                properties.gpa
-            );
-            sender.send(false).unwrap();
-            return;
-        }
-
-        let region = self
+        let Some(region) = self
             .guest_memory()
-            .find_region(GuestAddress(properties.gpa));
-        if region.is_none() {
+            .find_region(GuestAddress(properties.gpa))
+        else {
             error!(
                 "guest memory region corresponding to GPA 0x{:x} not found",
                 properties.gpa
             );
             sender.send(false).unwrap();
             return;
-        }
+        };
 
         let offset = properties.gpa - region_start;
+        let region_addr = MemoryRegionAddress(offset);
+        let Ok(host_startaddr) = region.get_host_address(region_addr) else {
+            error!(
+                "host address corresponding to memory region address 0x{:x} not found",
+                region_addr.raw_value()
+            );
+            sender.send(false).unwrap();
+            return;
+        };
+
+        let attr = |private| kvm_memory_attributes {
+            address: properties.gpa,
+            size: properties.size,
+            attributes: if private {
+                KVM_MEMORY_ATTRIBUTE_PRIVATE as u64
+            } else {
+                0
+            },
+            flags: 0,
+        };
 
         if properties.private {
-            let region_addr = MemoryRegionAddress(offset);
+            #[cfg(feature = "vfio")]
+            if let Some(dma) = self.vfio_dma_manager()
+                && let Err(error) = dma.unmap_range(properties.gpa, properties.size)
+            {
+                error!("unable to remove confidential VFIO DMA mapping: {error}");
+                sender.send(false).unwrap();
+                return;
+            }
 
-            let Ok(host_startaddr) = region.unwrap().get_host_address(region_addr) else {
+            if self
+                .kvm_vm()
+                .fd()
+                .set_memory_attributes(attr(true))
+                .is_err()
+            {
+                #[cfg(feature = "vfio")]
+                if let Some(dma) = self.vfio_dma_manager() {
+                    let _ = dma.map_range(properties.gpa, properties.size, host_startaddr.cast());
+                }
                 error!(
-                    "host address corresponding to memory region address 0x{:x} not found",
-                    region_addr.raw_value()
+                    "unable to make guest memory private at GPA 0x{:x}",
+                    properties.gpa
                 );
                 sender.send(false).unwrap();
                 return;
-            };
+            }
 
             let ret = unsafe {
                 madvise(
@@ -150,8 +164,23 @@ impl super::Vmm {
                     properties.gpa
                 );
                 sender.send(false).unwrap();
+                return;
             }
         } else {
+            if self
+                .kvm_vm()
+                .fd()
+                .set_memory_attributes(attr(false))
+                .is_err()
+            {
+                error!(
+                    "unable to make guest memory shared at GPA 0x{:x}",
+                    properties.gpa
+                );
+                sender.send(false).unwrap();
+                return;
+            }
+
             let ret = unsafe {
                 fallocate(
                     guest_memfd,
@@ -163,7 +192,28 @@ impl super::Vmm {
 
             if ret < 0 {
                 error!("unable to allocate space in guest_memfd for shared memory (fallocate)");
+                let _ = self.kvm_vm().fd().set_memory_attributes(attr(true));
                 sender.send(false).unwrap();
+                return;
+            }
+
+            #[cfg(feature = "vfio")]
+            if let Some(dma) = self.vfio_dma_manager()
+                && let Err(error) =
+                    dma.map_range(properties.gpa, properties.size, host_startaddr.cast())
+            {
+                error!("unable to install confidential VFIO DMA mapping: {error}");
+                let _ = self.kvm_vm().fd().set_memory_attributes(attr(true));
+                // SAFETY: the host mapping covers the validated converted range.
+                let _ = unsafe {
+                    madvise(
+                        host_startaddr as *mut c_void,
+                        properties.size.try_into().unwrap(),
+                        MADV_DONTNEED,
+                    )
+                };
+                sender.send(false).unwrap();
+                return;
             }
         }
 


### PR DESCRIPTION
## Summary

- add typed runtime TEE selection used by embedders that ship one dedicated TEE artifact
- relay `KVM_EXIT_TDX` GetQuote requests to a configured QGS Unix socket with bounded QGS 1.1 framing
- pass an exact caller-owned 32-byte commitment through `krun_set_snp_host_data` into `SNP_LAUNCH_FINISH.HOST_DATA`
- add Linux x86_64 VFIO cdev/IOMMUFD cold-plug PCI assignment with fixed 32/64-bit BARs and MSI-X
- map ordinary guest RAM through one VM IOAS and map confidential guest pages only while they are shared
- expose `KRUN_FEATURE_VFIO`, C API documentation, build flags, and focused deterministic tests
- size TDX measured RAM from the configured VM instead of assuming 2 GiB
- isolate imago block buffers from libkrun's guest-memory crate version so enabling VFIO cannot resolve an incompatible `vm-memory` type
- dispatch `KVM_EXIT_TDX` from the `VcpuExit::Unsupported(40)` result produced by current `kvm-ioctls`

## SNP launch binding and dependency hardening

Commits `3869f8e8` and `ed8ea578` add the owned C API `krun_set_snp_host_data(ctx, ptr, len)`, copy exactly 32 bytes into VM resources, and place them in `SNP_LAUNCH_FINISH.HOST_DATA` before vCPUs run. `HOST_DATA` is authenticated guest-owner policy data, not an extra SNP page measurement; callers must pin both launch measurement and commitment.

The imago integration no longer enables imago's broad guest-memory feature. libkrun now converts its own `VolatileSlice` buffers at the device boundary, preventing VFIO's newer `vm-memory` dependency from silently changing block-device guest-memory types.

Validation added: 2 SNP host-data tests, TDX + blk + net + VFIO check, SNP + blk + net + VFIO check, 63 `krun-devices` tests, and default macOS `cargo check -p libkrun`. The SNP path awaits an RMP-capable host; the attempted GCP C4D bare-metal platform had no firmware RMP reservation.

## Security boundary

VFIO assignment is plumbing, not proof of TDISP, PCIe IDE, device firmware identity, GPU protected mode, or encrypted accelerator links. Confidential DMA starts with no mappings and follows guest private/shared page transitions. Device and topology claims must still be appraised from hardware evidence tied to the VM launch policy.

## Hardware validation

Tested on GCP `c4-standard-288-metal` (Intel Xeon 6985P / Granite Rapids) with Ubuntu's 6.17 TDX host kernel and libkrunfw 5.5.0 TDX firmware:

- KVM TDX initialized and a 1 GiB TD launched after replacing the hard-coded 2 GiB measured region with the configured low/high RAM layout.
- A Linux `tdx_guest` configfs report request generated `KVM_EXIT_TDX` GetQuote. Current `kvm-ioctls` returned exit reason 40 as `VcpuExit::Unsupported(40)`; handling that arm reached the relay.
- libkrun forwarded the guest's 1,052-byte request to Intel QGS over the configured Unix socket.
- QGS loaded its SGX PCE after correcting the host's `/dev` `noexec` setup and reached local PCCS/Intel PCS.
- The GCP bare-metal platform itself is not enrolled in Intel PCS, so PCS returns platform-not-found and no production quote is available on this host. The guest/VMM/QGS relay is exercised through that external provisioning boundary.

The VFIO/MSI-X and confidential NVIDIA B200 paths still require representative PCIe B200 and HGX B200 hardware.

## Validation

- `cargo test -p krun-vmm --features tdx quote::tests`
- `cargo check -p libkrun --no-default-features --features tdx,vfio`
- hardware launch and configfs GetQuote relay on GCP C4 bare metal as described above
