### PR TITLE
display/edid: fix aspect ratio and refresh rate encoding bug

### DIFF
--- a/src/devices/src/display/edid.rs
+++ b/src/devices/src/display/edid.rs
@@ -281,7 +281,7 @@ fn populate_standard_timings(edid: &mut [u8], info: &EdidInfo) {
             continue;
         }
         edid[0x26 + (slot * 2)] = (width / 8 - 31) as u8;
-        edid[0x27 + (slot * 2)] = aspect_ratio_bits;
+        edid[0x27 + (slot * 2)] = aspect_ratio_bits << 6;
         slot += 1;
     }
     for i in slot..8 {


### PR DESCRIPTION
After reviewing #815 I noticed another pre-existing issue regarding the standard timings. The aspect ratio bits weren't properly shifted causing incorrect aspect ratio and refresh rate being reported.

Before this fix edid-decode reported:
```
Standard Timings:
    GTF     :   800x500    61.000414 Hz  16:10    31.598 kHz     31.851000 MHz
    GTF     :  1280x800    62.000258 Hz  16:10    51.398 kHz     86.349000 MHz
    GTF     :  1400x875    61.000104 Hz  16:10    55.266 kHz    103.016000 MHz
    DMT 0x2f:  1440x900    59.887445 Hz  16:10    55.935 kHz    106.500000 MHz
    GTF     :  1600x1000   63.000151 Hz  16:10    65.331 kHz    140.070000 MHz
    DMT 0x3a:  1680x1050   59.954250 Hz  16:10    65.290 kHz    146.250000 MHz
    DMT 0x45:  1920x1200   59.884600 Hz  16:10    74.556 kHz    193.250000 MHz
```

After:
```
Standard Timings:
    DMT 0x09:   800x600    60.316541 Hz   4:3     37.879 kHz     40.000000 MHz
    DMT 0x23:  1280x1024   60.019740 Hz   5:4     63.981 kHz    108.000000 MHz
    DMT 0x2a:  1400x1050   59.978442 Hz   4:3     65.317 kHz    121.750000 MHz
    DMT 0x2f:  1440x900    59.887445 Hz  16:10    55.935 kHz    106.500000 MHz
    DMT 0x53:  1600x900    60.000000 Hz  16:9     60.000 kHz    108.000000 MHz (RB)
    DMT 0x3a:  1680x1050   59.954250 Hz  16:10    65.290 kHz    146.250000 MHz
    DMT 0x45:  1920x1200   59.884600 Hz  16:10    74.556 kHz    193.250000 MHz
```

@dorindabassey 