### PR TITLE
virtio/gpu: implement CREATE_GUEST_HANDLE for zero-copy shared memory buffers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,17 +80,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,67 +465,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "futures"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-channel"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
-dependencies = [
- "futures-core",
- "futures-sink",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
-
-[[package]]
-name = "futures-io"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
-
-[[package]]
-name = "futures-task"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
-
-[[package]]
-name = "futures-util"
-version = "0.3.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
-dependencies = [
- "futures-core",
- "futures-sink",
- "futures-task",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,17 +544,14 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "404f567d70cd6d288e43f95ea8f2d6e8fe6156dd07df7da955cb9b147c4ab2a5"
 dependencies = [
- "async-trait",
  "bincode",
  "cfg-if",
- "futures",
  "libc",
  "maybe-async",
  "miniz_oxide",
  "nix 0.30.1",
  "page_size",
  "rustc_version",
- "tokio",
  "tracing",
  "vm-memory",
  "windows-sys",
@@ -1539,12 +1464,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
 name = "sm3"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1655,15 +1574,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio"
-version = "1.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
-dependencies = [
- "pin-project-lite",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -551,21 +612,23 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "imago"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c"
+checksum = "404f567d70cd6d288e43f95ea8f2d6e8fe6156dd07df7da955cb9b147c4ab2a5"
 dependencies = [
  "async-trait",
  "bincode",
  "cfg-if",
+ "futures",
  "libc",
+ "maybe-async",
  "miniz_oxide",
  "nix 0.30.1",
  "page_size",
  "rustc_version",
  "tokio",
  "tracing",
- "vm-memory 0.17.1",
+ "vm-memory",
  "windows-sys",
 ]
 
@@ -680,7 +743,7 @@ dependencies = [
  "libc",
  "linux-loader",
  "tdx",
- "vm-memory 0.17.1",
+ "vm-memory",
  "vmm-sys-util",
  "windows-sys",
 ]
@@ -740,7 +803,7 @@ dependencies = [
  "vhost",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory 0.17.1",
+ "vm-memory",
  "vmm-sys-util",
  "windows-sys",
  "zerocopy",
@@ -816,7 +879,7 @@ name = "krun-kernel"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
  "krun-utils",
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -848,7 +911,7 @@ dependencies = [
 name = "krun-smbios"
 version = "0.1.0-2.0.0-dev"
 dependencies = [
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -895,7 +958,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tdx",
- "vm-memory 0.17.1",
+ "vm-memory",
  "vmm-sys-util",
  "windows-sys",
  "zstd",
@@ -911,18 +974,18 @@ dependencies = [
 
 [[package]]
 name = "kvm-bindings"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3c06ff73c7ce03e780887ec2389d62d2a2a9ddf471ab05c2ff69207cd3f3b4"
+checksum = "11cf0ca75d59e9d298647c59cf6c5286fa048120caa77972a7a504a0824d234f"
 dependencies = [
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "kvm-ioctls"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "333f77a20344a448f3f70664918135fddeb804e938f28a99d685bd92926e0b19"
+checksum = "06ac372c120eb893b086d1a12027669cf2b478d1f71204021ffa7adf57948d63"
 dependencies = [
  "bitflags 2.11.0",
  "kvm-bindings",
@@ -963,7 +1026,7 @@ dependencies = [
  "log",
  "nitro-enclaves 0.5.0",
  "once_cell",
- "vm-memory 0.17.1",
+ "vm-memory",
  "windows-sys",
 ]
 
@@ -991,11 +1054,11 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de72cb02c55ecffcf75fe78295926f872eb6eb0a58d629c58a8c324dc26380f6"
+checksum = "d54207cb617cd75b10c57ad20235c914ab62b180ceeff2ef3111983670d3b321"
 dependencies = [
- "vm-memory 0.17.1",
+ "vm-memory",
 ]
 
 [[package]]
@@ -1017,6 +1080,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1465,6 +1539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "sm3"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1524,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "tdx"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83943e37cf46979f711ad11489c641fa058fd0fae92c122d1fc26a664e82acab"
+checksum = "820ee90f5e642ed0a36b8e80cf9b4d2e074a14a03ec9b4c5f26f92bd9efe69b8"
 dependencies = [
  "bitflags 2.11.0",
  "iocuddle",
@@ -1579,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "pin-project-lite",
 ]
@@ -1674,7 +1754,7 @@ dependencies = [
  "bitflags 2.11.0",
  "libc",
  "uuid",
- "vm-memory 0.18.0",
+ "vm-memory",
  "vmm-sys-util",
 ]
 
@@ -1695,17 +1775,6 @@ name = "vm-fdt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
-
-[[package]]
-name = "vm-memory"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
-dependencies = [
- "libc",
- "thiserror 2.0.18",
- "winapi",
-]
 
 [[package]]
 name = "vm-memory"

--- a/src/arch/Cargo.toml
+++ b/src/arch/Cargo.toml
@@ -14,7 +14,7 @@ tdx = [ "tee", "dep:tdx" ]
 
 [dependencies]
 libc = ">=0.2.39"
-vm-memory = { version = "=0.17.1", default-features = false, features = ["backend-mmap"] }
+vm-memory = { version = "0.18.0", default-features = false, features = ["backend-mmap"] }
 vmm-sys-util = "0.15"
 
 arch_gen = { package = "krun-arch-gen", version = "=0.1.0-2.0.0-dev", path = "../arch_gen" }
@@ -24,12 +24,12 @@ utils = { package = "krun-utils", version = "=0.1.0-2.0.0-dev", path = "../utils
 smbios = { package = "krun-smbios", version = "=0.1.0-2.0.0-dev", path = "../smbios" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-kvm-bindings = { version = "0.14", features = ["fam-wrappers"] }
-kvm-ioctls = "0.24"
-tdx = { version = "0.1.1", optional = true }
+kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
+kvm-ioctls = "0.25"
+tdx = { version = "0.1.2", optional = true }
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
-linux-loader = { version = "0.13.2", features = ["elf"] }
+linux-loader = { version = "0.14.0", features = ["elf"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 whp = { package = "krun-whp", version = "=0.1.0-2.0.0-dev", path = "../whp" }

--- a/src/arch/src/riscv64/mod.rs
+++ b/src/arch/src/riscv64/mod.rs
@@ -12,7 +12,7 @@ pub use self::linux::*;
 use std::fmt::Debug;
 
 use crate::{ArchMemoryInfo, riscv64::layout::FIRMWARE_START};
-use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory::{Address, GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
 use vmm_sys_util::align_upwards;
 
 /// Errors thrown while configuring riscv64 system.

--- a/src/arch/src/x86_64/mptable.rs
+++ b/src/arch/src/x86_64/mptable.rs
@@ -12,7 +12,7 @@ use std::slice;
 use libc::c_char;
 
 use arch_gen::x86::mpspec;
-use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory::{Address, ByteValued, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
 
 // This is a workaround to the Rust enforcement specifying that any implementation of a foreign
 // trait (in this case `ByteValued`) where:

--- a/src/arch/src/x86_64/regs.rs
+++ b/src/arch/src/x86_64/regs.rs
@@ -9,7 +9,7 @@ use std::mem;
 
 use super::gdt::{SegmentDescriptor, gdt_entry, segment_from_gdt};
 
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
 
 // Initial pagetables.
 pub const PML4_START: u64 = 0x9000;

--- a/src/arch/src/x86_64/windows/regs.rs
+++ b/src/arch/src/x86_64/windows/regs.rs
@@ -134,7 +134,7 @@ mod tests {
     use super::*;
     use std::ffi::c_void;
     use std::sync::Arc;
-    use vm_memory::{Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
+    use vm_memory::{Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
     use whp::{WhpVcpu, WhpVm};
 
     const GUEST_MEM_SIZE: usize = 0x10000;

--- a/src/cpuid/Cargo.toml
+++ b/src/cpuid/Cargo.toml
@@ -14,5 +14,5 @@ tdx = []
 vmm-sys-util = "0.15"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-kvm-bindings = { version = "0.14", features = ["fam-wrappers"] }
-kvm-ioctls = "0.24"
+kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
+kvm-ioctls = "0.25"

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -42,7 +42,7 @@ arch = { package = "krun-arch", version = "=0.1.0-2.0.0-dev", path = "../arch" }
 utils = { package = "krun-utils", version = "=0.1.0-2.0.0-dev", path = "../utils" }
 polly = { package = "krun-polly", version = "=0.1.0-2.0.0-dev", path = "../polly" }
 rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-2.0.0-dev", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
-imago = { version = "0.2.4", features = ["sync-wrappers", "vm-memory"] }
+imago = { version = "0.2.4", default-features = false, features = ["sync", "vm-memory"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30.1", features = ["ioctl", "net", "poll", "socket", "fs"] }

--- a/src/devices/Cargo.toml
+++ b/src/devices/Cargo.toml
@@ -33,7 +33,7 @@ thiserror = { version = "2.0", optional = true }
 vhost = { version = "0.17", optional = true, features = ["vhost-user-frontend"] }
 vmm-sys-util = { version = "0.15", optional = true }
 virtio-bindings = "0.2.0"
-vm-memory = { version = "0.17", default-features = false, features = ["backend-mmap", "rawfd"] }
+vm-memory = { version = "0.18", default-features = false, features = ["backend-mmap", "rawfd"] }
 zerocopy = { version = "0.8.26", optional = true, features = ["derive"] }
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", features = ["bindgen_clang_runtime"], optional = true }
@@ -42,7 +42,7 @@ arch = { package = "krun-arch", version = "=0.1.0-2.0.0-dev", path = "../arch" }
 utils = { package = "krun-utils", version = "=0.1.0-2.0.0-dev", path = "../utils" }
 polly = { package = "krun-polly", version = "=0.1.0-2.0.0-dev", path = "../polly" }
 rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-2.0.0-dev", path = "../rutabaga_gfx", features = ["virgl_renderer", "virgl_renderer_next"], optional = true }
-imago = { version = "0.2.3", features = ["sync-wrappers", "vm-memory"] }
+imago = { version = "0.2.4", features = ["sync-wrappers", "vm-memory"] }
 
 [target.'cfg(unix)'.dependencies]
 nix = { version = "0.30.1", features = ["ioctl", "net", "poll", "socket", "fs"] }
@@ -54,8 +54,8 @@ lru = ">=0.9"
 [target.'cfg(target_os = "linux")'.dependencies]
 rutabaga_gfx = { package = "krun-rutabaga-gfx", version = "=0.1.0-2.0.0-dev", path = "../rutabaga_gfx", features = ["x"], optional = true }
 caps = "0.5.5"
-kvm-bindings = { version = "0.14", features = ["fam-wrappers"] }
-kvm-ioctls = "0.24"
+kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
+kvm-ioctls = "0.25"
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 vm-fdt = ">= 0.2.0"

--- a/src/devices/src/virtio/balloon/device.rs
+++ b/src/devices/src/virtio/balloon/device.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use std::io::Write;
 
 use utils::eventfd::EventFd;
-use vm_memory::{ByteValued, GuestMemory, GuestMemoryMmap};
+use vm_memory::{ByteValued, GuestMemoryBackend, GuestMemoryMmap};
 
 use super::super::{
     ActivateError, ActivateResult, BalloonError, DeviceQueue, DeviceState, QueueConfig,

--- a/src/devices/src/virtio/block/device.rs
+++ b/src/devices/src/virtio/block/device.rs
@@ -19,8 +19,8 @@ use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 
 use imago::{
-    DynStorage, FormatDriverBuilder, PermissiveImplicitOpenGate, Storage, StorageOpenOptions,
-    SyncFormatAccess, file::File as ImagoFile, qcow2::Qcow2, raw::Raw, vmdk::Vmdk,
+    DynStorage, FormatAccess, FormatDriverBuilder, PermissiveImplicitOpenGate, Storage,
+    StorageOpenOptions, file::File as ImagoFile, qcow2::Qcow2, raw::Raw, vmdk::Vmdk,
 };
 use log::{error, warn};
 use utils::eventfd::{EFD_NONBLOCK, EventFd};
@@ -77,14 +77,14 @@ impl CacheType {
 /// Helper object for setting up all `Block` fields derived from its backing file.
 pub(crate) struct DiskProperties {
     cache_type: CacheType,
-    pub(crate) file: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
+    pub(crate) file: Arc<Mutex<FormatAccess<Box<dyn DynStorage>>>>,
     nsectors: u64,
     image_id: Vec<u8>,
 }
 
 impl DiskProperties {
     pub fn new(
-        disk_image: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
+        disk_image: Arc<Mutex<FormatAccess<Box<dyn DynStorage>>>>,
         disk_image_id: Vec<u8>,
         cache_type: CacheType,
     ) -> io::Result<Self> {
@@ -242,7 +242,7 @@ pub struct Block {
     // Host file and properties.
     disk: Option<DiskProperties>,
     cache_type: CacheType,
-    disk_image: Arc<Mutex<SyncFormatAccess<Box<dyn DynStorage>>>>,
+    disk_image: Arc<Mutex<FormatAccess<Box<dyn DynStorage>>>>,
     disk_image_id: Vec<u8>,
     worker_thread: Option<JoinHandle<()>>,
     worker_stopfd: EventFd,
@@ -288,33 +288,31 @@ impl Block {
             .direct(direct_io);
 
         #[cfg(target_os = "macos")]
-        let file_opts = file_opts.relaxed_sync(sync_mode == SyncMode::Relaxed);
-        let file = ImagoFile::open_sync(file_opts)?;
+        let file_opts = file_opts.relaxed(sync_mode == SyncMode::Relaxed);
+        let file = ImagoFile::open(file_opts)?;
         let discard_alignment = file.discard_align();
 
         let disk_image = match disk_image_format {
             ImageType::Qcow2 => {
                 let mut qcow2 =
-                    Qcow2::<Box<dyn DynStorage>, Arc<imago::FormatAccess<_>>>::open_image_sync(
+                    Qcow2::<Box<dyn DynStorage>, Arc<imago::FormatAccess<_>>>::open_image(
                         Box::new(file),
                         !is_disk_read_only,
                     )?;
-                qcow2.open_implicit_dependencies_sync()?;
-                SyncFormatAccess::new(qcow2)?
+                qcow2.open_implicit_dependencies()?;
+                FormatAccess::new(qcow2)
             }
             ImageType::Raw => {
-                let raw = Raw::<Box<dyn DynStorage>>::open_image_sync(
-                    Box::new(file),
-                    !is_disk_read_only,
-                )?;
-                SyncFormatAccess::new(raw)?
+                let raw =
+                    Raw::<Box<dyn DynStorage>>::open_image(Box::new(file), !is_disk_read_only)?;
+                FormatAccess::new(raw)
             }
             ImageType::Vmdk => {
                 let vmdk = Vmdk::<Box<dyn DynStorage>, Arc<imago::FormatAccess<_>>>::builder(
                     Box::new(file),
                 )
-                .open_sync(PermissiveImplicitOpenGate::default())?;
-                SyncFormatAccess::new(vmdk)?
+                .open(PermissiveImplicitOpenGate::default())?;
+                FormatAccess::new(vmdk)
             }
         };
 

--- a/src/devices/src/virtio/console/process_rx.rs
+++ b/src/devices/src/virtio/console/process_rx.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::{io, thread};
 
-use vm_memory::{GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory::{GuestMemoryBackend, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion};
 
 use crate::virtio::console::console_control::ConsoleControl;
 use crate::virtio::console::port_io::PortInput;

--- a/src/devices/src/virtio/console/process_tx.rs
+++ b/src/devices/src/virtio/console/process_tx.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::{io, thread};
 
-use vm_memory::{GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory::{GuestMemoryBackend, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion};
 
 use crate::virtio::console::port_io::PortOutput;
 use crate::virtio::{DescriptorChain, InterruptTransport, Queue};

--- a/src/devices/src/virtio/descriptor_utils.rs
+++ b/src/devices/src/virtio/descriptor_utils.rs
@@ -13,8 +13,9 @@ use std::result;
 
 use crate::virtio::queue::DescriptorChain;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
-    GuestMemoryRegion, Le16, Le32, Le64, VolatileMemory, VolatileMemoryError, VolatileSlice,
+    Address, ByteValued, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryError,
+    GuestMemoryMmap, GuestMemoryRegion, Le16, Le32, Le64, VolatileMemory, VolatileMemoryError,
+    VolatileSlice,
 };
 
 use super::file_traits::{FileReadWriteAtVolatile, FileReadWriteVolatile};

--- a/src/devices/src/virtio/gpu/device.rs
+++ b/src/devices/src/virtio/gpu/device.rs
@@ -15,6 +15,8 @@ use super::worker::Worker;
 use crate::display::DisplayInfo;
 use crate::virtio::InterruptTransport;
 use krun_display::DisplayBackend;
+#[cfg(target_os = "linux")]
+use utils::linux::udmabuf::UdmabufDriver;
 #[cfg(target_os = "macos")]
 use utils::worker_message::WorkerMessage;
 
@@ -38,6 +40,8 @@ pub struct Gpu {
     virgl_flags: u32,
     #[cfg(target_os = "macos")]
     map_sender: Sender<WorkerMessage>,
+    #[cfg(target_os = "linux")]
+    udmabuf_driver: Option<UdmabufDriver>,
     export_table: Option<ExportTable>,
     displays: Box<[DisplayInfo]>,
     display_backend: DisplayBackend<'static>,
@@ -50,14 +54,33 @@ impl Gpu {
         display_backend: DisplayBackend<'static>,
         #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
     ) -> super::Result<Gpu> {
+        #[cfg(target_os = "linux")]
+        let udmabuf_driver = UdmabufDriver::new()
+            .inspect_err(|err| {
+                warn!("Could not open udmabuf device: {err}");
+            })
+            .ok();
+
+        #[cfg(target_os = "linux")]
+        let avail_features = AVAIL_FEATURES
+            | if udmabuf_driver.is_some() {
+                1u64 << uapi::VIRTIO_GPU_F_CREATE_GUEST_HANDLE
+            } else {
+                0
+            };
+        #[cfg(not(target_os = "linux"))]
+        let avail_features = AVAIL_FEATURES;
+
         Ok(Gpu {
-            avail_features: AVAIL_FEATURES,
+            avail_features,
             acked_features: 0,
             device_state: DeviceState::Inactive,
             shm_region: None,
             virgl_flags,
             #[cfg(target_os = "macos")]
             map_sender,
+            #[cfg(target_os = "linux")]
+            udmabuf_driver,
             export_table: None,
             displays,
             display_backend,
@@ -215,6 +238,8 @@ impl VirtioDevice for Gpu {
             self.virgl_flags,
             #[cfg(target_os = "macos")]
             self.map_sender.clone(),
+            #[cfg(target_os = "linux")]
+            self.udmabuf_driver.take(),
             self.export_table.take(),
             self.displays.clone(),
             self.display_backend,

--- a/src/devices/src/virtio/gpu/mod.rs
+++ b/src/devices/src/virtio/gpu/mod.rs
@@ -25,8 +25,8 @@ mod defs {
         pub const VIRTIO_GPU_F_RESOURCE_BLOB: u32 = 3;
         pub const VIRTIO_GPU_F_CONTEXT_INIT: u32 = 4;
         /* The following capabilities are not upstreamed. */
-        pub const VIRTIO_GPU_F_RESOURCE_SYNC: u32 = 5;
-        pub const VIRTIO_GPU_F_CREATE_GUEST_HANDLE: u32 = 6;
+        // pub const VIRTIO_GPU_F_RESOURCE_SYNC: u32 = 5;
+        pub const VIRTIO_GPU_F_CREATE_GUEST_HANDLE: u32 = 5;
 
         #[derive(Copy, Clone, Debug, Default)]
         #[repr(C)]

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -735,9 +735,26 @@ impl VirtioGpu {
         mem: &GuestMemoryMmap,
     ) -> VirtioGpuResult {
         let mut rutabaga_iovecs = None;
+        let mut handle = None;
 
         if resource_create_blob.blob_flags & VIRTIO_GPU_BLOB_FLAG_CREATE_GUEST_HANDLE != 0 {
-            panic!("GUEST_HANDLE unimplemented");
+            if let Some(driver) = &self.udmabuf_driver {
+                handle = driver
+                    .create_udmabuf(mem, &vecs)
+                    .inspect_err(|err| {
+                        warn!("Failed to create udmabuf: {err}");
+                    })
+                    .map(|fd| RutabagaHandle {
+                        os_handle: unsafe {
+                            RutabagaDescriptor::from_raw_descriptor(fd.into_raw_fd())
+                        },
+                        handle_type: RUTABAGA_MEM_HANDLE_TYPE_DMABUF,
+                    })
+                    .ok();
+            } else {
+                // Not expecting well-behaved guests to hit this path, as we don't set the feature flag without the driver
+                return Err(ErrUnspec);
+            }
         } else if resource_create_blob.blob_mem != VIRTIO_GPU_BLOB_MEM_HOST3D {
             rutabaga_iovecs =
                 Some(sglist_to_rutabaga_iovecs(&vecs[..], mem).map_err(|_| ErrUnspec)?);
@@ -748,7 +765,7 @@ impl VirtioGpu {
             resource_id,
             resource_create_blob,
             rutabaga_iovecs,
-            None,
+            handle,
         )?;
 
         let resource = VirtioGpuResource::new(resource_id, 0, 0, None, resource_create_blob.size);

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -38,7 +38,7 @@ use rutabaga_gfx::{
 };
 #[cfg(target_os = "macos")]
 use utils::worker_message::WorkerMessage;
-use vm_memory::{GuestAddress, GuestMemory, GuestMemoryMmap, VolatileSlice};
+use vm_memory::{GuestAddress, GuestMemoryBackend, GuestMemoryMmap, VolatileSlice};
 
 use super::{GpuError, Result};
 use crate::display::DisplayInfo;

--- a/src/devices/src/virtio/gpu/virtio_gpu.rs
+++ b/src/devices/src/virtio/gpu/virtio_gpu.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 use std::env;
 use std::io::IoSliceMut;
 #[cfg(target_os = "linux")]
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsRawFd, IntoRawFd};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -20,7 +20,7 @@ use krun_display::{
 use libc::c_void;
 #[cfg(target_os = "macos")]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_APPLE;
-#[cfg(all(feature = "virgl_resource_map2", target_os = "linux"))]
+#[cfg(target_os = "linux")]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_DMABUF;
 #[cfg(all(not(feature = "virgl_resource_map2"), target_os = "linux"))]
 use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_OPAQUE_FD;
@@ -30,12 +30,15 @@ use rutabaga_gfx::RUTABAGA_MEM_HANDLE_TYPE_SHM;
 use rutabaga_gfx::{
     RUTABAGA_CHANNEL_TYPE_PW, RUTABAGA_CHANNEL_TYPE_X11, RUTABAGA_MAP_ACCESS_MASK,
     RUTABAGA_MAP_ACCESS_READ, RUTABAGA_MAP_ACCESS_RW, RUTABAGA_MAP_ACCESS_WRITE,
+    RutabagaDescriptor, RutabagaFromRawDescriptor, RutabagaHandle,
 };
 use rutabaga_gfx::{
     RUTABAGA_CHANNEL_TYPE_WAYLAND, RUTABAGA_MAP_CACHE_MASK, ResourceCreate3D, ResourceCreateBlob,
     Rutabaga, RutabagaBuilder, RutabagaChannel, RutabagaFence, RutabagaFenceHandler, RutabagaIovec,
     Transfer3D,
 };
+#[cfg(target_os = "linux")]
+use utils::linux::udmabuf::UdmabufDriver;
 #[cfg(target_os = "macos")]
 use utils::worker_message::WorkerMessage;
 use vm_memory::{GuestAddress, GuestMemoryBackend, GuestMemoryMmap, VolatileSlice};
@@ -153,6 +156,8 @@ pub struct VirtioGpu {
     fence_state: Arc<Mutex<FenceState>>,
     #[cfg(target_os = "macos")]
     map_sender: Sender<WorkerMessage>,
+    #[cfg(target_os = "linux")]
+    udmabuf_driver: Option<UdmabufDriver>,
     scanouts: [Option<VirtioGpuScanout>; VIRTIO_GPU_MAX_SCANOUTS as usize],
     displays: Box<[DisplayInfo]>,
     display_backend: DisplayBackendInstance,
@@ -306,6 +311,7 @@ impl VirtioGpu {
         interrupt: InterruptTransport,
         virgl_flags: u32,
         #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
+        #[cfg(target_os = "linux")] udmabuf_driver: Option<UdmabufDriver>,
         export_table: Option<ExportTable>,
         displays: Box<[DisplayInfo]>,
         display_backend: DisplayBackend,
@@ -348,6 +354,8 @@ impl VirtioGpu {
             display_backend,
             #[cfg(target_os = "macos")]
             map_sender,
+            #[cfg(target_os = "linux")]
+            udmabuf_driver,
         }
     }
 

--- a/src/devices/src/virtio/gpu/worker.rs
+++ b/src/devices/src/virtio/gpu/worker.rs
@@ -12,6 +12,8 @@ use rutabaga_gfx::{
     RUTABAGA_PIPE_BIND_RENDER_TARGET, RUTABAGA_PIPE_TEXTURE_2D, ResourceCreate3D,
     ResourceCreateBlob, RutabagaFence, Transfer3D,
 };
+#[cfg(target_os = "linux")]
+use utils::linux::udmabuf::UdmabufDriver;
 #[cfg(target_os = "macos")]
 use utils::worker_message::WorkerMessage;
 use vm_memory::{GuestAddress, GuestMemoryMmap};
@@ -39,6 +41,8 @@ pub struct Worker {
     virgl_flags: u32,
     #[cfg(target_os = "macos")]
     map_sender: Sender<WorkerMessage>,
+    #[cfg(target_os = "linux")]
+    udmabuf_driver: Option<UdmabufDriver>,
     export_table: Option<ExportTable>,
     displays: Box<[DisplayInfo]>,
     display_backend: DisplayBackend<'static>,
@@ -53,6 +57,7 @@ impl Worker {
         shm_region: VirtioShmRegion,
         virgl_flags: u32,
         #[cfg(target_os = "macos")] map_sender: Sender<WorkerMessage>,
+        #[cfg(target_os = "linux")] udmabuf_driver: Option<UdmabufDriver>,
         export_table: Option<ExportTable>,
         displays: Box<[DisplayInfo]>,
         display_backend: DisplayBackend<'static>,
@@ -74,6 +79,8 @@ impl Worker {
             virgl_flags,
             #[cfg(target_os = "macos")]
             map_sender,
+            #[cfg(target_os = "linux")]
+            udmabuf_driver,
             export_table,
             displays,
             display_backend,
@@ -95,6 +102,8 @@ impl Worker {
             self.virgl_flags,
             #[cfg(target_os = "macos")]
             self.map_sender.clone(),
+            #[cfg(target_os = "linux")]
+            self.udmabuf_driver.take(),
             self.export_table.take(),
             self.displays.clone(),
             self.display_backend,

--- a/src/devices/src/virtio/queue.rs
+++ b/src/devices/src/virtio/queue.rs
@@ -11,8 +11,8 @@ use std::num::Wrapping;
 use std::sync::atomic::{Ordering, fence};
 use virtio_bindings::virtio_ring::VRING_USED_F_NO_NOTIFY;
 use vm_memory::{
-    Address, ByteValued, Bytes, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap,
-    VolatileMemoryError,
+    Address, ByteValued, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryError,
+    GuestMemoryMmap, VolatileMemoryError,
 };
 
 /// Size of used ring header: flags (u16) + idx (u16)

--- a/src/devices/src/virtio/vhost_user/device.rs
+++ b/src/devices/src/virtio/vhost_user/device.rs
@@ -28,7 +28,7 @@ use vhost::vhost_user::{
     VhostUserProtocolFeatures,
 };
 use vhost::{VhostBackend, VhostUserMemoryRegionInfo, VringConfigData};
-use vm_memory::{Address, GuestMemory, GuestMemoryMmap, GuestMemoryRegion};
+use vm_memory::{Address, GuestMemoryBackend, GuestMemoryMmap, GuestMemoryRegion};
 use vmm_sys_util::eventfd::EventFd as VhostEventFd;
 
 use crate::display::DisplayInfo;

--- a/src/devices/src/virtio/vsock/packet.rs
+++ b/src/devices/src/virtio/vsock/packet.rs
@@ -27,7 +27,7 @@ use std::result;
 use nix::sys::socket::{AddressFamily, sockaddr};
 use nix::sys::socket::{SockaddrLike, SockaddrStorage};
 use utils::byte_order;
-use vm_memory::{self, Address, GuestAddress, GuestMemory, GuestMemoryError};
+use vm_memory::{self, Address, GuestAddress, GuestMemoryBackend, GuestMemoryError};
 
 use super::super::DescriptorChain;
 use super::defs;
@@ -194,7 +194,7 @@ pub struct VsockPacket {
     owned_buf: Option<Vec<u8>>,
 }
 
-fn get_host_address<T: GuestMemory>(
+fn get_host_address<T: GuestMemoryBackend>(
     mem: &T,
     guest_addr: GuestAddress,
     size: usize,

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -7,6 +7,6 @@ license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"
 
 [dependencies]
-vm-memory = { version = "0.17", default-features = false, features = ["backend-mmap"] }
+vm-memory = { version = "0.18", default-features = false, features = ["backend-mmap"] }
 
 utils = { package = "krun-utils", version = "=0.1.0-2.0.0-dev", path = "../utils" }

--- a/src/kernel/src/loader/mod.rs
+++ b/src/kernel/src/loader/mod.rs
@@ -12,7 +12,7 @@ use std::ffi::CString;
 use std::fmt;
 
 use super::cmdline::Error as CmdlineError;
-use vm_memory::{Address, Bytes, GuestAddress, GuestMemory, GuestMemoryMmap};
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryMmap};
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum Error {

--- a/src/libkrun/Cargo.toml
+++ b/src/libkrun/Cargo.toml
@@ -40,11 +40,11 @@ vmm = { package = "krun-vmm", version = "=0.1.0-2.0.0-dev", path = "../vmm" }
 hvf = { package = "krun-hvf", version = "=0.1.0-2.0.0-dev", path = "../hvf" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-kvm-bindings = { version = "0.14", features = ["fam-wrappers"] }
-kvm-ioctls = "0.24"
+kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
+kvm-ioctls = "0.25"
 aws-nitro = { package = "krun-aws-nitro", version = "=0.1.0-2.0.0-dev", path = "../aws_nitro", optional = true }
 nitro-enclaves = { version = "0.5.0", optional = true }
-vm-memory = { version = "=0.17.1", features = ["backend-mmap"] }
+vm-memory = { version = "0.18.0", features = ["backend-mmap"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-sys = { version = "0.61.2", features = [

--- a/src/rutabaga_gfx/src/cross_domain/mod.rs
+++ b/src/rutabaga_gfx/src/cross_domain/mod.rs
@@ -1374,19 +1374,31 @@ impl RutabagaComponent for CrossDomain {
         resource_id: u32,
         resource_create_blob: ResourceCreateBlob,
         iovec_opt: Option<Vec<RutabagaIovec>>,
-        _handle_opt: Option<RutabagaHandle>,
+        handle_opt: Option<RutabagaHandle>,
     ) -> RutabagaResult<RutabagaResource> {
-        if resource_create_blob.blob_mem != RUTABAGA_BLOB_MEM_GUEST
-            && resource_create_blob.blob_flags != RUTABAGA_BLOB_FLAG_USE_MAPPABLE
-        {
+        if resource_create_blob.blob_mem != RUTABAGA_BLOB_MEM_GUEST {
             return Err(RutabagaError::SpecViolation(
                 "expected only guest memory blobs",
             ));
         }
 
+        if resource_create_blob.blob_flags & RUTABAGA_BLOB_FLAG_CREATE_GUEST_HANDLE
+            == RUTABAGA_BLOB_FLAG_CREATE_GUEST_HANDLE
+        {
+            if handle_opt.is_none() {
+                return Err(RutabagaError::SpecViolation(
+                    "expected a handle when using CREATE_GUEST_HANDLE",
+                ));
+            }
+        } else if resource_create_blob.blob_flags != RUTABAGA_BLOB_FLAG_USE_MAPPABLE {
+            return Err(RutabagaError::SpecViolation(
+                "expected only create-handle or mappable guest memory blobs",
+            ));
+        }
+
         Ok(RutabagaResource {
             resource_id,
-            handle: None,
+            handle: handle_opt.map(Arc::new),
             blob: true,
             blob_mem: resource_create_blob.blob_mem,
             blob_flags: resource_create_blob.blob_flags,

--- a/src/rutabaga_gfx/src/cross_domain/mod.rs
+++ b/src/rutabaga_gfx/src/cross_domain/mod.rs
@@ -1307,23 +1307,13 @@ impl RutabagaContext for CrossDomainContext {
     }
 
     fn attach(&mut self, resource: &mut RutabagaResource) {
-        if resource.blob_mem == RUTABAGA_BLOB_MEM_GUEST {
-            self.context_resources.lock().unwrap().insert(
-                resource.resource_id,
-                CrossDomainResource {
-                    handle: None,
-                    backing_iovecs: resource.backing_iovecs.take(),
-                },
-            );
-        } else if let Some(ref handle) = resource.handle {
-            self.context_resources.lock().unwrap().insert(
-                resource.resource_id,
-                CrossDomainResource {
-                    handle: Some(handle.clone()),
-                    backing_iovecs: None,
-                },
-            );
-        }
+        self.context_resources.lock().unwrap().insert(
+            resource.resource_id,
+            CrossDomainResource {
+                handle: resource.handle.clone(),
+                backing_iovecs: resource.backing_iovecs.take(),
+            },
+        );
     }
 
     fn detach(&mut self, resource: &RutabagaResource) {

--- a/src/rutabaga_gfx/src/rutabaga_core.rs
+++ b/src/rutabaga_gfx/src/rutabaga_core.rs
@@ -733,9 +733,21 @@ impl Rutabaga {
             return Err(RutabagaError::InvalidResourceId);
         }
 
+        // Imported guest resources (from udmabuf or a passed-through real GPU) with host handles
+        // cannot have a `ctx_id` set, we need to pass them to the cross-domain *component* to
+        // make a RutabagaResource that simply wraps the handle.
+        let component_type = if ctx_id == 0
+            && resource_create_blob.blob_flags & RUTABAGA_BLOB_FLAG_CREATE_GUEST_HANDLE
+                == RUTABAGA_BLOB_FLAG_CREATE_GUEST_HANDLE
+        {
+            &RutabagaComponentType::CrossDomain
+        } else {
+            &self.default_component
+        };
+
         let component = self
             .components
-            .get_mut(&self.default_component)
+            .get_mut(component_type)
             .ok_or(RutabagaError::InvalidComponent)?;
 
         let mut context = None;

--- a/src/rutabaga_gfx/src/rutabaga_utils.rs
+++ b/src/rutabaga_gfx/src/rutabaga_utils.rs
@@ -75,6 +75,7 @@ pub const RUTABAGA_BLOB_MEM_HOST3D_GUEST: u32 = 0x0003;
 pub const RUTABAGA_BLOB_FLAG_USE_MAPPABLE: u32 = 0x0001;
 pub const RUTABAGA_BLOB_FLAG_USE_SHAREABLE: u32 = 0x0002;
 pub const RUTABAGA_BLOB_FLAG_USE_CROSS_DEVICE: u32 = 0x0004;
+pub const RUTABAGA_BLOB_FLAG_CREATE_GUEST_HANDLE: u32 = 0x0008;
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct ResourceCreateBlob {

--- a/src/smbios/Cargo.toml
+++ b/src/smbios/Cargo.toml
@@ -7,4 +7,4 @@ license = "Apache-2.0"
 repository = "https://github.com/containers/libkrun"
 
 [dependencies]
-vm-memory = { version = "0.17", default-features = false, features = ["backend-mmap"] }
+vm-memory = { version = "0.18", default-features = false, features = ["backend-mmap"] }

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -18,7 +18,7 @@ vmm-sys-util = "0.15"
 crossbeam-channel = ">=0.5.15"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-kvm-bindings = { version = "0.14", features = ["fam-wrappers"] }
+kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 nix = { version = "0.30.1", features = ["fs"] }

--- a/src/utils/Cargo.toml
+++ b/src/utils/Cargo.toml
@@ -19,6 +19,9 @@ crossbeam-channel = ">=0.5.15"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
+vm-memory = { version = "0.18.0", default-features = false, features = ["backend-mmap"] }
+nix = { version = "0.30.1", features = ["ioctl"] }
+thiserror = "2.0.12"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 nix = { version = "0.30.1", features = ["fs"] }

--- a/src/utils/src/linux/mod.rs
+++ b/src/utils/src/linux/mod.rs
@@ -1,2 +1,3 @@
 pub mod epoll;
 pub mod eventfd;
+pub mod udmabuf;

--- a/src/utils/src/linux/udmabuf.rs
+++ b/src/utils/src/linux/udmabuf.rs
@@ -1,0 +1,150 @@
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::fd::OwnedFd;
+use std::path::Path;
+
+use kvm_bindings::__IncompleteArrayField;
+use nix::fcntl;
+use nix::fcntl::OFlag;
+use nix::sys::stat::Mode;
+use nix::unistd::SysconfVar;
+use nix::unistd::sysconf;
+use thiserror::Error;
+use vm_memory::Address;
+use vm_memory::GuestAddress;
+use vm_memory::GuestMemoryBackend;
+use vm_memory::GuestMemoryMmap;
+use vm_memory::GuestMemoryRegion;
+use vmm_sys_util::fam::{self, FamStruct, FamStructWrapper};
+use vmm_sys_util::generate_fam_struct_impl;
+
+#[derive(Error, Debug)]
+pub enum UdmabufError {
+    #[error("system call returned {0}")]
+    NixError(nix::Error),
+
+    #[error("could not create ioctl struct: {0}")]
+    StructError(fam::Error),
+
+    #[error("page size unavailable")]
+    NoPageSize,
+
+    #[error("could not find memory region")]
+    RegionNotFound,
+
+    #[error("memory region not backed by memfd")]
+    RegionNotFileBacked,
+
+    #[error("provided address and length are out of bounds for a region")]
+    OutOfBounds,
+
+    #[error("starting address or length not page aligned")]
+    NotPageAligned,
+}
+
+pub type Result<T> = std::result::Result<T, UdmabufError>;
+
+const UDMABUF_FLAGS_CLOEXEC: u32 = 1;
+
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+struct UdmabufCreateItem {
+    memfd: i32,
+    __pad: u32,
+    offset: u64,
+    size: u64,
+}
+
+#[repr(C)]
+#[derive(Debug, Default)]
+struct UdmabufCreateList {
+    flags: u32,
+    count: u32,
+    list: __IncompleteArrayField<UdmabufCreateItem>,
+}
+
+generate_fam_struct_impl!(
+    UdmabufCreateList,
+    UdmabufCreateItem,
+    list,
+    u32,
+    count,
+    65535
+);
+
+type UdmabufCreateListWrapper = FamStructWrapper<UdmabufCreateList>;
+
+nix::ioctl_write_ptr!(create_list, b'u', 0x43, UdmabufCreateList);
+
+/// A convenience wrapper for the Linux kernel's udmabuf driver.
+pub struct UdmabufDriver {
+    driver_fd: OwnedFd,
+    page_size: usize,
+}
+
+impl UdmabufDriver {
+    pub fn new() -> Result<UdmabufDriver> {
+        const UDMABUF_PATH: &str = "/dev/udmabuf";
+        let path = Path::new(UDMABUF_PATH);
+        let driver_fd =
+            fcntl::open(path, OFlag::O_RDONLY, Mode::empty()).map_err(UdmabufError::NixError)?;
+
+        let page_size = sysconf(SysconfVar::PAGE_SIZE)
+            .map_err(UdmabufError::NixError)?
+            .ok_or(UdmabufError::NoPageSize)? as usize;
+
+        Ok(UdmabufDriver {
+            driver_fd,
+            page_size,
+        })
+    }
+
+    pub fn create_udmabuf(
+        &self,
+        mem: &GuestMemoryMmap,
+        iovecs: &[(GuestAddress, usize)],
+    ) -> Result<OwnedFd> {
+        log::warn!("create_udmabuf: {} iovecs", iovecs.len());
+        let mut list = UdmabufCreateListWrapper::from_header(UdmabufCreateList {
+            flags: UDMABUF_FLAGS_CLOEXEC,
+            ..Default::default()
+        })
+        .map_err(UdmabufError::StructError)?;
+        for &(addr, len) in iovecs.iter() {
+            let region = mem.find_region(addr).ok_or(UdmabufError::RegionNotFound)?;
+
+            let Some(file_offset) = region.file_offset() else {
+                return Err(UdmabufError::RegionNotFileBacked);
+            };
+
+            let map_offset = addr
+                .checked_sub(region.start_addr().0)
+                .ok_or(UdmabufError::OutOfBounds)?;
+
+            if map_offset.0 as usize + len > region.len() as usize {
+                return Err(UdmabufError::OutOfBounds);
+            }
+
+            let offset = file_offset.start() + map_offset.0;
+
+            if offset as usize % self.page_size != 0 || len % self.page_size != 0 {
+                return Err(UdmabufError::NotPageAligned);
+            }
+
+            list.push(UdmabufCreateItem {
+                memfd: file_offset.file().as_raw_fd(),
+                __pad: 0,
+                offset: offset,
+                size: len as u64,
+            })
+            .map_err(UdmabufError::StructError)?;
+        }
+
+        // SAFETY: We have correctly allocated the structure above
+        let fd = unsafe { create_list(self.driver_fd.as_raw_fd(), list.as_mut_fam_struct_ptr()) }
+            .map_err(UdmabufError::NixError)?;
+
+        // SAFETY: Returned i32 is a valid fd since it was positive
+        Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+    }
+}

--- a/src/vmm/Cargo.toml
+++ b/src/vmm/Cargo.toml
@@ -23,9 +23,9 @@ vhost-user = ["devices/vhost-user"]
 crossbeam-channel = ">=0.5.15"
 flate2 = "1.0.35"
 libc = ">=0.2.39"
-linux-loader = { version = "0.13.2", features = ["bzimage", "elf", "pe"] }
+linux-loader = { version = "0.14.0", features = ["bzimage", "elf", "pe"] }
 log = "0.4.0"
-vm-memory = { version = "0.17.0", default-features = false, features = ["backend-mmap"] }
+vm-memory = { version = "0.18.0", default-features = false, features = ["backend-mmap"] }
 vmm-sys-util = "0.15"
 krun_display = { package = "krun-display", version = "0.1.0", path = "../display", optional = true, features = ["bindgen_clang_runtime"] }
 krun_input = { package = "krun-input", version = "0.1.0", path = "../input", optional = true, features = ["bindgen_clang_runtime"] }
@@ -54,9 +54,9 @@ zstd = "0.13"
 nix = { version = "0.30.1", features = ["fs", "term"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tdx = { version = "0.1.1", optional = true }
-kvm-bindings = { version = "0.14", features = ["fam-wrappers"] }
-kvm-ioctls = "0.24"
+tdx = { version = "0.1.2", optional = true }
+kvm-bindings = { version = "0.14.1", features = ["fam-wrappers"] }
+kvm-ioctls = "0.25"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 hvf = { package = "krun-hvf", version = "=0.1.0-2.0.0-dev", path = "../hvf" }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -117,7 +117,7 @@ use vm_memory::Bytes;
 #[cfg(all(feature = "vhost-user", target_os = "linux"))]
 use vm_memory::FileOffset;
 #[cfg(not(feature = "aws-nitro"))]
-use vm_memory::GuestMemory;
+use vm_memory::GuestMemoryBackend;
 #[cfg(feature = "tdx")]
 use vm_memory::GuestMemoryRegion;
 #[cfg(all(target_arch = "x86_64", not(feature = "tee")))]
@@ -224,7 +224,7 @@ pub enum StartMicrovmError {
     RegisterConsoleDevice(device_manager::mmio::Error),
     /// Cannot register SIGWINCH event file descriptor.
     #[cfg(target_os = "linux")]
-    RegisterFsSigwinch(kvm_ioctls::Error),
+    RegisterFsSigwinch(vmm_sys_util::errno::Error),
     /// Cannot initialize a MMIO Gpu device or add a device to the MMIO Bus.
     RegisterGpuDevice(device_manager::mmio::Error),
     /// Cannot initialize a MMIO Input device or add a device to the MMIO Bus.

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1926,7 +1926,10 @@ pub fn create_guest_memory(
                     // SAFETY: memfd_create is called with a valid null-terminated C string and valid flags.
                     // File descriptor ownership is transferred to File::from_raw_fd below.
                     let memfd = unsafe {
-                        let fd = libc::memfd_create(c"guest_mem".as_ptr(), libc::MFD_CLOEXEC);
+                        let fd = libc::memfd_create(
+                            c"guest_mem".as_ptr(),
+                            libc::MFD_CLOEXEC | libc::MFD_ALLOW_SEALING,
+                        );
                         if fd < 0 {
                             error!("Failed to create memfd: {:?}", io::Error::last_os_error());
                             return Err(io::Error::last_os_error());
@@ -1936,6 +1939,16 @@ pub fn create_guest_memory(
                                 "Failed to ftruncate memfd: {:?}",
                                 io::Error::last_os_error()
                             );
+                            libc::close(fd);
+                            return Err(io::Error::last_os_error());
+                        }
+                        if libc::fcntl(
+                            fd,
+                            libc::F_ADD_SEALS,
+                            libc::F_SEAL_GROW | libc::F_SEAL_SHRINK,
+                        ) < 0
+                        {
+                            error!("Failed to seal memfd: {:?}", io::Error::last_os_error());
                             libc::close(fd);
                             return Err(io::Error::last_os_error());
                         }

--- a/src/vmm/src/builder.rs
+++ b/src/vmm/src/builder.rs
@@ -1900,14 +1900,19 @@ pub fn create_guest_memory(
     #[cfg(not(all(feature = "vhost-user", target_os = "linux")))]
     let use_vhost_user = false;
 
+    #[cfg(all(feature = "gpu", target_os = "linux"))]
+    let use_gpu_udmabuf = vm_resources.gpu_virgl_flags.is_some();
+    #[cfg(not(all(feature = "gpu", target_os = "linux")))]
+    let use_gpu_udmabuf = false;
+
     // Add SHM regions before creating guest memory
     arch_mem_regions.extend(shm_manager.regions());
 
-    let guest_mem = if use_vhost_user {
-        #[cfg(all(feature = "vhost-user", target_os = "linux"))]
+    let guest_mem = if use_vhost_user || use_gpu_udmabuf {
+        #[cfg(all(any(feature = "gpu", feature = "vhost-user"), target_os = "linux"))]
         {
             debug!(
-                "Creating file-backed memory for vhost-user (regions: {})",
+                "Creating file-backed memory for gpu or vhost-user (regions: {})",
                 arch_mem_regions.len()
             );
             // Create file-backed memory regions using memfd

--- a/src/vmm/src/linux/tee/amdsnp/mod.rs
+++ b/src/vmm/src/linux/tee/amdsnp/mod.rs
@@ -13,7 +13,7 @@ use launch::{error::FirmwareError, firmware::Firmware, *};
 use kvm_bindings::{CpuId, KVM_CPUID_FLAG_SIGNIFCANT_INDEX, kvm_enc_region};
 use kvm_ioctls::VmFd;
 use vm_memory::{
-    Bytes, GuestAddress, GuestMemory, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
+    Bytes, GuestAddress, GuestMemoryBackend, GuestMemoryMmap, GuestMemoryRegion, GuestRegionMmap,
 };
 
 #[derive(Debug)]

--- a/src/vmm/src/linux/vstate.rs
+++ b/src/vmm/src/linux/vstate.rs
@@ -66,8 +66,8 @@ use utils::sm::StateMachine;
 #[cfg(feature = "tee")]
 use utils::worker_message::{MemoryProperties, WorkerMessage};
 use vm_memory::{
-    Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
-    GuestRegionMmap,
+    Address, GuestAddress, GuestMemoryBackend, GuestMemoryError, GuestMemoryMmap,
+    GuestMemoryRegion, GuestRegionMmap,
 };
 
 #[cfg(feature = "amd-sev")]

--- a/src/vmm/src/macos/vstate.rs
+++ b/src/vmm/src/macos/vstate.rs
@@ -23,7 +23,7 @@ use devices::legacy::VcpuList;
 use hvf::{HvfVcpu, HvfVm, VcpuExit, Vcpus};
 use utils::eventfd::EventFd;
 use vm_memory::{
-    Address, GuestAddress, GuestMemory, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
+    Address, GuestAddress, GuestMemoryBackend, GuestMemoryError, GuestMemoryMmap, GuestMemoryRegion,
 };
 
 /// Errors associated with the wrappers over KVM ioctls.

--- a/src/vmm/src/worker.rs
+++ b/src/vmm/src/worker.rs
@@ -16,7 +16,7 @@ use libc::{FALLOC_FL_KEEP_SIZE, FALLOC_FL_PUNCH_HOLE, MADV_DONTNEED, fallocate, 
 use std::ffi::c_void;
 #[cfg(all(feature = "tee", target_arch = "x86_64"))]
 use vm_memory::{
-    Address, GuestAddress, GuestMemoryRegion, MemoryRegionAddress, guest_memory::GuestMemory,
+    Address, GuestAddress, GuestMemoryRegion, MemoryRegionAddress, guest_memory::GuestMemoryBackend,
 };
 
 pub fn start_worker_thread(


### PR DESCRIPTION
[As recently featured on your favorite federated social network](https://social.treehouse.systems/@valpackett/117149550756102167)… together with corresponding [changes to wl-cross-domain-proxy](https://codeberg.org/drakulix/wl-cross-domain-proxy/pulls/24) and the (guest side) Linux kernel, this allows for a true zero-copy fast path for Wayland wl_shm pools. In the guest, udmabuf is used to turn regular-Wayland-client-provided memfds into something importable into virtio-gpu as a blob resource; while on the host, udmabuf is used to pick out ranges only specifically containing the shared buffers out of huge memory-region memfds.

I'm making a public draft PR right now to have a reference implementation to point to while upstreaming the Linux part and corresponding virtio spec changes. The rutabaga-gfx changes are [also sent upstream](https://github.com/magma-gpu/rutabaga_gfx/pull/81).

One TODO item left is to try extracting the /dev/udmabuf wrapper code into the `vm-memory` crate; that was in fact the reason I worked on #814 :)