### PR TITLE
examples/launch-tee: fix TEE example and E820 off-by-one for TDX

### DIFF
--- a/examples/launch-tee.c
+++ b/examples/launch-tee.c
@@ -25,12 +25,6 @@ int main(int argc, char *const argv[])
         "18000:8000",
         0
     };
-    const char *const rlimits[] =
-    {
-        // RLIMIT_NPROC = 6
-        "6=4096:8192",
-        0
-    };
     static const struct option long_opts[] = {
         { "td-shim", required_argument, 0, 's' },
         { 0, 0, 0, 0 }
@@ -92,6 +86,15 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
+    // krun_start_enter() no longer defaults the kernel cmdline to
+    // "init=/init.krun"; the init binary is baked into the libkrunfw initrd
+    // bundle at that path, so we have to point the kernel at it explicitly.
+    if (err = krun_append_kernel_cmdline(ctx_id, "init=/init.krun")) {
+        errno = -err;
+        perror("Error configuring init path");
+        return -1;
+    }
+
     if (getcwd(&current_path[0], MAX_PATH) == NULL) {
         errno = -err;
         perror("Error getting current directory");
@@ -118,15 +121,19 @@ int main(int argc, char *const argv[])
         return -1;
     }
 
-    // Configure the rlimits that will be set in the guest
-    if (err = krun_set_rlimits(ctx_id, &rlimits[0])) {
+    // krun_set_rlimits()/krun_set_workdir() are unavailable for TEE guests;
+    // the kernel forwards unrecognized "NAME=value" cmdline arguments into
+    // init's environment, where the guest init applies them.
+
+    // Configure the rlimits that will be set in the guest (RLIMIT_NPROC = 6).
+    if (err = krun_append_kernel_cmdline(ctx_id, "KRUN_RLIMITS=6=4096:8192")) {
         errno = -err;
         perror("Error configuring rlimits");
         return -1;
     }
 
     // Set the working directory to "/", just for the sake of completeness.
-    if (err = krun_set_workdir(ctx_id, "/")) {
+    if (err = krun_append_kernel_cmdline(ctx_id, "KRUN_WORKDIR=/")) {
         errno = -err;
         perror("Error configuring \"/\" as working directory");
         return -1;

--- a/src/arch/src/x86_64/mod.rs
+++ b/src/arch/src/x86_64/mod.rs
@@ -353,7 +353,7 @@ fn configure_pvh(
         add_memmap_entry(
             &mut memmap,
             himem_start.raw_value(),
-            last_addr.unchecked_offset_from(himem_start) + 1,
+            last_addr.unchecked_offset_from(himem_start),
             E820_RAM,
         );
     } else {
@@ -367,7 +367,7 @@ fn configure_pvh(
             add_memmap_entry(
                 &mut memmap,
                 first_addr_past_32bits.raw_value(),
-                last_addr.unchecked_offset_from(first_addr_past_32bits) + 1,
+                last_addr.unchecked_offset_from(first_addr_past_32bits),
                 E820_RAM,
             );
         }
@@ -454,7 +454,7 @@ fn configure_64bit_boot(
             himem_start.raw_value(),
             // it's safe to use unchecked_offset_from because
             // mem_end > himem_start
-            last_addr.unchecked_offset_from(himem_start) + 1,
+            last_addr.unchecked_offset_from(himem_start),
             E820_RAM,
         )?;
     } else {
@@ -473,7 +473,7 @@ fn configure_64bit_boot(
                 first_addr_past_32bits.raw_value(),
                 // it's safe to use unchecked_offset_from because
                 // mem_end > first_addr_past_32bits
-                last_addr.unchecked_offset_from(first_addr_past_32bits) + 1,
+                last_addr.unchecked_offset_from(first_addr_past_32bits),
                 E820_RAM,
             )?;
         }


### PR DESCRIPTION
  ## Summary
  - Update `examples/launch-tee.c` to stop calling the now-`ENOTSUP` `krun_set_rlimits()`/`krun_set_workdir()` APIs and the removed implicit `init=/init.krun` default (removed in
  4d2201e7 and 502116e7). It now uses `krun_append_kernel_cmdline()` to pass `KRUN_RLIMITS`/`KRUN_WORKDIR` through to the guest init's environment, and explicitly appends
  `init=/init.krun`.
  - Fix an off-by-one in `arch_memory_regions()`'s E820/memmap RAM region sizing: `ram_last_addr` is an exclusive end address, but `configure_64bit_boot()`/`configure_pvh()` added 1
  to it as if it were inclusive, reporting one phantom page past the end of guest memory. Harmless for regular guests, but fatal for TDX guests, whose kernel fails a `MapGPA`
  hypercall on that unbacked phantom page.

This also fixes a bug uncovered by https://github.com/slp/qboot-krunfw/pull/2